### PR TITLE
Chore audit fixes

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -7,3 +7,8 @@ CVE-2026-27903
 # Published: Feb 26, 2026 | Modified: Feb 27, 2026
 # https://avd.aquasec.com/nvd/2026/cve-2026-27904/
 CVE-2026-27904
+
+# GHSA-qffp-2rhf-9h96 tar has Hardlink Path Traversal via Drive-Relative Linkpath 
+# Published: March 5, 2026
+# https://github.com/advisories/GHSA-qffp-2rhf-9h96
+ GHSA-qffp-2rhf-9h96

--- a/package-lock.json
+++ b/package-lock.json
@@ -899,13 +899,13 @@
             }
         },
         "node_modules/@aws-sdk/xml-builder": {
-            "version": "3.972.8",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.8.tgz",
-            "integrity": "sha512-Ql8elcUdYCha83Ol7NznBsgN5GVZnv3vUd86fEc6waU6oUdY0T1O9NODkEEOS/Uaogr87avDrUC6DSeM4oXjZg==",
+            "version": "3.972.9",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.9.tgz",
+            "integrity": "sha512-ItnlMgSqkPrUfJs7EsvU/01zw5UeIb2tNPhD09LBLHbg+g+HDiKibSLwpkuz/ZIlz4F2IMn+5XgE4AK/pfPuog==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^4.13.0",
-                "fast-xml-parser": "5.3.6",
+                "fast-xml-parser": "5.4.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -6205,10 +6205,22 @@
             ],
             "license": "BSD-3-Clause"
         },
+        "node_modules/fast-xml-builder": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
+            "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/fast-xml-parser": {
-            "version": "5.3.6",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
-            "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
+            "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
             "funding": [
                 {
                     "type": "github",
@@ -6217,6 +6229,7 @@
             ],
             "license": "MIT",
             "dependencies": {
+                "fast-xml-builder": "^1.0.0",
                 "strnum": "^2.1.2"
             },
             "bin": {
@@ -6864,9 +6877,9 @@
             "license": "ISC"
         },
         "node_modules/immutable": {
-            "version": "5.1.4",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
-            "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+            "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
             "dev": true,
             "license": "MIT"
         },
@@ -7651,9 +7664,9 @@
             "license": "MIT"
         },
         "node_modules/multer": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.0.tgz",
-            "integrity": "sha512-TBm6j41rxNohqawsxlsWsNNh/VdV4QFXcBvRcPhXaA05EZ79z0qJ2bQFpync6JBoHTeNY5Q1JpG7AlTjdlfAEA==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+            "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
             "license": "MIT",
             "dependencies": {
                 "append-field": "^1.0.0",
@@ -9186,9 +9199,9 @@
             }
         },
         "node_modules/strnum": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-            "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
+            "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
             "funding": [
                 {
                     "type": "github",


### PR DESCRIPTION
-  add  GHSA-qffp-2rhf-9h96 to trivyignore
- run npm audit fix 
immutable 5.1.4 to 5.1.5
multer 2.1.0 to 2.1.1
@aws-sdk/xml-builder 3.972.8 to 3.972.9
add fast-xml-builder 1.0.0
fast-xml-parser 5.3.6 to 5.4.1
strnum 2.1.2 to 2.2.0