### PR TITLE
chore(trivy): set trivy cache to false

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,6 +88,7 @@ jobs:
         if: ${{ !inputs.skip_security_scan }}
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
         with:
+          cache: "false"
           image-ref: ${{ steps.login-ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY }}:${{ github.sha }}
           format: "table"
           exit-code: "1"
@@ -101,6 +102,7 @@ jobs:
         if: ${{ !inputs.skip_security_scan }}
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
         with:
+          cache: "false"
           image-ref: ${{ steps.login-ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY }}:${{ github.sha }}
           format: "table"
           exit-code: "0"


### PR DESCRIPTION
-  set trivy cache to false as it's using as it's using an older NODE version, resulting in deprecation warning in github action logs