### PR TITLE
fix(gitleaks): fail on pre-commit if gitleaks is not installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "coverage:html": "c8 report --reporter=html",
         "lint": "biome check --write",
         "format": "biome format --write",
-        "precommit:secrets": "command -v gitleaks >/dev/null 2>&1 || { echo 'gitleaks not found on PATH; skipping secrets scan. Install gitleaks from https://github.com/gitleaks/gitleaks or disable the precommit:secrets hook if this is intentional.'; exit 0; }; gitleaks protect --staged --redact --verbose --config .gitleaks.toml",
+        "precommit:secrets": "command -v gitleaks >/dev/null 2>&1 || { echo 'gitleaks not found on PATH; skipping secrets scan. Install gitleaks from https://github.com/gitleaks/gitleaks or disable the precommit:secrets hook if this is intentional.'; exit 1; }; gitleaks protect --staged --redact --verbose --config .gitleaks.toml",
         "precommit": "npm run format && npm run lint && npm run sass && npm run precommit:secrets",
         "prepush": "npm run test && npm run jsdoc:check",
         "jsdoc:check": "eslint .",


### PR DESCRIPTION
- changed exit 0: to exit 1, pre-commit should fail if gitleaks it not installed