### PR TITLE
Chore/trivy scan dockerignore biome tweaks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,6 +28,5 @@
 !auth
 
 !app.js
-!.env
 !package.json
 !package-lock.json

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,9 +1,9 @@
-# CVE-2025-64756: glob Command Injection Vulnerability
-# This vulnerability exists in npm's bundled dependencies (node-gyp) in the Node.js base image
-# It does not affect the application runtime as glob CLI is not used by the application
-# Will be resolved when Node.js updates their bundled npm version
-CVE-2025-64756
+# CVE-2026-27903 Inefficient Algorithmic Complexity
+# Published: Feb 26, 2026 | Modified: Feb 27, 2026
+# https://avd.aquasec.com/nvd/2026/cve-2026-27903/
+CVE-2026-27903 
 
-# node-tar is a Tar for Node.js. The node-tar library (<= 7.5.2) fails to sanitize the linkpath of Link #(hardlink) and SymbolicLink entries when preservePaths is false (the default secure behavior). This allows malicious archives to bypass the extraction root restriction, leading to Arbitrary File Overwrite via hardlinks and Symlink Poisoning via absolute symlink targets. This vulnerability is fixed in 7.5.3.
-#Published 2026-01-16 22:00:09 Updated 2026-01-16 22:16:27 
-CVE-2026-23745
+# CVE-2026-27904 Inefficient Regular Expression Complexity
+# Published: Feb 26, 2026 | Modified: Feb 27, 2026
+# https://avd.aquasec.com/nvd/2026/cve-2026-27904/
+CVE-2026-27904

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.4.5/schema.json",
     "files": {
         "ignoreUnknown": false,
         "includes": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -982,7 +982,6 @@
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -2724,6 +2723,7 @@
             "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "eslint-visitor-keys": "^3.4.3"
             },
@@ -2743,6 +2743,7 @@
             "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             },
@@ -2756,6 +2757,7 @@
             "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
             }
@@ -2766,6 +2768,7 @@
             "integrity": "sha512-YF+fE6LV4v5MGWRGj7G404/OZzGNepVF8fxk7jqmqo3lrza7a0uUcDnROGRBG1WFC1omYUS/Wp1f42i0M+3Q3A==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@eslint/object-schema": "^3.0.2",
                 "debug": "^4.3.1",
@@ -2781,6 +2784,7 @@
             "integrity": "sha512-a5MxrdDXEvqnIq+LisyCX6tQMPF/dSJpCfBgBauY+pNZ28yCtSsTvyTYrMhaI+LK26bVyCJfJkT0u8KIj2i1dQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@eslint/core": "^1.1.0"
             },
@@ -2794,6 +2798,7 @@
             "integrity": "sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.15"
             },
@@ -2807,6 +2812,7 @@
             "integrity": "sha512-HOy56KJt48Bx8KmJ+XGQNSUMT/6dZee/M54XyUyuvTvPXJmsERRvBchsUVx1UMe1WwIH49XLAczNC7V2INsuUw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": "^20.19.0 || ^22.13.0 || >=24"
             }
@@ -2817,6 +2823,7 @@
             "integrity": "sha512-bIZEUzOI1jkhviX2cp5vNyXQc6olzb2ohewQubuYlMXZ2Q/XjBO0x0XhGPvc9fjSIiUN0vw+0hq53BJ4eQSJKQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@eslint/core": "^1.1.0",
                 "levn": "^0.4.1"
@@ -2831,6 +2838,7 @@
             "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=18.18.0"
             }
@@ -2841,6 +2849,7 @@
             "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@humanfs/core": "^0.19.1",
                 "@humanwhocodes/retry": "^0.4.0"
@@ -2855,6 +2864,7 @@
             "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=12.22"
             },
@@ -2869,6 +2879,7 @@
             "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=18.18"
             },
@@ -2925,6 +2936,7 @@
             "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25"
@@ -4145,6 +4157,7 @@
             "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
@@ -4156,6 +4169,7 @@
             "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/eslint": "*",
                 "@types/estree": "*"
