### PR TITLE
fix(docs): point moj compliance badge to the correct repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FIND
 
-[![Ministry of Justice Repository Compliance Badge](https://github-community.service.justice.gov.uk/repository-standards/api/cica-review-case-documents-airflow/badge)](https://github-community.service.justice.gov.uk/repository-standards/cica-review-case-documents-airflow)
+[![Ministry of Justice Repository Compliance Badge](https://github-community.service.justice.gov.uk/repository-standards/api/cica-review-case-documents/badge)](https://github-community.service.justice.gov.uk/repository-standards/cica-review-case-documents)
 
 
 [![GitHub repo size](https://img.shields.io/github/repo-size/ministryofjustice/cica-review-case-documents)](https://github.com/ministryofjustice/cica-review-case-documents)


### PR DESCRIPTION
- point to the correct repo, removed airflow from the url