### PR TITLE
feat: Add interactive Entra account selection fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,7 +49,10 @@ APP_LOG_LEVEL=info # Possible values: error, warn, info, verbose, debug, silly
 APP_LOG_REDACT_EXTRA=blah
 APP_LOG_REDACT_DISABLE=false
 
-# Entra Authentication Configuration (preferred in non-local environments)
+# Entra Authentication Configuration 
+# Replace with the live-cica-review-case-documents-dev values from AWS secrets manager
+# See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/accessing-the-cloud-console.html
+# DEV entra has been configured for both local and development environment
 ENTRA_CLIENT_ID=00000000-0000-0000-0000-000000000000
 ENTRA_CLIENT_SECRET=replace-with-entra-client-secret
 ENTRA_TENANT_ID=00000000-0000-0000-0000-000000000000

--- a/.env.example
+++ b/.env.example
@@ -49,7 +49,7 @@ APP_LOG_LEVEL=info # Possible values: error, warn, info, verbose, debug, silly
 APP_LOG_REDACT_EXTRA=blah
 APP_LOG_REDACT_DISABLE=false
 
-# Entra Authentication Configuration 
+# Entra Authentication Configuration
 # Replace with the live-cica-review-case-documents-dev values from AWS secrets manager
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/accessing-the-cloud-console.html
 # DEV entra has been configured for both local and development environments, so the same values can be used for both.

--- a/.env.example
+++ b/.env.example
@@ -52,12 +52,12 @@ APP_LOG_REDACT_DISABLE=false
 # Entra Authentication Configuration 
 # Replace with the live-cica-review-case-documents-dev values from AWS secrets manager
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/accessing-the-cloud-console.html
-# DEV entra has been configured for both local and development environment
+# DEV entra has been configured for both local and development environments, so the same values can be used for both.
 ENTRA_CLIENT_ID=00000000-0000-0000-0000-000000000000
 ENTRA_CLIENT_SECRET=replace-with-entra-client-secret
 ENTRA_TENANT_ID=00000000-0000-0000-0000-000000000000
 ENTRA_SCOPE=openid profile email
-ENTRA_INTERACTIVE_FALLBACK=false
+
 ENTRA_AUTH_TRANSACTION_MAX_AGE_MS=600000
 ENTRA_JWKS_CACHE_TTL_MS=60000
 

--- a/README.md
+++ b/README.md
@@ -141,10 +141,8 @@ When `ENTRA_CLIENT_ID`, `ENTRA_CLIENT_SECRET`, and `ENTRA_TENANT_ID` are set, `/
 
 This avoids relying on request host/protocol values when generating authentication callback URIs.
 
-By default, login starts with silent SSO (`prompt=none`) and does not automatically fall back to interactive login when Entra returns `login_required`, `interaction_required`, or `consent_required`.
-
-When unset, interactive fallback is disabled by default.
-To explicitly enable fallback, set `ENTRA_INTERACTIVE_FALLBACK` to `true`, `1`, `yes`, or `on`.
+By default, login starts with silent SSO (`prompt=none`).
+When specific Entra callback errors are returned (`AADSTS65001`/`consent_required` and `AADSTS16000`), the app performs a controlled interactive retry to account selection.
 
 Auth callback transactions expire after 10 minutes by default.
 You can tune this with `ENTRA_AUTH_TRANSACTION_MAX_AGE_MS`.

--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ When `ENTRA_CLIENT_ID`, `ENTRA_CLIENT_SECRET`, and `ENTRA_TENANT_ID` are set, `/
 This avoids relying on request host/protocol values when generating authentication callback URIs.
 
 By default, login starts with silent SSO (`prompt=none`).
-When specific Entra callback errors are returned (`AADSTS65001`/`consent_required` and `AADSTS16000`), the app performs a controlled interactive retry to account selection.
+When specific Entra callback error codes are returned (`AADSTS65001`, `AADSTS16000`, `AADSTS16001`), the app performs a controlled interactive retry to account selection.
+All other callback errors return `401 Authentication failed`.
 
 Auth callback transactions expire after 10 minutes by default.
 You can tune this with `ENTRA_AUTH_TRANSACTION_MAX_AGE_MS`.

--- a/README.md
+++ b/README.md
@@ -143,7 +143,9 @@ This avoids relying on request host/protocol values when generating authenticati
 
 By default, login starts with silent SSO (`prompt=none`).
 When specific Entra callback error codes are returned (`AADSTS65001`, `AADSTS16000`, `AADSTS16001`), the app performs a controlled interactive retry to account selection.
-All other callback errors return `401 Authentication failed`.
+Allowlisted interactive-retry callback errors return `302` to `/auth/login` for one controlled retry.
+Non-retriable callback failures return `401 Authentication failed`.
+Detailed failure reasons (for example Entra error codes or invalid/stale callback transaction state) are recorded in server logs.
 
 Auth callback transactions expire after 10 minutes by default.
 You can tune this with `ENTRA_AUTH_TRANSACTION_MAX_AGE_MS`.

--- a/auth/handlers/callback-handler.js
+++ b/auth/handlers/callback-handler.js
@@ -6,20 +6,14 @@ import {
     regenerateSession
 } from '../auth-flow-helpers.js';
 import { getUsernameFromEntraClaims } from '../utils/entra-auth/claims.js';
-import {
-    isEntraConfigured,
-    isEntraInteractiveFallbackEnabled
-} from '../utils/entra-auth/config.js';
+import { isEntraConfigured } from '../utils/entra-auth/config.js';
 import {
     decodeAndValidateEntraIdToken,
     exchangeEntraAuthorizationCode
 } from '../utils/entra-auth/token.js';
 
-const ENTRA_INTERACTION_ERRORS = new Set([
-    'interaction_required',
-    'login_required',
-    'consent_required'
-]);
+const ENTRA_INTERACTIVE_RETRY_ERRORS = new Set(['consent_required']);
+const ENTRA_INTERACTIVE_RETRY_ERROR_CODES = new Set(['AADSTS65001', 'AADSTS16000']);
 const ENTRA_AUTH_TRANSACTION_MAX_AGE_MS =
     Number(process.env.ENTRA_AUTH_TRANSACTION_MAX_AGE_MS) || 10 * 60 * 1000;
 