@@ -4166,7 +4180,8 @@
             "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
             "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/estree": {
             "version": "1.0.8",
@@ -4293,6 +4308,7 @@
             "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/helper-numbers": "1.13.2",
                 "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -4303,21 +4319,24 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
             "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@webassemblyjs/helper-api-error": {
             "version": "1.13.2",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
             "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@webassemblyjs/helper-buffer": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
             "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@webassemblyjs/helper-numbers": {
             "version": "1.13.2",
@@ -4325,6 +4344,7 @@
             "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/floating-point-hex-parser": "1.13.2",
                 "@webassemblyjs/helper-api-error": "1.13.2",
@@ -4336,7 +4356,8 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
             "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@webassemblyjs/helper-wasm-section": {
             "version": "1.14.1",
@@ -4344,6 +4365,7 @@
             "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-buffer": "1.14.1",
@@ -4357,6 +4379,7 @@
             "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@xtuc/ieee754": "^1.2.0"
             }
@@ -4367,6 +4390,7 @@
             "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@xtuc/long": "4.2.2"
             }
@@ -4376,7 +4400,8 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
             "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@webassemblyjs/wasm-edit": {
             "version": "1.14.1",
@@ -4384,6 +4409,7 @@
             "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-buffer": "1.14.1",
@@ -4401,6 +4427,7 @@
             "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -4415,6 +4442,7 @@
             "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-buffer": "1.14.1",
@@ -4428,6 +4456,7 @@
             "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-api-error": "1.13.2",
@@ -4443,6 +4472,7 @@
             "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@xtuc/long": "4.2.2"
@@ -4500,14 +4530,16 @@
             "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
             "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
             "dev": true,
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/@xtuc/long": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true,
-            "license": "Apache-2.0"
+            "license": "Apache-2.0",
+            "peer": true
         },
         "node_modules/a-sync-waterfall": {
             "version": "1.0.1",
@@ -4534,7 +4566,6 @@
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -4548,6 +4579,7 @@
             "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10.13.0"
             },
@@ -4570,7 +4602,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -4628,6 +4659,7 @@
             "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3"
             },
@@ -4904,7 +4936,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -5119,7 +5150,6 @@
             "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
@@ -5145,6 +5175,7 @@
             "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.0"
             }
@@ -5476,7 +5507,8 @@
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
@@ -5596,6 +5628,7 @@
             "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.2.4",
                 "tapable": "^2.3.0"
@@ -5640,7 +5673,8 @@
             "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
             "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
@@ -5803,6 +5837,7 @@
             "integrity": "sha512-GaUN0sWim5qc8KVErfPBWmc31LEsOkrUJbvJZV+xuL3u2phMUK4HIvXlWAakfC8W4nzlK+chPEAkYOYb5ZScIw==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "@types/esrecurse": "^4.3.1",
                 "@types/estree": "^1.0.8",
@@ -5835,6 +5870,7 @@
             "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -5852,6 +5888,7 @@
             "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "is-glob": "^4.0.3"
             },
@@ -5864,7 +5901,8 @@
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/espree": {
             "version": "11.1.1",
@@ -5903,6 +5941,7 @@
             "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "estraverse": "^5.2.0"
             },
@@ -5945,6 +5984,7 @@
             "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.8.x"
             }
@@ -5954,7 +5994,6 @@
             "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
             "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "accepts": "^2.0.0",
                 "body-parser": "^2.2.1",
@@ -6133,14 +6172,16 @@
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/fast-safe-stringify": {
             "version": "2.1.1",
@@ -6198,6 +6239,7 @@
             "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "flat-cache": "^4.0.0"
             },
@@ -6272,6 +6314,7 @@
             "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "flatted": "^3.2.9",
                 "keyv": "^4.5.4"
@@ -6285,7 +6328,8 @@
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
             "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
             "dev": true,
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/foreground-child": {
             "version": "3.3.1",
@@ -6403,7 +6447,6 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -6535,7 +6578,8 @@
             "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
             "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
             "dev": true,
-            "license": "BSD-2-Clause"
+            "license": "BSD-2-Clause",
+            "peer": true
         },
         "node_modules/glob/node_modules/balanced-match": {
             "version": "1.0.2",
@@ -6630,7 +6674,8 @@
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "dev": true,
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
@@ -6806,6 +6851,7 @@
             "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -6850,6 +6896,7 @@
             "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.8.19"
             }
@@ -7107,6 +7154,7 @@
             "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "merge-stream": "^2.0.0",
@@ -7172,14 +7220,16 @@
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/json-schema-traverse": {
             "version": "1.0.0",
@@ -7192,7 +7242,8 @@
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/json11": {
             "version": "2.0.2",
@@ -7277,6 +7328,7 @@
             "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "json-buffer": "3.0.1"
             }
@@ -7297,6 +7349,7 @@
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1",
                 "type-check": "~0.4.0"
