### PR TITLE
chore(dependabot): ignore odd numbered NODE version deployment images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,12 @@ updates:
       all-docker:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "node"
+        versions:
+          - "~> 25.0"
+          - "~> 27.0"
+          - "~> 29.0"
   - package-ecosystem: "npm"
     directory: "/" # Location of package manifests
     schedule:


### PR DESCRIPTION
- trying this to see if it stops the odd numbering node container dependabot.