### PR TITLE
feat: session based feature flags

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,6 +19,7 @@ import {
 } from './middleware/ensureEnvVarsAreValid/index.js';
 import errorHandler from './middleware/errors/globalErrorHandler.js';
 import notFoundHandler from './middleware/errors/notFoundHandler.js';
+import featureFlags from './middleware/featureFlags/index.js';
 import getCaseReferenceNumberFromQueryString from './middleware/getCaseReferenceNumberFromQueryString/index.js';
 import isAuthenticated from './middleware/isAuthenticated/index.js';
 import defaultCreateLogger from './middleware/logger/index.js';
@@ -177,6 +178,7 @@ async function createApp({ createLogger = defaultCreateLogger } = {}) {
         generalRateLimiter,
         getCaseReferenceNumberFromQueryString,
         caseSelected,
+        featureFlags,
         createDocumentRouter()
     );
     app.use(
@@ -185,6 +187,7 @@ async function createApp({ createLogger = defaultCreateLogger } = {}) {
         generalRateLimiter,
         getCaseReferenceNumberFromQueryString,
         caseSelected,
+        featureFlags,
         searchRouter({ createTemplateEngineService, createSearchService })
     );
 

--- a/document/handlers/page-viewer.js
+++ b/document/handlers/page-viewer.js
@@ -1,3 +1,4 @@
+import { getFeatureFlagValue } from '../../middleware/featureFlags/index.js';
 import createApiJwtToken from '../../service/request/create-api-jwt-token.js';
 import createTemplateEngineService from '../../templateEngine/index.js';
 import { VIEW_MODES } from '../constants/viewModes.js';
@@ -28,8 +29,10 @@ export function createPageViewerHandler(
 
             // Use pre-validated parameters from middleware
             const { documentId, pageNumber, crn } = req.validatedParams;
-            const { searchTerm = '', align = 'on' } = req.query;
-            const apiJwtToken = createApiJwtToken(req.session?.username);
+            const { searchTerm = '' } = req.query;
+            const alignFlag = getFeatureFlagValue(req.session, 'align');
+            const userName = req.session?.username;
+            const apiJwtToken = createApiJwtToken(userName);
 
             // Fetch document page metadata from API (which queries OpenSearch)
             let pageMetadata;
@@ -84,8 +87,10 @@ export function createPageViewerHandler(
                 return next(error);
             }
 
-            const alignedPageHighlights = determineHighlightAlignmentStrategy(align, pageChunks);
-            const userName = req.session?.username;
+            const alignedPageHighlights = determineHighlightAlignmentStrategy(
+                alignFlag,
+                pageChunks
+            );
 
             const html = render('document/page/imageview.njk', {
                 documentId,

--- a/document/handlers/page-viewer.test.js
+++ b/document/handlers/page-viewer.test.js
@@ -122,7 +122,7 @@ describe('alignOverlappingHighlights', () => {
 });
 
 describe('Chunk strategy', () => {
-    it('uses processed chunks when align is on', () => {
+    it('uses processed chunks when align is enabled', () => {
         const input = [
             {
                 id: 'chunk-1',
@@ -135,16 +135,16 @@ describe('Chunk strategy', () => {
         ];
 
         const expected = alignOverlappingHighlights(input);
-        const result = determineHighlightAlignmentStrategy('on', input);
+        const result = determineHighlightAlignmentStrategy(true, input);
 
         assert.deepStrictEqual(result, expected);
         assert.notDeepStrictEqual(result, input);
     });
 
-    it('uses original chunks when align is off', () => {
+    it('uses original chunks when align is disabled', () => {
         const input = [{ id: 'chunk-raw', bounding_box: { top: 1, left: 1, width: 1, height: 1 } }];
 
-        const result = determineHighlightAlignmentStrategy('off', input);
+        const result = determineHighlightAlignmentStrategy(false, input);
 
         assert.strictEqual(result, input);
     });
@@ -244,6 +244,74 @@ describe('Page Viewer Handler', () => {
             assert.equal(nextError, undefined);
             assert.equal(responseSent, true);
             assert.equal(renderParams.userName, 'viewer@example.com');
+        });
+
+        it('uses the session feature flag to control alignment', async () => {
+            let renderedPageChunks;
+
+            const stubCreateMetadataService = () => ({
+                getPageMetadata: async () =>
+                    buildPageMetadataFixture({
+                        overrides: {
+                            correspondence_type: 'TC19 - REQUEST',
+                            page_num: 1,
+                            page_count: 1
+                        }
+                    })
+            });
+            const stubPageChunks = [
+                {
+                    id: 'chunk-1',
+                    bounding_box: { top: 1, left: 1, width: 4, height: 6 }
+                },
+                {
+                    id: 'chunk-2',
+                    bounding_box: { top: 2, left: 0, width: 8, height: 2 }
+                }
+            ];
+            const stubCreatePageChunksService = () => ({
+                getPageChunks: async () => stubPageChunks
+            });
+
+            const handler = createPageViewerHandler(
+                stubCreateMetadataService,
+                stubCreatePageChunksService,
+                () => ({
+                    render: (_template, params) => {
+                        renderedPageChunks = params.pageChunks;
+                        return 'render-output-session-align';
+                    }
+                })
+            );
+
+            const req = {
+                validatedParams: {
+                    documentId: 'doc-789',
+                    pageNumber: 1,
+                    crn: 'CASE-2024-003'
+                },
+                query: {
+                    searchTerm: 'test'
+                },
+                session: {
+                    featureFlags: {
+                        align: false
+                    }
+                },
+                log: { info: () => {}, error: () => {}, warn: () => {} }
+            };
+
+            const res = {
+                locals: {
+                    csrfToken: 'csrf-token',
+                    cspNonce: 'nonce'
+                },
+                send: () => {}
+            };
+
+            await handler(req, res, () => {});
+
+            assert.strictEqual(renderedPageChunks, stubPageChunks);
         });
 
         it('handles missing query parameters with defaults', async () => {

--- a/document/utils/overlap-strategy/index.js
+++ b/document/utils/overlap-strategy/index.js
@@ -129,9 +129,9 @@ export const alignOverlappingHighlights = (highlights = []) => {
 /**
  * Resolves whether highlight overlap alignment should be applied.
  *
- * @param {string} align - Query flag controlling highlight alignment
+ * @param {boolean} align - Feature flag controlling highlight alignment
  * @param {Array<object>} [highlights=[]] - Raw highlighted areas from the page chunks service
  * @returns {Array<object>} Processed or original highlighted areas based on align flag
  */
 export const determineHighlightAlignmentStrategy = (align, highlights = []) =>
-    align === 'on' ? alignOverlappingHighlights(highlights) : highlights;
+    align ? alignOverlappingHighlights(highlights) : highlights;

--- a/middleware/featureFlags/index.js
+++ b/middleware/featureFlags/index.js
@@ -1,0 +1,72 @@
+export const FEATURE_FLAG_DEFAULTS = Object.freeze({
+    align: true, // toggle alignment of image highlighting to prevent or show overlapping
+    hybrid: false // toggle hybrid search on and off
+});
+
+/**
+ * Parses a query-string feature flag value.
+ *
+ * Accepts `on` and `off` values and ignores any other input.
+ *
+ * @param {unknown} value - Raw query-string value.
+ * @returns {boolean | undefined} Parsed boolean value when valid.
+ */
+export function parseFeatureFlagValue(value) {
+    const flagValue = Array.isArray(value) ? value.at(-1) : value;
+
+    if (typeof flagValue !== 'string') {
+        return undefined;
+    }
+
+    switch (flagValue.trim().toLowerCase()) {
+        case 'on':
+            return true;
+        case 'off':
+            return false;
+        default:
+            return undefined;
+    }
+}
+
+/**
+ * Resolves a feature flag value from session state, with repo defaults.
+ *
+ * @param {import('express-session').Session | undefined} session - Request session object.
+ * @param {'align' | 'hybrid'} flagName - Supported feature flag name.
+ * @returns {boolean} The active feature flag value.
+ */
+export function getFeatureFlagValue(session, flagName) {
+    const sessionFlagValue = session?.featureFlags?.[flagName];
+
+    if (typeof sessionFlagValue === 'boolean') {
+        return sessionFlagValue;
+    }
+
+    return FEATURE_FLAG_DEFAULTS[flagName];
+}
+
+/**
+ * Persists supported feature flags from query-string params into the session.
+ *
+ * @param {import('express').Request} req - Express request object.
+ * @param {import('express').Response} res - Express response object.
+ * @param {import('express').NextFunction} next - Express next middleware function.
+ */
+export default function featureFlags(req, res, next) {
+    const flags = {};
+
+    if (req.session) {
+        for (const flagName of Object.keys(FEATURE_FLAG_DEFAULTS)) {
+            flags[flagName] = getFeatureFlagValue(req.session, flagName);
+
+            const queryFlagValue = parseFeatureFlagValue(req.query?.[flagName]);
+            if (typeof queryFlagValue === 'boolean') {
+                flags[flagName] = queryFlagValue;
+            }
+        }
+        req.session.featureFlags = flags;
+        res.locals.featureFlags = flags;
+    }
+
+    next();
+}

--- a/middleware/featureFlags/index.test.js
+++ b/middleware/featureFlags/index.test.js
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import featureFlags, {
+    FEATURE_FLAG_DEFAULTS,
+    getFeatureFlagValue,
+    parseFeatureFlagValue
+} from './index.js';
+
+describe('featureFlags middleware', () => {
+    it('sets default feature flags in session and res.locals', () => {
+        const req = {
+            query: {},
+            session: {}
+        };
+        const res = {
+            locals: {}
+        };
+
+        let nextCalled = false;
+        featureFlags(req, res, () => {
+            nextCalled = true;
+        });
+
+        assert.equal(nextCalled, true);
+        assert.deepEqual(req.session.featureFlags, FEATURE_FLAG_DEFAULTS);
+        assert.deepEqual(res.locals.featureFlags, FEATURE_FLAG_DEFAULTS);
+    });
+
+    it('updates hybrid flag from query string', () => {
+        const req = {
+            query: { hybrid: 'on' },
+            session: {}
+        };
+        const res = {
+            locals: {}
+        };
+
+        featureFlags(req, res, () => {});
+
+        assert.equal(req.session.featureFlags.hybrid, true);
+        assert.equal(req.session.featureFlags.align, true);
+    });
+
+    it('updates align flag from query string', () => {
+        const req = {
+            query: { align: 'off' },
+            session: {}
+        };
+        const res = {
+            locals: {}
+        };
+
+        featureFlags(req, res, () => {});
+
+        assert.equal(req.session.featureFlags.align, false);
+        assert.equal(req.session.featureFlags.hybrid, false);
+    });
+
+    it('preserves existing feature flag values when the query string is absent', () => {
+        const req = {
+            query: {},
+            session: {
+                featureFlags: {
+                    align: false,
+                    hybrid: true
+                }
+            }
+        };
+        const res = {
+            locals: {}
+        };
+
+        featureFlags(req, res, () => {});
+
+        assert.deepEqual(req.session.featureFlags, {
+            align: false,
+            hybrid: true
+        });
+    });
+
+    it('ignores invalid query-string values', () => {
+        const req = {
+            query: { hybrid: 'maybe', align: 'sometimes' },
+            session: {}
+        };
+        const res = {
+            locals: {}
+        };
+
+        featureFlags(req, res, () => {});
+
+        assert.deepEqual(req.session.featureFlags, FEATURE_FLAG_DEFAULTS);
+    });
+});
+
+describe('parseFeatureFlagValue', () => {
+    it('parses supported on and off values', () => {
+        assert.equal(parseFeatureFlagValue('on'), true);
+        assert.equal(parseFeatureFlagValue('off'), false);
+        assert.equal(parseFeatureFlagValue(['off']), false);
+    });
+
+    it('returns undefined for unsupported values', () => {
+        assert.equal(parseFeatureFlagValue('other'), undefined);
+        assert.equal(parseFeatureFlagValue(undefined), undefined);
+    });
+});
+
+describe('getFeatureFlagValue', () => {
+    it('returns the session value when present', () => {
+        assert.equal(getFeatureFlagValue({ featureFlags: { hybrid: true } }, 'hybrid'), true);
+        assert.equal(getFeatureFlagValue({ featureFlags: { align: false } }, 'align'), false);
+    });
+
+    it('falls back to defaults when the session value is missing', () => {
+        assert.equal(getFeatureFlagValue({}, 'hybrid'), false);
+        assert.equal(getFeatureFlagValue({}, 'align'), true);
+    });
+});


### PR DESCRIPTION
Adds a session-backed feature-flag mechanism (with query-string overrides) and implements it for highlight-overlap alignment behavior as an example of how to use this for the hybrid search switching.