@@ -32,6 +26,21 @@ function clearPendingEntraAuth(req) {
     if (req.session) {
         delete req.session.entraAuth;
     }
+}
+
+/**
+ * Sets one-time interactive retry metadata for the next login request.
+ *
+ * @param {import('express').Request} req - Express request object.
+ */
+function setInteractiveRetry(req) {
+    if (!req.session) {
+        return;
+    }
+
+    req.session.entraInteractiveRetry = {
+        enabled: true
+    };
 }
 
 /**
@@ -53,8 +62,8 @@ function handleEntraCallbackError(req, res) {
 
     if (
         pendingAuth?.mode === 'silent' &&
-        isEntraInteractiveFallbackEnabled() &&
-        ENTRA_INTERACTION_ERRORS.has(entraError)
+        (ENTRA_INTERACTIVE_RETRY_ERRORS.has(entraError) ||
+            ENTRA_INTERACTIVE_RETRY_ERROR_CODES.has(entraErrorCode))
     ) {
         req.log?.info(
             {
@@ -64,7 +73,8 @@ function handleEntraCallbackError(req, res) {
             },
             'Entra silent sign-in requires interaction; retrying with interactive login'
         );
-        res.redirect('/auth/login?interactive=1');
+        setInteractiveRetry(req);
+        res.redirect('/auth/login');
         return true;
     }
 
@@ -134,6 +144,7 @@ function respondInvalidAuthTransaction(req, res, { state, hasNonce, isStaleAuthT
     res.status(401).send('Invalid authentication state');
 }
 
+/**
 /**
  * Regenerates session and stores authenticated user details.
  *
@@ -206,6 +217,7 @@ export const createCallbackHandler = () => async (req, res, next) => {
             tokenResponse.id_token,
             pendingAuth.nonce
         );
+
         await establishAuthenticatedSession(req, claims);
 
         req.log?.info(

--- a/auth/handlers/callback-handler.js
+++ b/auth/handlers/callback-handler.js
@@ -12,8 +12,14 @@ import {
     exchangeEntraAuthorizationCode
 } from '../utils/entra-auth/token.js';
 
-const ENTRA_INTERACTIVE_RETRY_ERRORS = new Set(['consent_required']);
-const ENTRA_INTERACTIVE_RETRY_ERROR_CODES = new Set(['AADSTS65001', 'AADSTS16000']);
+const ENTRA_INTERACTIVE_RETRY_ERROR_CODES = new Set([
+    // AADSTS65001: DelegationDoesNotExist - user/admin consent missing; requires interactive consent.
+    'AADSTS65001',
+    // AADSTS16000: multiple identities or unsupported selected account; allow account selection retry.
+    'AADSTS16000',
+    // AADSTS16001: UserAccountSelectionInvalid; allow recovery through updated account selection.
+    'AADSTS16001'
+]);
 const ENTRA_AUTH_TRANSACTION_MAX_AGE_MS =
     Number(process.env.ENTRA_AUTH_TRANSACTION_MAX_AGE_MS) || 10 * 60 * 1000;
 
@@ -65,8 +71,7 @@ function handleEntraCallbackError(req, res) {
     if (
         pendingAuth?.mode === 'silent' &&
         hasMatchingState &&
-        (ENTRA_INTERACTIVE_RETRY_ERRORS.has(entraError) ||
-            ENTRA_INTERACTIVE_RETRY_ERROR_CODES.has(entraErrorCode))
+        ENTRA_INTERACTIVE_RETRY_ERROR_CODES.has(entraErrorCode)
     ) {
         req.log?.info(
             {

--- a/auth/handlers/callback-handler.js
+++ b/auth/handlers/callback-handler.js
@@ -236,7 +236,8 @@ export const createCallbackHandler = () => async (req, res, next) => {
             tokenResponse = await exchangeEntraAuthorizationCode(req, String(code));
             claims = await decodeAndValidateEntraIdToken(tokenResponse.id_token, pendingAuth.nonce);
         } catch (err) {
-            req.log?.error(safeErrorForLog(err), 'Entra token exchange failed');
+            const wrappedError = new Error('Token exchange failed', { cause: err });
+            req.log?.error(safeErrorForLog(wrappedError), 'Entra token exchange failed');
             clearPendingEntraAuth(req);
             res.status(401).send('Authentication failed');
             return;

--- a/auth/handlers/callback-handler.js
+++ b/auth/handlers/callback-handler.js
@@ -57,16 +57,18 @@ function setInteractiveRetry(req) {
  * @returns {boolean} True when an Entra error was handled and response was sent.
  */
 function handleEntraCallbackError(req, res) {
-    if (!req.query.error) {
+    const entraError = getSingleNonEmptyQueryParam(req.query?.error);
+
+    if (!entraError) {
         return false;
     }
 
     const pendingAuth = req.session?.entraAuth;
     const state = getSingleNonEmptyQueryParam(req.query?.state);
     const hasMatchingState = Boolean(state) && state === pendingAuth?.state;
-    const entraError = String(req.query.error);
-    const entraErrorCode = getEntraErrorCode(req.query.error_description);
-    const entraErrorUri = req.query.error_uri;
+    const entraErrorDescription = getSingleNonEmptyQueryParam(req.query?.error_description);
+    const entraErrorCode = getEntraErrorCode(entraErrorDescription);
+    const entraErrorUri = getSingleNonEmptyQueryParam(req.query?.error_uri);
 
     const createdAtMs = Number(pendingAuth?.createdAt);
     const isStale =

--- a/auth/handlers/callback-handler.js
+++ b/auth/handlers/callback-handler.js
@@ -56,12 +56,15 @@ function handleEntraCallbackError(req, res) {
     }
 
     const pendingAuth = req.session?.entraAuth;
+    const state = getSingleNonEmptyQueryParam(req.query?.state);
+    const hasMatchingState = Boolean(state) && state === pendingAuth?.state;
     const entraError = String(req.query.error);
     const entraErrorCode = getEntraErrorCode(req.query.error_description);
     const entraErrorUri = req.query.error_uri;
 
     if (
         pendingAuth?.mode === 'silent' &&
+        hasMatchingState &&
         (ENTRA_INTERACTIVE_RETRY_ERRORS.has(entraError) ||
             ENTRA_INTERACTIVE_RETRY_ERROR_CODES.has(entraErrorCode))
     ) {
@@ -82,7 +85,9 @@ function handleEntraCallbackError(req, res) {
         {
             error: entraError,
             entraErrorCode,
-            errorUri: entraErrorUri
+            errorUri: entraErrorUri,
+            hasState: Boolean(state),
+            hasMatchingState
         },
         'Entra authorization failed'
     );

--- a/auth/handlers/callback-handler.js
+++ b/auth/handlers/callback-handler.js
@@ -237,7 +237,7 @@ export const createCallbackHandler = () => async (req, res, next) => {
             claims = await decodeAndValidateEntraIdToken(tokenResponse.id_token, pendingAuth.nonce);
         } catch (err) {
             // Re-throw with stack trace showing this callback handler location
-            throw new Error(`Token exchange failed: ${err.message}`, { cause: err });
+            throw new Error('Token exchange failed', { cause: err });
         }
 
         await establishAuthenticatedSession(req, claims);

--- a/auth/handlers/callback-handler.js
+++ b/auth/handlers/callback-handler.js
@@ -145,7 +145,6 @@ function respondInvalidAuthTransaction(req, res, { state, hasNonce, isStaleAuthT
 }
 
 /**
-/**
  * Regenerates session and stores authenticated user details.
  *
  * @param {import('express').Request} req - Express request object.

--- a/auth/handlers/callback-handler.js
+++ b/auth/handlers/callback-handler.js
@@ -152,7 +152,7 @@ function respondInvalidAuthTransaction(req, res, { state, hasNonce, isStaleAuthT
         },
         'Invalid Entra callback state'
     );
-    res.status(401).send('Invalid authentication state');
+    res.status(401).send('Authentication failed');
 }
 
 /**

--- a/auth/handlers/callback-handler.js
+++ b/auth/handlers/callback-handler.js
@@ -230,11 +230,15 @@ export const createCallbackHandler = () => async (req, res, next) => {
             return;
         }
 
-        const tokenResponse = await exchangeEntraAuthorizationCode(req, String(code));
-        const claims = await decodeAndValidateEntraIdToken(
-            tokenResponse.id_token,
-            pendingAuth.nonce
-        );
+        let tokenResponse;
+        let claims;
+        try {
+            tokenResponse = await exchangeEntraAuthorizationCode(req, String(code));
+            claims = await decodeAndValidateEntraIdToken(tokenResponse.id_token, pendingAuth.nonce);
+        } catch (err) {
+            // Re-throw with stack trace showing this callback handler location
+            throw new Error(`Token exchange failed: ${err.message}`, { cause: err });
+        }
 
         await establishAuthenticatedSession(req, claims);
 

--- a/auth/handlers/callback-handler.js
+++ b/auth/handlers/callback-handler.js
@@ -236,8 +236,10 @@ export const createCallbackHandler = () => async (req, res, next) => {
             tokenResponse = await exchangeEntraAuthorizationCode(req, String(code));
             claims = await decodeAndValidateEntraIdToken(tokenResponse.id_token, pendingAuth.nonce);
         } catch (err) {
-            // Re-throw with stack trace showing this callback handler location
-            throw new Error('Token exchange failed', { cause: err });
+            req.log?.error(safeErrorForLog(err), 'Entra token exchange failed');
+            clearPendingEntraAuth(req);
+            res.status(401).send('Authentication failed');
+            return;
         }
 
         await establishAuthenticatedSession(req, claims);

--- a/auth/handlers/callback-handler.js
+++ b/auth/handlers/callback-handler.js
@@ -68,9 +68,15 @@ function handleEntraCallbackError(req, res) {
     const entraErrorCode = getEntraErrorCode(req.query.error_description);
     const entraErrorUri = req.query.error_uri;
 
+    const createdAtMs = Number(pendingAuth?.createdAt);
+    const isStale =
+        !Number.isFinite(createdAtMs) ||
+        Date.now() - createdAtMs > ENTRA_AUTH_TRANSACTION_MAX_AGE_MS;
+
     if (
         pendingAuth?.mode === 'silent' &&
         hasMatchingState &&
+        !isStale &&
         ENTRA_INTERACTIVE_RETRY_ERROR_CODES.has(entraErrorCode)
     ) {
         req.log?.info(

--- a/auth/handlers/callback-handler.js
+++ b/auth/handlers/callback-handler.js
@@ -81,6 +81,7 @@ function handleEntraCallbackError(req, res) {
             },
             'Entra silent sign-in requires interaction; retrying with interactive login'
         );
+        clearPendingEntraAuth(req);
         setInteractiveRetry(req);
         res.redirect('/auth/login');
         return true;

--- a/auth/handlers/callback-handler.test.js
+++ b/auth/handlers/callback-handler.test.js
@@ -79,7 +79,7 @@ test('createCallbackHandler returns 400 when Entra is not configured', async () 
     assert.strictEqual(responsePayload.body, 'Entra authentication is not configured');
 });
 
-test('createCallbackHandler retries interactive login after silent interaction error', async () => {
+test('createCallbackHandler does not retry interactive login for login_required without targeted error code', async () => {
     const handler = createCallbackHandler();
 
     const req = {
@@ -98,7 +98,35 @@ test('createCallbackHandler retries interactive login after silent interaction e
 
     await handler(req, res, () => {});
 
-    assert.strictEqual(responsePayload.redirectLocation, '/auth/login?interactive=1');
+    assert.strictEqual(responsePayload.statusCode, 401);
+    assert.strictEqual(responsePayload.body, 'Authentication failed');
+    assert.strictEqual(req.session.entraInteractiveRetry, undefined);
+});
+
+test('createCallbackHandler retries interactive login for AADSTS16000 callback errors', async () => {
+    const handler = createCallbackHandler();
+
+    const req = {
+        query: {
+            error: 'interaction_required',
+            error_description:
+                'AADSTS16000: Either multiple user identities are available or selected account is unsupported'
+        },
+        session: {
+            entraAuth: {
+                mode: 'silent'
+            }
+        },
+        log: { warn: () => {}, info: () => {}, error: () => {} }
+    };
+    const { responsePayload, res } = createResponseRecorder();
+
+    await handler(req, res, () => {});
+
+    assert.strictEqual(responsePayload.redirectLocation, '/auth/login');
+    assert.deepStrictEqual(req.session.entraInteractiveRetry, {
+        enabled: true
+    });
 });
 
 test('createCallbackHandler rejects invalid auth transaction when session is missing', async () => {

--- a/auth/handlers/callback-handler.test.js
+++ b/auth/handlers/callback-handler.test.js
@@ -247,6 +247,60 @@ test('createCallbackHandler rejects interactive retry when pending auth transact
     assert.strictEqual(req.session.entraInteractiveRetry, undefined);
 });
 
+test('createCallbackHandler returns 401 when error is an array query parameter', async () => {
+    const handler = createCallbackHandler();
+
+    const req = {
+        query: {
+            error: ['interaction_required', 'login_required'],
+            state: 'state-1',
+            error_description: 'AADSTS16001: UserAccountSelectionInvalid'
+        },
+        session: {
+            entraAuth: {
+                mode: 'silent',
+                state: 'state-1',
+                createdAt: Date.now()
+            }
+        },
+        log: { warn: () => {}, info: () => {}, error: () => {} }
+    };
+    const { responsePayload, res } = createResponseRecorder();
+
+    await handler(req, res, () => {});
+
+    assert.strictEqual(responsePayload.statusCode, 401);
+    assert.strictEqual(responsePayload.body, 'Authentication failed');
+    assert.strictEqual(req.session.entraInteractiveRetry, undefined);
+});
+
+test('createCallbackHandler returns 401 when error_description is an array query parameter', async () => {
+    const handler = createCallbackHandler();
+
+    const req = {
+        query: {
+            error: 'interaction_required',
+            state: 'state-1',
+            error_description: ['AADSTS16001: first', 'AADSTS16001: second']
+        },
+        session: {
+            entraAuth: {
+                mode: 'silent',
+                state: 'state-1',
+                createdAt: Date.now()
+            }
+        },
+        log: { warn: () => {}, info: () => {}, error: () => {} }
+    };
+    const { responsePayload, res } = createResponseRecorder();
+
+    await handler(req, res, () => {});
+
+    assert.strictEqual(responsePayload.statusCode, 401);
+    assert.strictEqual(responsePayload.body, 'Authentication failed');
+    assert.strictEqual(req.session.entraInteractiveRetry, undefined);
+});
+
 test('createCallbackHandler rejects invalid auth transaction when session is missing', async () => {
     const handler = createCallbackHandler();
 

--- a/auth/handlers/callback-handler.test.js
+++ b/auth/handlers/callback-handler.test.js
@@ -126,6 +126,7 @@ test('createCallbackHandler retries interactive login for AADSTS16000 callback e
     await handler(req, res, () => {});
 
     assert.strictEqual(responsePayload.redirectLocation, '/auth/login');
+    assert.strictEqual(req.session.entraAuth, undefined);
     assert.deepStrictEqual(req.session.entraInteractiveRetry, {
         enabled: true
     });
@@ -154,6 +155,7 @@ test('createCallbackHandler retries interactive login for AADSTS16001 callback e
     await handler(req, res, () => {});
 
     assert.strictEqual(responsePayload.redirectLocation, '/auth/login');
+    assert.strictEqual(req.session.entraAuth, undefined);
     assert.deepStrictEqual(req.session.entraInteractiveRetry, {
         enabled: true
     });

--- a/auth/handlers/callback-handler.test.js
+++ b/auth/handlers/callback-handler.test.js
@@ -235,7 +235,7 @@ test('createCallbackHandler rejects invalid auth transaction when session is mis
 
     assert.strictEqual(nextError, undefined);
     assert.strictEqual(responsePayload.statusCode, 401);
-    assert.strictEqual(responsePayload.body, 'Invalid authentication state');
+    assert.strictEqual(responsePayload.body, 'Authentication failed');
 });
 
 test('createCallbackHandler regenerates session and redirects to returnTo on successful sign-in', async () => {

--- a/auth/handlers/callback-handler.test.js
+++ b/auth/handlers/callback-handler.test.js
@@ -116,7 +116,8 @@ test('createCallbackHandler retries interactive login for AADSTS16000 callback e
         session: {
             entraAuth: {
                 mode: 'silent',
-                state: 'state-16000'
+                state: 'state-16000',
+                createdAt: Date.now()
             }
         },
         log: { warn: () => {}, info: () => {}, error: () => {} }
@@ -145,7 +146,8 @@ test('createCallbackHandler retries interactive login for AADSTS16001 callback e
         session: {
             entraAuth: {
                 mode: 'silent',
-                state: 'state-16001'
+                state: 'state-16001',
+                createdAt: Date.now()
             }
         },
         log: { warn: () => {}, info: () => {}, error: () => {} }
@@ -202,6 +204,35 @@ test('createCallbackHandler rejects interactive retry callback errors without ma
             entraAuth: {
                 mode: 'silent',
                 state: 'expected-state'
+            }
+        },
+        log: { warn: () => {}, info: () => {}, error: () => {} }
+    };
+    const { responsePayload, res } = createResponseRecorder();
+
+    await handler(req, res, () => {});
+
+    assert.strictEqual(responsePayload.statusCode, 401);
+    assert.strictEqual(responsePayload.body, 'Authentication failed');
+    assert.strictEqual(req.session.entraAuth, undefined);
+    assert.strictEqual(req.session.entraInteractiveRetry, undefined);
+});
+
+test('createCallbackHandler rejects interactive retry when pending auth transaction is stale', async () => {
+    const handler = createCallbackHandler();
+
+    const req = {
+        query: {
+            error: 'interaction_required',
+            state: 'state-stale',
+            error_description:
+                'AADSTS16001: UserAccountSelectionInvalid - selected account is no longer valid for this session selection'
+        },
+        session: {
+            entraAuth: {
+                mode: 'silent',
+                state: 'state-stale',
+                createdAt: Date.now() - 11 * 60 * 1000
             }
         },
         log: { warn: () => {}, info: () => {}, error: () => {} }

--- a/auth/handlers/callback-handler.test.js
+++ b/auth/handlers/callback-handler.test.js
@@ -109,12 +109,14 @@ test('createCallbackHandler retries interactive login for AADSTS16000 callback e
     const req = {
         query: {
             error: 'interaction_required',
+            state: 'state-16000',
             error_description:
                 'AADSTS16000: Either multiple user identities are available or selected account is unsupported'
         },
         session: {
             entraAuth: {
-                mode: 'silent'
+                mode: 'silent',
+                state: 'state-16000'
             }
         },
         log: { warn: () => {}, info: () => {}, error: () => {} }
@@ -127,6 +129,34 @@ test('createCallbackHandler retries interactive login for AADSTS16000 callback e
     assert.deepStrictEqual(req.session.entraInteractiveRetry, {
         enabled: true
     });
+});
+
+test('createCallbackHandler rejects interactive retry callback errors without matching state', async () => {
+    const handler = createCallbackHandler();
+
+    const req = {
+        query: {
+            error: 'interaction_required',
+            state: 'unexpected-state',
+            error_description:
+                'AADSTS16000: Either multiple user identities are available or selected account is unsupported'
+        },
+        session: {
+            entraAuth: {
+                mode: 'silent',
+                state: 'expected-state'
+            }
+        },
+        log: { warn: () => {}, info: () => {}, error: () => {} }
+    };
+    const { responsePayload, res } = createResponseRecorder();
+
+    await handler(req, res, () => {});
+
+    assert.strictEqual(responsePayload.statusCode, 401);
+    assert.strictEqual(responsePayload.body, 'Authentication failed');
+    assert.strictEqual(req.session.entraAuth, undefined);
+    assert.strictEqual(req.session.entraInteractiveRetry, undefined);
 });
 
 test('createCallbackHandler rejects invalid auth transaction when session is missing', async () => {

--- a/auth/handlers/callback-handler.test.js
+++ b/auth/handlers/callback-handler.test.js
@@ -131,6 +131,61 @@ test('createCallbackHandler retries interactive login for AADSTS16000 callback e
     });
 });
 
+test('createCallbackHandler retries interactive login for AADSTS16001 callback errors', async () => {
+    const handler = createCallbackHandler();
+
+    const req = {
+        query: {
+            error: 'interaction_required',
+            state: 'state-16001',
+            error_description:
+                'AADSTS16001: UserAccountSelectionInvalid - selected account is no longer valid for this session selection'
+        },
+        session: {
+            entraAuth: {
+                mode: 'silent',
+                state: 'state-16001'
+            }
+        },
+        log: { warn: () => {}, info: () => {}, error: () => {} }
+    };
+    const { responsePayload, res } = createResponseRecorder();
+
+    await handler(req, res, () => {});
+
+    assert.strictEqual(responsePayload.redirectLocation, '/auth/login');
+    assert.deepStrictEqual(req.session.entraInteractiveRetry, {
+        enabled: true
+    });
+});
+
+test('createCallbackHandler does not retry interactive login without an allowlisted AADSTS code', async () => {
+    const handler = createCallbackHandler();
+
+    const req = {
+        query: {
+            error: 'consent_required',
+            state: 'state-consent',
+            error_description: 'Consent is required but code is missing'
+        },
+        session: {
+            entraAuth: {
+                mode: 'silent',
+                state: 'state-consent'
+            }
+        },
+        log: { warn: () => {}, info: () => {}, error: () => {} }
+    };
+    const { responsePayload, res } = createResponseRecorder();
+
+    await handler(req, res, () => {});
+
+    assert.strictEqual(responsePayload.statusCode, 401);
+    assert.strictEqual(responsePayload.body, 'Authentication failed');
+    assert.strictEqual(req.session.entraAuth, undefined);
+    assert.strictEqual(req.session.entraInteractiveRetry, undefined);
+});
+
 test('createCallbackHandler rejects interactive retry callback errors without matching state', async () => {
     const handler = createCallbackHandler();
 

--- a/auth/handlers/login-handler.js
+++ b/auth/handlers/login-handler.js
@@ -1,10 +1,10 @@
 import { nanoid } from 'nanoid';
-import { getSessionValuesToPreserve, regenerateSession } from '../auth-flow-helpers.js';
 import {
-    buildEntraAuthorizeUrl,
-    isEntraConfigured,
-    isEntraInteractiveFallbackEnabled
-} from '../utils/entra-auth/config.js';
+    getSessionValuesToPreserve,
+    getSingleNonEmptyQueryParam,
+    regenerateSession
+} from '../auth-flow-helpers.js';
+import { buildEntraAuthorizeUrl, isEntraConfigured } from '../utils/entra-auth/config.js';
 
 /**
  * Creates an auth login handler that starts the Entra authorization flow.
@@ -17,8 +17,15 @@ export const createLoginHandler = () => async (req, res, next) => {
     }
 
     try {
-        const interactiveRequested =
-            isEntraInteractiveFallbackEnabled() && req.query?.interactive === '1';
+        const interactiveRetry = req.session?.entraInteractiveRetry;
+        const interactiveRequested = interactiveRetry?.enabled === true;
+        const queryLoginHint = getSingleNonEmptyQueryParam(req.query?.login_hint);
+        const requestedLoginHint = queryLoginHint;
+
+        if (req.session) {
+            delete req.session.entraInteractiveRetry;
+        }
+
         const preservedSessionValues = getSessionValuesToPreserve(req.session);
         await regenerateSession(req);
         Object.assign(req.session, preservedSessionValues);
@@ -32,7 +39,14 @@ export const createLoginHandler = () => async (req, res, next) => {
             mode: interactiveRequested ? 'interactive' : 'silent'
         };
 
-        const authorizeOptions = interactiveRequested ? {} : { prompt: 'none' };
+        const authorizeOptions = {
+            prompt: interactiveRequested ? 'select_account' : 'none'
+        };
+
+        if (requestedLoginHint) {
+            authorizeOptions.loginHint = requestedLoginHint;
+        }
+
         return res.redirect(buildEntraAuthorizeUrl(req, state, nonce, authorizeOptions));
     } catch (error) {
         return next(error);

--- a/auth/handlers/login-handler.js
+++ b/auth/handlers/login-handler.js
@@ -1,9 +1,5 @@
 import { nanoid } from 'nanoid';
-import {
-    getSessionValuesToPreserve,
-    getSingleNonEmptyQueryParam,
-    regenerateSession
-} from '../auth-flow-helpers.js';
+import { getSessionValuesToPreserve, regenerateSession } from '../auth-flow-helpers.js';
 import { buildEntraAuthorizeUrl, isEntraConfigured } from '../utils/entra-auth/config.js';
 
 /**
@@ -19,8 +15,6 @@ export const createLoginHandler = () => async (req, res, next) => {
     try {
         const interactiveRetry = req.session?.entraInteractiveRetry;
         const interactiveRequested = interactiveRetry?.enabled === true;
-        const queryLoginHint = getSingleNonEmptyQueryParam(req.query?.login_hint);
-        const requestedLoginHint = queryLoginHint;
 
         if (req.session) {
             delete req.session.entraInteractiveRetry;
@@ -42,10 +36,6 @@ export const createLoginHandler = () => async (req, res, next) => {
         const authorizeOptions = {
             prompt: interactiveRequested ? 'select_account' : 'none'
         };
-
-        if (requestedLoginHint) {
-            authorizeOptions.loginHint = requestedLoginHint;
-        }
 
         return res.redirect(buildEntraAuthorizeUrl(req, state, nonce, authorizeOptions));
     } catch (error) {

--- a/auth/handlers/login-handler.test.js
+++ b/auth/handlers/login-handler.test.js
@@ -99,7 +99,32 @@ test('createLoginHandler starts silent auth by default', async () => {
     assert.match(responsePayload.redirectLocation, /prompt=none/);
 });
 
-test('createLoginHandler supports interactive mode when requested', async () => {
+test('createLoginHandler starts interactive mode when one-time retry flag is present', async () => {
+    const handler = createLoginHandler();
+
+    const req = {
+        query: {},
+        session: {
+            entraInteractiveRetry: {
+                enabled: true
+            },
+            regenerate: (callback) => {
+                req.session = {
+                    regenerate: req.session.regenerate
+                };
+                callback();
+            }
+        }
+    };
+    const { responsePayload, res } = createResponseRecorder();
+
+    await handler(req, res, () => {});
+
+    assert.strictEqual(req.session.entraAuth.mode, 'interactive');
+    assert.match(responsePayload.redirectLocation, /prompt=select_account/);
+});
+
+test('createLoginHandler ignores interactive query parameter without retry flag', async () => {
     const handler = createLoginHandler();
 
     const req = {
@@ -117,6 +142,27 @@ test('createLoginHandler supports interactive mode when requested', async () => 
 
     await handler(req, res, () => {});
 
-    assert.strictEqual(req.session.entraAuth.mode, 'interactive');
-    assert.doesNotMatch(responsePayload.redirectLocation, /prompt=none/);
+    assert.strictEqual(req.session.entraAuth.mode, 'silent');
+    assert.match(responsePayload.redirectLocation, /prompt=none/);
+});
+
+test('createLoginHandler forwards login_hint to authorize request', async () => {
+    const handler = createLoginHandler();
+
+    const req = {
+        query: { login_hint: 'Known.User@Example.COM' },
+        session: {
+            regenerate: (callback) => {
+                req.session = {
+                    regenerate: req.session.regenerate
+                };
+                callback();
+            }
+        }
+    };
+    const { responsePayload, res } = createResponseRecorder();
+
+    await handler(req, res, () => {});
+
+    assert.match(responsePayload.redirectLocation, /login_hint=Known.User%40Example.COM/);
 });

--- a/auth/handlers/login-handler.test.js
+++ b/auth/handlers/login-handler.test.js
@@ -145,24 +145,3 @@ test('createLoginHandler ignores interactive query parameter without retry flag'
     assert.strictEqual(req.session.entraAuth.mode, 'silent');
     assert.match(responsePayload.redirectLocation, /prompt=none/);
 });
-
-test('createLoginHandler forwards login_hint to authorize request', async () => {
-    const handler = createLoginHandler();
-
-    const req = {
-        query: { login_hint: 'Known.User@Example.COM' },
-        session: {
-            regenerate: (callback) => {
-                req.session = {
-                    regenerate: req.session.regenerate
-                };
-                callback();
-            }
-        }
-    };
-    const { responsePayload, res } = createResponseRecorder();
-
-    await handler(req, res, () => {});
-
-    assert.match(responsePayload.redirectLocation, /login_hint=Known.User%40Example.COM/);
-});

--- a/auth/handlers/login-handler.test.js
+++ b/auth/handlers/login-handler.test.js
@@ -121,6 +121,7 @@ test('createLoginHandler starts interactive mode when one-time retry flag is pre
     await handler(req, res, () => {});
 
     assert.strictEqual(req.session.entraAuth.mode, 'interactive');
+    assert.strictEqual(req.session.entraInteractiveRetry, undefined);
     assert.match(responsePayload.redirectLocation, /prompt=select_account/);
 });
 

--- a/auth/routes.test.js
+++ b/auth/routes.test.js
@@ -152,21 +152,7 @@ test('createLoginHandler should regenerate session before starting Entra auth fl
     assert.strictEqual(req.session.entraAuth.mode, 'silent');
 });
 
-test('GET /auth/callback with login_required should fallback to interactive by default', async () => {
-    await agent.get('/auth/login').expect(302);
-
-    const response = await agent.get('/auth/callback').query({
-        error: 'login_required',
-        error_description: 'Silent sign-in required interaction'
-    });
-
-    assert.strictEqual(response.status, 302);
-    assert.strictEqual(response.headers.location, '/auth/login?interactive=1');
-});
-
-test('GET /auth/callback with login_required should fail when interactive fallback is disabled', async () => {
-    process.env.ENTRA_INTERACTIVE_FALLBACK = 'false';
-
+test('GET /auth/callback with login_required should fail when targeted fallback conditions are not met', async () => {
     await agent.get('/auth/login').expect(302);
 
     const response = await agent.get('/auth/callback').query({
@@ -178,9 +164,23 @@ test('GET /auth/callback with login_required should fail when interactive fallba
     assert.match(response.text, /Authentication failed/);
 });
 
-test('GET /auth/callback should handle non-interactive Entra error with AADSTS code', async () => {
-    process.env.ENTRA_INTERACTIVE_FALLBACK = 'false';
+test('GET /auth/callback with consent_required should redirect to interactive even when fallback env flag is disabled', async () => {
+    await agent.get('/auth/login').expect(302);
 
+    const response = await agent.get('/auth/callback').query({
+        error: 'consent_required',
+        error_description: 'AADSTS65001: User or administrator has not consented'
+    });
+
+    assert.strictEqual(response.status, 302);
+    assert.strictEqual(response.headers.location, '/auth/login');
+
+    const interactiveLoginResponse = await agent.get('/auth/login').expect(302);
+    const authorizeUrl = new URL(interactiveLoginResponse.headers.location);
+    assert.strictEqual(authorizeUrl.searchParams.get('prompt'), 'select_account');
+});
+
+test('GET /auth/callback should handle non-interactive Entra error with AADSTS code', async () => {
     await agent.get('/auth/login').expect(302);
 
     const response = await agent.get('/auth/callback').query({
@@ -194,8 +194,6 @@ test('GET /auth/callback should handle non-interactive Entra error with AADSTS c
 });
 
 test('GET /auth/callback should handle Entra error when error_description is missing', async () => {
-    process.env.ENTRA_INTERACTIVE_FALLBACK = 'false';
-
     await agent.get('/auth/login').expect(302);
 
     const response = await agent.get('/auth/callback').query({
@@ -677,6 +675,80 @@ test('GET /auth/callback should complete sign-in when state and token are valid'
     }
 });
 
+test('GET /search returnTo is preserved across consent_required retry and interactive sign-in', async () => {
+    const originalGet = got.get;
+    const originalPost = got.post;
+
+    try {
+        const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+        const kid = 'test-kid-return-to-interactive-retry';
+        const issuer = 'https://login.microsoftonline.com/test-entra-tenant-id/v2.0';
+        const jwk = { ...publicKey.export({ format: 'jwk' }), kid, use: 'sig' };
+
+        let idToken = '';
+        got.get = () => ({
+            json: async () => ({ keys: [jwk] })
+        });
+        got.post = () => ({
+            json: async () => ({ id_token: idToken })
+        });
+
+        const protectedUrl = '/search?caseReferenceNumber=26-711111';
+        const initialResponse = await agent.get(protectedUrl);
+
+        assert.strictEqual(initialResponse.status, 302);
+        assert.strictEqual(initialResponse.headers.location, '/auth/login');
+
+        const firstLoginResponse = await agent.get('/auth/login').expect(302);
+        const firstAuthorizeUrl = new URL(firstLoginResponse.headers.location);
+        const firstState = firstAuthorizeUrl.searchParams.get('state');
+
+        const mismatchResponse = await agent.get('/auth/callback').query({
+            error: 'consent_required',
+            error_description: 'AADSTS65001: User or administrator has not consented',
+            state: firstState
+        });
+
+        assert.strictEqual(mismatchResponse.status, 302);
+        assert.strictEqual(mismatchResponse.headers.location, '/auth/login');
+
+        const secondLoginResponse = await agent.get('/auth/login').expect(302);
+        const secondAuthorizeUrl = new URL(secondLoginResponse.headers.location);
+        assert.strictEqual(secondAuthorizeUrl.searchParams.get('prompt'), 'select_account');
+        const secondState = secondAuthorizeUrl.searchParams.get('state');
+        const secondNonce = secondAuthorizeUrl.searchParams.get('nonce');
+
+        idToken = jwt.sign(
+            {
+                sub: 'entra-user-match',
+                nonce: secondNonce,
+                tid: 'tenant-1',
+                oid: 'oid-match',
+                name: 'Known User',
+                preferred_username: 'known.user@example.com'
+            },
+            privateKey,
+            {
+                algorithm: 'RS256',
+                keyid: kid,
+                issuer,
+                audience: 'test-entra-client-id',
+                expiresIn: '5m'
+            }
+        );
+
+        const successResponse = await agent
+            .get('/auth/callback')
+            .query({ code: 'auth-code-1', state: secondState });
+
+        assert.strictEqual(successResponse.status, 302);
+        assert.strictEqual(successResponse.headers.location, protectedUrl);
+    } finally {
+        got.get = originalGet;
+        got.post = originalPost;
+    }
+});
+
 test('GET /auth/callback should authenticate when oid is missing and fallback to sub', async () => {
     const originalGet = got.get;
     const originalPost = got.post;
@@ -813,13 +885,11 @@ test('callback handler should log a sanitized error when token exchange fails', 
     }
 });
 
-test('GET /auth/login?interactive=1 should skip prompt=none when fallback is enabled', async () => {
-    process.env.ENTRA_INTERACTIVE_FALLBACK = 'true';
-
+test('GET /auth/login ignores interactive query parameter without retry state', async () => {
     const response = await agent.get('/auth/login').query({ interactive: '1' });
 
     assert.strictEqual(response.status, 302);
-    assert.doesNotMatch(response.headers.location, /prompt=none/);
+    assert.match(response.headers.location, /prompt=none/);
 });
 
 test('GET /auth/sign-out displays sign out message without active session', async () => {

--- a/auth/routes.test.js
+++ b/auth/routes.test.js
@@ -861,7 +861,7 @@ test('GET /auth/callback should authenticate when oid is missing and fallback to
     }
 });
 
-test('GET /auth/callback should pass token exchange errors to error handler', async () => {
+test('GET /auth/callback should return 401 when token exchange fails', async () => {
     const originalPost = got.post;
 
     try {
@@ -875,13 +875,14 @@ test('GET /auth/callback should pass token exchange errors to error handler', as
 
         const response = await agent.get('/auth/callback').query({ code: 'auth-code', state });
 
-        assert.strictEqual(response.status, 500);
+        assert.strictEqual(response.status, 401);
+        assert.match(response.text, /Authentication failed/);
     } finally {
         got.post = originalPost;
     }
 });
 
-test('callback handler should log a sanitized error when token exchange fails', async () => {
+test('callback handler should log a sanitized error and return 401 when token exchange fails', async () => {
     const callbackHandler = getRouteHandler('/callback');
     const originalPost = got.post;
     const tokenExchangeError = Object.assign(new Error('entra-token-exchange-failed'), {
@@ -926,28 +927,36 @@ test('callback handler should log a sanitized error when token exchange fails', 
             throw tokenExchangeError;
         };
 
-        let capturedError;
-        await callbackHandler(req, {}, (err) => {
-            capturedError = err;
+        let statusCode;
+        let responseBody;
+        const res = {
+            status(code) {
+                statusCode = code;
+                return this;
+            },
+            send(body) {
+                responseBody = body;
+                return this;
+            }
+        };
+
+        let nextCalled = false;
+        await callbackHandler(req, res, () => {
+            nextCalled = true;
         });
 
-        assert.strictEqual(capturedError.message, 'Token exchange failed');
-        assert.strictEqual(capturedError.cause, tokenExchangeError);
+        assert.strictEqual(nextCalled, false);
+        assert.strictEqual(statusCode, 401);
+        assert.strictEqual(responseBody, 'Authentication failed');
         assert.strictEqual(loggedErrors.length, 1);
-        assert.deepStrictEqual(loggedErrors[0].payload.name, 'Error');
-        assert.deepStrictEqual(loggedErrors[0].payload.message, 'Token exchange failed');
-        assert.deepStrictEqual(loggedErrors[0].payload.code, undefined);
-        assert.deepStrictEqual(loggedErrors[0].payload.statusCode, undefined);
-        assert.strictEqual(loggedErrors[0].message, 'Entra callback handling failed');
+        assert.deepStrictEqual(loggedErrors[0].payload.name, 'HTTPError');
+        assert.deepStrictEqual(loggedErrors[0].payload.message, 'entra-token-exchange-failed');
+        assert.deepStrictEqual(loggedErrors[0].payload.code, 'ERR_NON_2XX_3XX_RESPONSE');
+        assert.deepStrictEqual(loggedErrors[0].payload.statusCode, 401);
+        assert.strictEqual(loggedErrors[0].message, 'Entra token exchange failed');
         assert.equal(typeof loggedErrors[0].payload.stack, 'string');
         assert.equal('options' in loggedErrors[0].payload, false);
         assert.equal('response' in loggedErrors[0].payload, false);
-        // Verify cause error is preserved with safe fields only
-        assert.ok(loggedErrors[0].payload.cause);
-        assert.strictEqual(loggedErrors[0].payload.cause.name, 'HTTPError');
-        assert.strictEqual(loggedErrors[0].payload.cause.code, 'ERR_NON_2XX_3XX_RESPONSE');
-        assert.equal('options' in loggedErrors[0].payload.cause, false);
-        assert.equal('response' in loggedErrors[0].payload.cause, false);
     } finally {
         got.post = originalPost;
     }

--- a/auth/routes.test.js
+++ b/auth/routes.test.js
@@ -335,7 +335,7 @@ test('callback handler should reject stale auth transaction and clear pending st
     await callbackHandler(req, res, () => {});
 
     assert.strictEqual(responsePayload.statusCode, 401);
-    assert.strictEqual(responsePayload.body, 'Invalid authentication state');
+    assert.strictEqual(responsePayload.body, 'Authentication failed');
     assert.strictEqual(req.session.entraAuth, undefined);
 });
 
@@ -376,7 +376,7 @@ test('callback handler should reject callback when code is an array query parame
     await callbackHandler(req, res, () => {});
 
     assert.strictEqual(responsePayload.statusCode, 401);
-    assert.strictEqual(responsePayload.body, 'Invalid authentication state');
+    assert.strictEqual(responsePayload.body, 'Authentication failed');
     assert.strictEqual(req.session.entraAuth, undefined);
 });
 
@@ -417,7 +417,7 @@ test('callback handler should reject callback when state is an array query param
     await callbackHandler(req, res, () => {});
 
     assert.strictEqual(responsePayload.statusCode, 401);
-    assert.strictEqual(responsePayload.body, 'Invalid authentication state');
+    assert.strictEqual(responsePayload.body, 'Authentication failed');
     assert.strictEqual(req.session.entraAuth, undefined);
 });
 
@@ -492,7 +492,7 @@ test('callback handler should return 401 for invalid auth transaction when sessi
 
     assert.strictEqual(nextError, undefined);
     assert.strictEqual(responsePayload.statusCode, 401);
-    assert.strictEqual(responsePayload.body, 'Invalid authentication state');
+    assert.strictEqual(responsePayload.body, 'Authentication failed');
 });
 
 test('callback handler should regenerate session and preserve required values after sign-in', async () => {

--- a/auth/routes.test.js
+++ b/auth/routes.test.js
@@ -164,7 +164,7 @@ test('GET /auth/callback with login_required should fail when targeted fallback 
     assert.match(response.text, /Authentication failed/);
 });
 
-test('GET /auth/callback with consent_required should redirect to interactive even when fallback env flag is disabled', async () => {
+test('GET /auth/callback with consent_required should perform a controlled retry to interactive for AADSTS65001', async () => {
     await agent.get('/auth/login').expect(302);
 
     const response = await agent.get('/auth/callback').query({

--- a/auth/routes.test.js
+++ b/auth/routes.test.js
@@ -931,17 +931,11 @@ test('callback handler should log a sanitized error when token exchange fails', 
             capturedError = err;
         });
 
-        assert.strictEqual(
-            capturedError.message,
-            'Token exchange failed: entra-token-exchange-failed'
-        );
+        assert.strictEqual(capturedError.message, 'Token exchange failed');
         assert.strictEqual(capturedError.cause, tokenExchangeError);
         assert.strictEqual(loggedErrors.length, 1);
         assert.deepStrictEqual(loggedErrors[0].payload.name, 'Error');
-        assert.deepStrictEqual(
-            loggedErrors[0].payload.message,
-            'Token exchange failed: entra-token-exchange-failed'
-        );
+        assert.deepStrictEqual(loggedErrors[0].payload.message, 'Token exchange failed');
         assert.deepStrictEqual(loggedErrors[0].payload.code, undefined);
         assert.deepStrictEqual(loggedErrors[0].payload.statusCode, undefined);
         assert.strictEqual(loggedErrors[0].message, 'Entra callback handling failed');

--- a/auth/routes.test.js
+++ b/auth/routes.test.js
@@ -931,16 +931,29 @@ test('callback handler should log a sanitized error when token exchange fails', 
             capturedError = err;
         });
 
-        assert.strictEqual(capturedError, tokenExchangeError);
+        assert.strictEqual(
+            capturedError.message,
+            'Token exchange failed: entra-token-exchange-failed'
+        );
+        assert.strictEqual(capturedError.cause, tokenExchangeError);
         assert.strictEqual(loggedErrors.length, 1);
-        assert.deepStrictEqual(loggedErrors[0].payload.name, 'HTTPError');
-        assert.deepStrictEqual(loggedErrors[0].payload.message, 'entra-token-exchange-failed');
-        assert.deepStrictEqual(loggedErrors[0].payload.code, 'ERR_NON_2XX_3XX_RESPONSE');
-        assert.deepStrictEqual(loggedErrors[0].payload.statusCode, 401);
+        assert.deepStrictEqual(loggedErrors[0].payload.name, 'Error');
+        assert.deepStrictEqual(
+            loggedErrors[0].payload.message,
+            'Token exchange failed: entra-token-exchange-failed'
+        );
+        assert.deepStrictEqual(loggedErrors[0].payload.code, undefined);
+        assert.deepStrictEqual(loggedErrors[0].payload.statusCode, undefined);
         assert.strictEqual(loggedErrors[0].message, 'Entra callback handling failed');
         assert.equal(typeof loggedErrors[0].payload.stack, 'string');
         assert.equal('options' in loggedErrors[0].payload, false);
         assert.equal('response' in loggedErrors[0].payload, false);
+        // Verify cause error is preserved with safe fields only
+        assert.ok(loggedErrors[0].payload.cause);
+        assert.strictEqual(loggedErrors[0].payload.cause.name, 'HTTPError');
+        assert.strictEqual(loggedErrors[0].payload.cause.code, 'ERR_NON_2XX_3XX_RESPONSE');
+        assert.equal('options' in loggedErrors[0].payload.cause, false);
+        assert.equal('response' in loggedErrors[0].payload.cause, false);
     } finally {
         got.post = originalPost;
     }

--- a/auth/routes.test.js
+++ b/auth/routes.test.js
@@ -153,11 +153,16 @@ test('createLoginHandler should regenerate session before starting Entra auth fl
 });
 
 test('GET /auth/callback with login_required should fail when targeted fallback conditions are not met', async () => {
-    await agent.get('/auth/login').expect(302);
+    const loginResponse = await agent.get('/auth/login').expect(302);
+    const silentAuthorizeUrl = new URL(loginResponse.headers.location);
+    const state = silentAuthorizeUrl.searchParams.get('state');
+
+    assert.ok(state);
 
     const response = await agent.get('/auth/callback').query({
         error: 'login_required',
-        error_description: 'Silent sign-in required interaction'
+        state,
+        error_description: 'AADSTS50058: Silent sign-in required interaction'
     });
 
     assert.strictEqual(response.status, 401);

--- a/auth/routes.test.js
+++ b/auth/routes.test.js
@@ -949,14 +949,23 @@ test('callback handler should log a sanitized error and return 401 when token ex
         assert.strictEqual(statusCode, 401);
         assert.strictEqual(responseBody, 'Authentication failed');
         assert.strictEqual(loggedErrors.length, 1);
-        assert.deepStrictEqual(loggedErrors[0].payload.name, 'HTTPError');
-        assert.deepStrictEqual(loggedErrors[0].payload.message, 'entra-token-exchange-failed');
-        assert.deepStrictEqual(loggedErrors[0].payload.code, 'ERR_NON_2XX_3XX_RESPONSE');
-        assert.deepStrictEqual(loggedErrors[0].payload.statusCode, 401);
+
+        // We log a wrapped Error so the top stack frame points to application code.
+        // The original HTTPError details are preserved in payload.cause.
+        assert.strictEqual(loggedErrors[0].payload.name, 'Error');
+        assert.strictEqual(loggedErrors[0].payload.message, 'Token exchange failed');
+        assert.strictEqual(loggedErrors[0].payload.code, undefined);
+        assert.strictEqual(loggedErrors[0].payload.statusCode, undefined);
+
         assert.strictEqual(loggedErrors[0].message, 'Entra token exchange failed');
         assert.equal(typeof loggedErrors[0].payload.stack, 'string');
         assert.equal('options' in loggedErrors[0].payload, false);
         assert.equal('response' in loggedErrors[0].payload, false);
+        assert.ok(loggedErrors[0].payload.cause);
+        assert.strictEqual(loggedErrors[0].payload.cause.name, 'HTTPError');
+        assert.strictEqual(loggedErrors[0].payload.cause.code, 'ERR_NON_2XX_3XX_RESPONSE');
+        assert.equal('options' in loggedErrors[0].payload.cause, false);
+        assert.equal('response' in loggedErrors[0].payload.cause, false);
     } finally {
         got.post = originalPost;
     }

--- a/auth/routes.test.js
+++ b/auth/routes.test.js
@@ -164,7 +164,7 @@ test('GET /auth/callback with login_required should fail when targeted fallback 
     assert.match(response.text, /Authentication failed/);
 });
 
-test('GET /auth/callback with consent_required should perform a controlled retry to interactive for AADSTS65001', async () => {
+test('GET /auth/callback should perform a controlled retry to interactive for AADSTS65001', async () => {
     const loginResponse = await agent.get('/auth/login').expect(302);
     const silentAuthorizeUrl = new URL(loginResponse.headers.location);
     const state = silentAuthorizeUrl.searchParams.get('state');
@@ -185,12 +185,51 @@ test('GET /auth/callback with consent_required should perform a controlled retry
     assert.strictEqual(authorizeUrl.searchParams.get('prompt'), 'select_account');
 });
 
-test('GET /auth/callback with consent_required should reject retry when state is missing', async () => {
+test('GET /auth/callback should reject retry when state is missing', async () => {
     await agent.get('/auth/login').expect(302);
 
     const response = await agent.get('/auth/callback').query({
         error: 'consent_required',
         error_description: 'AADSTS65001: User or administrator has not consented'
+    });
+
+    assert.strictEqual(response.status, 401);
+    assert.match(response.text, /Authentication failed/);
+});
+
+test('GET /auth/callback should perform a controlled retry to interactive for AADSTS16001', async () => {
+    const loginResponse = await agent.get('/auth/login').expect(302);
+    const silentAuthorizeUrl = new URL(loginResponse.headers.location);
+    const state = silentAuthorizeUrl.searchParams.get('state');
+
+    assert.ok(state);
+
+    const response = await agent.get('/auth/callback').query({
+        error: 'interaction_required',
+        state,
+        error_description:
+            'AADSTS16001: UserAccountSelectionInvalid - selected account is no longer valid for this session selection'
+    });
+
+    assert.strictEqual(response.status, 302);
+    assert.strictEqual(response.headers.location, '/auth/login');
+
+    const interactiveLoginResponse = await agent.get('/auth/login').expect(302);
+    const authorizeUrl = new URL(interactiveLoginResponse.headers.location);
+    assert.strictEqual(authorizeUrl.searchParams.get('prompt'), 'select_account');
+});
+
+test('GET /auth/callback should not retry when consent_required has no allowlisted AADSTS code', async () => {
+    const loginResponse = await agent.get('/auth/login').expect(302);
+    const silentAuthorizeUrl = new URL(loginResponse.headers.location);
+    const state = silentAuthorizeUrl.searchParams.get('state');
+
+    assert.ok(state);
+
+    const response = await agent.get('/auth/callback').query({
+        error: 'consent_required',
+        state,
+        error_description: 'Consent is required but code is missing'
     });
 
     assert.strictEqual(response.status, 401);

--- a/auth/routes.test.js
+++ b/auth/routes.test.js
@@ -165,10 +165,15 @@ test('GET /auth/callback with login_required should fail when targeted fallback 
 });
 
 test('GET /auth/callback with consent_required should perform a controlled retry to interactive for AADSTS65001', async () => {
-    await agent.get('/auth/login').expect(302);
+    const loginResponse = await agent.get('/auth/login').expect(302);
+    const silentAuthorizeUrl = new URL(loginResponse.headers.location);
+    const state = silentAuthorizeUrl.searchParams.get('state');
+
+    assert.ok(state);
 
     const response = await agent.get('/auth/callback').query({
         error: 'consent_required',
+        state,
         error_description: 'AADSTS65001: User or administrator has not consented'
     });
 
@@ -178,6 +183,18 @@ test('GET /auth/callback with consent_required should perform a controlled retry
     const interactiveLoginResponse = await agent.get('/auth/login').expect(302);
     const authorizeUrl = new URL(interactiveLoginResponse.headers.location);
     assert.strictEqual(authorizeUrl.searchParams.get('prompt'), 'select_account');
+});
+
+test('GET /auth/callback with consent_required should reject retry when state is missing', async () => {
+    await agent.get('/auth/login').expect(302);
+
+    const response = await agent.get('/auth/callback').query({
+        error: 'consent_required',
+        error_description: 'AADSTS65001: User or administrator has not consented'
+    });
+
+    assert.strictEqual(response.status, 401);
+    assert.match(response.text, /Authentication failed/);
 });
 
 test('GET /auth/callback should handle non-interactive Entra error with AADSTS code', async () => {

--- a/auth/utils/entra-auth/config.js
+++ b/auth/utils/entra-auth/config.js
@@ -1,5 +1,4 @@
 const DEFAULT_ENTRA_SCOPE = 'openid profile email';
-const TRUE_VALUES = ['1', 'true', 'yes', 'on'];
 
 /**
  * Returns Entra configuration from environment variables.
@@ -33,23 +32,6 @@ export function getEntraIssuer(tenantId) {
  */
 export function getEntraJwksUrl(tenantId) {
     return `https://login.microsoftonline.com/${tenantId}/discovery/v2.0/keys`;
-}
-
-/**
- * Determines if interactive fallback is enabled after silent SSO fails.
- *
- * Defaults to disabled when ENTRA_INTERACTIVE_FALLBACK is unset.
- *
- * @returns {boolean}
- */
-export function isEntraInteractiveFallbackEnabled() {
-    const rawValue = process.env.ENTRA_INTERACTIVE_FALLBACK;
-
-    if (rawValue == null) {
-        return false;
-    }
-
-    return TRUE_VALUES.includes(String(rawValue).toLowerCase());
 }
 
 /**

--- a/auth/utils/entra-auth/config.js
+++ b/auth/utils/entra-auth/config.js
@@ -68,7 +68,7 @@ export function getEntraRedirectUri(req) {
  * @param {import('express').Request} req - Express request used to derive callback URI.
  * @param {string} state - OIDC state value bound to the current auth transaction.
  * @param {string} nonce - OIDC nonce value validated against the returned id token.
- * @param {{ prompt?: string, loginHint?: string, domainHint?: string }} [options] - Optional authorize request parameters.
+ * @param {{ prompt?: string, domainHint?: string }} [options] - Optional authorize request parameters.
  * @returns {string}
  */
 export function buildEntraAuthorizeUrl(req, state, nonce, options = {}) {
@@ -88,10 +88,6 @@ export function buildEntraAuthorizeUrl(req, state, nonce, options = {}) {
 
     if (options.prompt) {
         params.set('prompt', options.prompt);
-    }
-
-    if (options.loginHint) {
-        params.set('login_hint', options.loginHint);
     }
 
     if (options.domainHint) {

--- a/auth/utils/entra-auth/config.test.js
+++ b/auth/utils/entra-auth/config.test.js
@@ -4,8 +4,7 @@ import {
     buildEntraAuthorizeUrl,
     getEntraConfig,
     getEntraRedirectUri,
-    isEntraConfigured,
-    isEntraInteractiveFallbackEnabled
+    isEntraConfigured
 } from './config.js';
 
 const originalEnv = { ...process.env };
@@ -125,15 +124,5 @@ describe('entra-auth config utilities', () => {
         assert.match(url, /prompt=none/);
         assert.match(url, /login_hint=user%40example\.com/);
         assert.match(url, /domain_hint=organizations/);
-    });
-
-    it('disables interactive fallback by default when env is unset', () => {
-        delete process.env.ENTRA_INTERACTIVE_FALLBACK;
-        assert.equal(isEntraInteractiveFallbackEnabled(), false);
-    });
-
-    it('supports disabling interactive fallback using env flag', () => {
-        process.env.ENTRA_INTERACTIVE_FALLBACK = 'false';
-        assert.equal(isEntraInteractiveFallbackEnabled(), false);
     });
 });

--- a/auth/utils/entra-auth/config.test.js
+++ b/auth/utils/entra-auth/config.test.js
@@ -117,12 +117,10 @@ describe('entra-auth config utilities', () => {
 
         const url = buildEntraAuthorizeUrl(req, 'state-1', 'nonce-1', {
             prompt: 'none',
-            loginHint: 'user@example.com',
             domainHint: 'organizations'
         });
 
         assert.match(url, /prompt=none/);
-        assert.match(url, /login_hint=user%40example\.com/);
         assert.match(url, /domain_hint=organizations/);
     });
 });

--- a/deployments/templates/deployment.yml
+++ b/deployments/templates/deployment.yml
@@ -69,8 +69,6 @@ spec:
                 secretKeyRef:
                   name: cica-case-review-documents-secrets
                   key: entra_tenant_id
-            - name: ENTRA_INTERACTIVE_FALLBACK
-              value: "false"
             - name: APP_SEARCH_PAGINATION_ITEMS_PER_PAGE
               value: "10"
             - name: APP_DOCUMENT_PAGINATION_ITEMS_PER_PAGE

--- a/middleware/ensureEnvVarsAreValid/index.js
+++ b/middleware/ensureEnvVarsAreValid/index.js
@@ -35,7 +35,6 @@ const defaults = {
             'APP_ENTRA_RATE_LIMIT_MAX_LOGIN',
             'APP_ENTRA_RATE_LIMIT_MAX_CALLBACK',
             'ENTRA_SCOPE',
-            'ENTRA_INTERACTIVE_FALLBACK',
             'ENTRA_AUTH_TRANSACTION_MAX_AGE_MS',
             'ENTRA_JWKS_CACHE_TTL_MS',
             'APP_LOG_LEVEL',

--- a/middleware/ensureEnvVarsAreValid/index.test.js
+++ b/middleware/ensureEnvVarsAreValid/index.test.js
@@ -217,7 +217,6 @@ describe('ensureEnvVarsAreValid', () => {
                 'APP_ENTRA_RATE_LIMIT_MAX_LOGIN',
                 'APP_ENTRA_RATE_LIMIT_MAX_CALLBACK',
                 'ENTRA_SCOPE',
-                'ENTRA_INTERACTIVE_FALLBACK',
                 'ENTRA_AUTH_TRANSACTION_MAX_AGE_MS',
                 'ENTRA_JWKS_CACHE_TTL_MS',
                 'APP_LOG_LEVEL',

--- a/middleware/errors/globalErrorHandler.js
+++ b/middleware/errors/globalErrorHandler.js
@@ -1,4 +1,5 @@
 import createTemplateEngineService from '../../templateEngine/index.js';
+import safeErrorForLog from '../logger/utils/safeErrorForLog/index.js';
 
 /**
  * Express middleware for handling global errors.
@@ -23,7 +24,7 @@ export default function errorHandler(
     const log = req.log || console;
     const status = err.status || err.statusCode || 500;
 
-    log.error({ err, status }, 'Application Error');
+    log.error({ err: safeErrorForLog(err), status }, 'Application Error');
 
     if (res.headersSent) {
         return next(err);

--- a/middleware/errors/globalErrorHandler.test.js
+++ b/middleware/errors/globalErrorHandler.test.js
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import safeErrorForLog from '../logger/utils/safeErrorForLog/index.js';
 import errorHandler from './globalErrorHandler.js';
 
 const mockHtml = '<h1>Error Page</h1>';
@@ -25,7 +26,7 @@ test('errorHandler logs error and sends error page', async () => {
         log: {
             error: ({ err: loggedErr, status }, msg) => {
                 logged = true;
-                assert.equal(loggedErr, err);
+                assert.deepEqual(loggedErr, safeErrorForLog(err));
                 assert.equal(status, 500);
                 assert.equal(msg, 'Application Error');
             }

--- a/middleware/logger/utils/safeErrorForLog/index.js
+++ b/middleware/logger/utils/safeErrorForLog/index.js
@@ -1,8 +1,10 @@
 /**
  * Builds a safe error payload for structured logging without serializing request data.
+ * Stack traces capture the full error chain including where errors were caught in application code.
+ * Cause errors are included to preserve the full error chain for debugging.
  *
  * @param {any} err - Error-like value to sanitize for logging.
- * @returns {{ name: any, message: any, code: any, statusCode: any, stack?: any }}
+ * @returns {{ name: any, message: any, code: any, statusCode: any, stack?: any, cause?: any }}
  */
 export default function safeErrorForLog(err) {
     const payload = {
@@ -12,8 +14,18 @@ export default function safeErrorForLog(err) {
         statusCode: err?.statusCode ?? err?.response?.statusCode
     };
 
-    if (process.env.NODE_ENV !== 'production' && typeof err?.stack === 'string') {
+    if (typeof err?.stack === 'string') {
         payload.stack = err.stack;
+    }
+
+    // Include cause error details to preserve full error chain
+    if (err?.cause) {
+        payload.cause = {
+            name: err.cause.name,
+            message: err.cause.message,
+            code: err.cause.code,
+            stack: err.cause.stack
+        };
     }
 
     return payload;

--- a/middleware/logger/utils/safeErrorForLog/index.test.js
+++ b/middleware/logger/utils/safeErrorForLog/index.test.js
@@ -20,4 +20,22 @@ describe('safeErrorForLog', () => {
         });
         assert.strictEqual(result.statusCode, 401);
     });
+
+    it('preserves cause error details for error chain tracking', () => {
+        const causeErr = new Error('Original error');
+        causeErr.name = 'HTTPError';
+        causeErr.code = 'ERR_NETWORK';
+        causeErr.stack = 'HTTPError: Network failed\n    at ...';
+
+        const err = new Error('Wrapped error');
+        err.cause = causeErr;
+
+        const result = safeErrorForLog(err);
+        assert.deepStrictEqual(result.cause, {
+            name: 'HTTPError',
+            message: 'Original error',
+            code: 'ERR_NETWORK',
+            stack: 'HTTPError: Network failed\n    at ...'
+        });
+    });
 });


### PR DESCRIPTION
This commit enhances the authentication flow by introducing an interactive fallback mechanism for Entra account selection. When users encounter issues with automatic account selection and/or the app requires a permission grant, they will now be prompted to choose their account interactively and accept the permissions request, improving the overall user experience and ensuring smoother authentication processes. 

- Security guardrails added — state validation, staleness checking, parameter pollution guards
- One-time consumption — the retry flag is consumed after use, preventing loops
- Allowlisted error codes — only specific AADSTS codes trigger retry (AADSTS65001, AADSTS16000, AADSTS16001)

Security enhancements include:

- One-time interactive retry flag consumed immediately after use to prevent looping
- Pending auth transactions validated for freshness (10-minute default expiry) before allowing interactive retry
- Query parameters validated as single non-empty strings to prevent parameter pollution
- Interactive retry gated only to allowlisted Entra error codes (AADSTS65001, AADSTS16000, AADSTS16001)
- All callback failures return consistent 401 response; detailed diagnostics recorded in server logs