@@ -7311,6 +7364,7 @@
             "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6.11.5"
             },
@@ -7484,7 +7538,8 @@
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/methods": {
             "version": "1.1.2",
@@ -7579,18 +7634,6 @@
                 "node": ">=16 || 14 >=14.17"
             }
         },
-        "node_modules/mkdirp": {
-            "version": "0.5.6",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-            "license": "MIT",
-            "dependencies": {
-                "minimist": "^1.2.6"
-            },
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            }
-        },
         "node_modules/moment": {
             "version": "2.30.1",
             "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
@@ -7608,21 +7651,22 @@
             "license": "MIT"
         },
         "node_modules/multer": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
-            "integrity": "sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.0.tgz",
+            "integrity": "sha512-TBm6j41rxNohqawsxlsWsNNh/VdV4QFXcBvRcPhXaA05EZ79z0qJ2bQFpync6JBoHTeNY5Q1JpG7AlTjdlfAEA==",
             "license": "MIT",
             "dependencies": {
                 "append-field": "^1.0.0",
                 "busboy": "^1.6.0",
                 "concat-stream": "^2.0.0",
-                "mkdirp": "^0.5.6",
-                "object-assign": "^4.1.1",
-                "type-is": "^1.6.18",
-                "xtend": "^4.0.2"
+                "type-is": "^1.6.18"
             },
             "engines": {
                 "node": ">= 10.16.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/multer/node_modules/media-typer": {
@@ -7691,7 +7735,8 @@
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/negotiator": {
             "version": "1.0.0",
@@ -7707,7 +7752,8 @@
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/node-addon-api": {
             "version": "7.1.1",
@@ -7845,15 +7891,6 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/object-deep-merge": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.0.tgz",
@@ -7927,6 +7964,7 @@
             "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
@@ -8284,6 +8322,7 @@
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 0.8.0"
             }
@@ -8340,6 +8379,7 @@
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -8384,16 +8424,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/randombytes": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "^5.1.0"
             }
         },
         "node_modules/range-parser": {
@@ -8742,6 +8772,7 @@
             "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/json-schema": "^7.0.9",
                 "ajv": "^8.9.0",
@@ -8762,6 +8793,7 @@
             "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ajv": "^8.0.0"
             },
@@ -8814,16 +8846,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/serialize-javascript": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "randombytes": "^2.1.0"
             }
         },
         "node_modules/serve-static": {
@@ -9036,6 +9058,7 @@
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "dev": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -9056,6 +9079,7 @@
             "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
@@ -9275,6 +9299,7 @@
             "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             },
@@ -9289,6 +9314,7 @@
             "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
                 "acorn": "^8.15.0",
@@ -9303,16 +9329,16 @@
             }
         },
         "node_modules/terser-webpack-plugin": {
-            "version": "5.3.16",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-            "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+            "version": "5.3.17",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.17.tgz",
+            "integrity": "sha512-YR7PtUp6GMU91BgSJmlaX/rS2lGDbAF7D+Wtq7hRO+MiljNmodYvqslzCFiYVAgW+Qoaaia/QUIP4lGXufjdZw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "jest-worker": "^27.4.5",
                 "schema-utils": "^4.3.0",
-                "serialize-javascript": "^6.0.2",
                 "terser": "^5.31.1"
             },
             "engines": {
@@ -9342,7 +9368,8 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/test-exclude": {
             "version": "8.0.0",
@@ -9460,6 +9487,7 @@
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1"
             },
@@ -9614,6 +9642,7 @@
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "punycode": "^2.1.0"
             }
@@ -9681,6 +9710,7 @@
             "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.1.2"
@@ -9813,6 +9843,7 @@
             "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10.13.0"
             }
@@ -9823,6 +9854,7 @@
             "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^4.1.1"
@@ -9837,6 +9869,7 @@
             "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -9847,6 +9880,7 @@
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -9857,6 +9891,7 @@
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "mime-db": "1.52.0"
             },
@@ -9893,6 +9928,7 @@
             "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -9920,15 +9956,6 @@
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "license": "ISC"
-        },
-        "node_modules/xtend": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.4"
-            }
         },
         "node_modules/y18n": {
             "version": "5.0.8",


### PR DESCRIPTION
- chore(docker): remove .env from .dockerignore whitelisting
- chore(biome): migrate biome to 2.4.5
- chore(deps): run npm audit fix
- chore(trivy): add CVE-2026-27903,CVE-2026-27904 to trivy ignore