### PR TITLE
Feat hybrid search with search type url toggles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,6 @@ DEPLOY_ENV=local-dev
 # Local Kubernetes/Docker Testing Only
 APP_ALLOW_INSECURE_COOKIE=true # Only needed for Docker/Kubernetes local testing (NODE_ENV=production without HTTPS). Not needed for 'npm run start:dev'
 
-# PRETTY LOGGIING, multi line and color for dev, single line JSON for prod
+# PRETTY LOGGING, multiline and color for dev, single line JSON for prod
 APP_LOG_PRETTY_JSON=true
 

--- a/.env.example
+++ b/.env.example
@@ -72,3 +72,6 @@ DEPLOY_ENV=local-dev
 # Local Kubernetes/Docker Testing Only
 APP_ALLOW_INSECURE_COOKIE=true # Only needed for Docker/Kubernetes local testing (NODE_ENV=production without HTTPS). Not needed for 'npm run start:dev'
 
+# PRETTY LOGGIING, multi line and color for dev, single line JSON for prod
+APP_LOG_PRETTY_JSON=true
+

--- a/api/DAL/document-dal.js
+++ b/api/DAL/document-dal.js
@@ -4,6 +4,13 @@ import createDBQueryDefault from '../../db/index.js';
 import buildQueryJson from './utils/buildQueryJson/index.js';
 
 /**
+ *  TODO: both chunk queries have a `preference` attribute set to work around the issue of non-deterministic results when paginating through chunks.
+ *  When a better solution is found this can be removed or replaced
+ */
+
+const PAGE_CHUNK_QUERY_INTENT = 'pageChunkMatches';
+
+/**
  * @typedef {object} Logger
  * @property {(info: object, message?: string) => void} info
  *   Logs informational messages, typically structured objects with metadata.
@@ -40,6 +47,8 @@ import buildQueryJson from './utils/buildQueryJson/index.js';
  *
  * @param {Logger} [params.logger]
  *   Optional structured logger instance.
+ * @param {'keyword' | 'semantic' | 'hybrid'} [params.searchType='keyword']
+ *   Which search mode should be used.
  *
  * @throws {VError} Throws a `ConfigurationError` if the environment variable
  *   `OPENSEARCH_INDEX_CHUNKS_NAME` is not defined.
@@ -51,7 +60,12 @@ import buildQueryJson from './utils/buildQueryJson/index.js';
  * }}
  *   A frozen object exposing document and chunk retrieval methods.
  */
-function createDocumentDAL({ caseReferenceNumber, createDBQuery = createDBQueryDefault, logger }) {
+function createDocumentDAL({
+    caseReferenceNumber,
+    createDBQuery = createDBQueryDefault,
+    logger,
+    searchType = 'keyword'
+}) {
     if (process.env.OPENSEARCH_INDEX_CHUNKS_NAME === undefined) {
         throw new VError(
             {
@@ -81,6 +95,15 @@ function createDocumentDAL({ caseReferenceNumber, createDBQuery = createDBQueryD
     }
 
     /**
+     * Generates a consistent OpenSearch `preference` value based on the provided keyword.
+     * @param {string} searchTerm Keyword used to derive a deterministic preference value.
+     * @returns {string} unique preference string for this search term
+     */
+    function sessionPreference(searchTerm) {
+        return `session-${crypto.createHash('sha256').update(searchTerm).digest('hex')}`;
+    }
+
+    /**
      * Searches document chunks by keyword and paginates the results.
      *
      * @async
@@ -99,7 +122,8 @@ function createDocumentDAL({ caseReferenceNumber, createDBQuery = createDBQueryD
                 caseReferenceNumber,
                 pageNumber,
                 itemsPerPage,
-                logger
+                logger,
+                searchType
             });
             const buildEnd = Date.now();
 
@@ -121,6 +145,7 @@ function createDocumentDAL({ caseReferenceNumber, createDBQuery = createDBQueryD
             const dbStart = Date.now();
             const response = await db.query({
                 index: process.env.OPENSEARCH_INDEX_CHUNKS_NAME,
+                preference: sessionPreference(keyword),
                 body: queryBody
             });
             const dbEnd = Date.now();
@@ -210,47 +235,60 @@ function createDocumentDAL({ caseReferenceNumber, createDBQuery = createDBQueryD
      * @async
      * @param {string} documentId - The UUID of the document (source_doc_id in OpenSearch).
      * @param {number|string} pageNumber - The page number.
-     * @param {string} [searchTerm] - Search term to filter chunks by content.
+     * @param {string} [keyword] - Search term to filter chunks by content.
+     * @param {'keyword'|'semantic'|'hybrid'} [searchType='keyword'] - Search mode used to find chunks.
      * @returns {Promise<Array<Object>>} Array of chunk objects containing only bounding_box data.
      * @throws {VError} If the database query fails.
      */
-    async function getPageChunksByDocumentIdAndPageNumber(documentId, pageNumber, searchTerm) {
+    async function getPageChunksByDocumentIdAndPageNumber(
+        documentId,
+        pageNumber,
+        keyword = '',
+        searchType = 'keyword'
+    ) {
         try {
             logger?.info?.(
-                { documentId, pageNumber, searchTerm },
+                { documentId, pageNumber, searchType },
                 'Querying OpenSearch for page chunks with bounding boxes'
             );
 
-            const mustQuery = [
-                { match: { source_doc_id: documentId } },
-                { match: { page_number: parseInt(pageNumber, 10) } },
-                { match: { case_ref: caseReferenceNumber } }
+            const queryBody = buildQueryJson({
+                keyword,
+                caseReferenceNumber,
+                pageNumber,
+                searchType,
+                queryIntent: PAGE_CHUNK_QUERY_INTENT,
+                documentId,
+                logger
+            });
+
+            queryBody._source = [
+                'chunk_id',
+                'bounding_box',
+                'chunk_type',
+                'chunk_index',
+                'chunk_text'
             ];
+            queryBody.sort = [{ chunk_index: { order: 'asc' } }];
 
-            if (searchTerm) {
-                mustQuery.push({ match: { chunk_text: searchTerm } });
-            }
-
-            const queryBody = {
-                query: {
-                    bool: {
-                        must: mustQuery
-                    }
-                },
-                _source: ['chunk_id', 'bounding_box', 'chunk_type', 'chunk_index', 'chunk_text'],
-                sort: [{ chunk_index: { order: 'asc' } }]
-            };
-
+            const dbStart = Date.now();
             const response = await db.query({
                 index: process.env.OPENSEARCH_INDEX_CHUNKS_NAME,
+                preference: sessionPreference(keyword),
                 body: queryBody
             });
+            const dbEnd = Date.now();
 
             const hits = response?.body?.hits?.hits || [];
 
             logger?.info?.(
-                { documentId, pageNumber, chunksCount: hits.length, searchTerm },
-                'Retrieved page chunks'
+                {
+                    keyword,
+                    caseReferenceNumber,
+                    hitsCount: hits.length,
+                    dbMs: dbEnd - dbStart
+                },
+                '[OpenSearch] Search response page chunks'
             );
 
             return hits.map((hit) => hit._source);

--- a/api/DAL/document-dal.js
+++ b/api/DAL/document-dal.js
@@ -1,6 +1,7 @@
 import crypto from 'node:crypto';
 import VError from 'verror';
 import createDBQueryDefault from '../../db/index.js';
+import { DEFAULT_SEARCH_TYPE } from '../search/constants/searchTypes.js';
 import buildQueryJson from './utils/buildQueryJson/index.js';
 
 /**
@@ -59,7 +60,7 @@ function createDocumentDAL({
     caseReferenceNumber,
     createDBQuery = createDBQueryDefault,
     logger,
-    searchType = 'keyword-dates'
+    searchType = DEFAULT_SEARCH_TYPE
 }) {
     if (process.env.OPENSEARCH_INDEX_CHUNKS_NAME === undefined) {
         throw new VError(
@@ -233,7 +234,7 @@ function createDocumentDAL({
      * @param {string} documentId - The UUID of the document (source_doc_id in OpenSearch).
      * @param {number|string} pageNumber - The page number.
      * @param {string} [keyword] - Search term to filter chunks by content.
-     * @param {string} [searchType='keyword-dates'] - Search mode (one of SEARCH_TYPES).
+     * @param {string} [searchType=DEFAULT_SEARCH_TYPE] - Search mode (one of SEARCH_TYPES).
      * @returns {Promise<Array<Object>>} Array of chunk objects containing only bounding_box data.
      * @throws {VError} If the database query fails.
      */
@@ -241,7 +242,7 @@ function createDocumentDAL({
         documentId,
         pageNumber,
         keyword = '',
-        searchType = 'keyword-dates'
+        searchType = DEFAULT_SEARCH_TYPE
     ) {
         try {
             logger?.info?.(

--- a/api/DAL/document-dal.js
+++ b/api/DAL/document-dal.js
@@ -40,12 +40,8 @@ import buildQueryJson from './utils/buildQueryJson/index.js';
  *
  * @param {Logger} [params.logger]
  *   Optional structured logger instance.
- * @param {boolean} [params.useKeyword=true]
- *   Enable lexical (BM25) keyword matching.
- * @param {boolean} [params.useSemantic=false]
- *   Enable neural (vector) semantic matching.
- * @param {boolean} [params.enableDateExtraction=true]
- *   Enable date phrase extraction and format-variant expansion.
+ * @param {string} [params.searchType='keyword']
+ *   Search mode. One of `'keyword'`, `'semantic'`, or `'hybrid'`.
  *
  * @throws {VError} Throws a `ConfigurationError` if the environment variable
  *   `OPENSEARCH_INDEX_CHUNKS_NAME` is not defined.
@@ -53,7 +49,9 @@ import buildQueryJson from './utils/buildQueryJson/index.js';
  * @returns {{
  *   getDocuments: () => Promise<object[]>,
  *   getDocument: (documentId: string) => Promise<object>,
- *   getDocumentsChunksByKeyword: (keyword: string, pageNumber: number, itemsPerPage: number) => Promise<object[]>
+ *   getDocumentsChunksByKeyword: (keyword: string, pageNumber: number, itemsPerPage: number) => Promise<object[]>,
+ *   getPageMetadataByDocumentIdAndPageNumber: (documentId: string, pageNumber: number|string) => Promise<object|null>,
+ *   getPageChunksByDocumentIdAndPageNumber: (documentId: string, pageNumber: number|string, keyword?: string, searchType?: string) => Promise<object[]>
  * }}
  *   A frozen object exposing document and chunk retrieval methods.
  */
@@ -61,9 +59,7 @@ function createDocumentDAL({
     caseReferenceNumber,
     createDBQuery = createDBQueryDefault,
     logger,
-    useKeyword = true,
-    useSemantic = false,
-    enableDateExtraction = true
+    searchType = 'keyword-dates'
 }) {
     if (process.env.OPENSEARCH_INDEX_CHUNKS_NAME === undefined) {
         throw new VError(
@@ -121,10 +117,10 @@ function createDocumentDAL({
                 caseReferenceNumber,
                 pageNumber,
                 itemsPerPage,
-                logger,
-                useKeyword,
-                useSemantic,
-                enableDateExtraction
+                options: {
+                    logger,
+                    searchType
+                }
             });
             const buildEnd = Date.now();
 
@@ -237,9 +233,7 @@ function createDocumentDAL({
      * @param {string} documentId - The UUID of the document (source_doc_id in OpenSearch).
      * @param {number|string} pageNumber - The page number.
      * @param {string} [keyword] - Search term to filter chunks by content.
-     * @param {boolean} [useKeyword=true] - Enable lexical keyword matching.
-     * @param {boolean} [useSemantic=false] - Enable neural semantic matching.
-     * @param {boolean} [enableDateExtraction=true] - Enable date extraction.
+     * @param {string} [searchType='keyword-dates'] - Search mode (one of SEARCH_TYPES).
      * @returns {Promise<Array<Object>>} Array of chunk objects containing only bounding_box data.
      * @throws {VError} If the database query fails.
      */
@@ -247,13 +241,11 @@ function createDocumentDAL({
         documentId,
         pageNumber,
         keyword = '',
-        useKeyword = true,
-        useSemantic = false,
-        enableDateExtraction = true
+        searchType = 'keyword-dates'
     ) {
         try {
             logger?.info?.(
-                { documentId, pageNumber, useKeyword, useSemantic, enableDateExtraction },
+                { documentId, pageNumber, searchType },
                 'Querying OpenSearch for page chunks with bounding boxes'
             );
 
@@ -261,12 +253,12 @@ function createDocumentDAL({
                 keyword,
                 caseReferenceNumber,
                 pageNumber,
-                useKeyword,
-                useSemantic,
-                enableDateExtraction,
-                includePagination: false,
-                documentId,
-                logger
+                options: {
+                    searchType,
+                    includePagination: false,
+                    documentId,
+                    logger
+                }
             });
 
             queryBody._source = [

--- a/api/DAL/document-dal.js
+++ b/api/DAL/document-dal.js
@@ -41,7 +41,7 @@ import buildQueryJson from './utils/buildQueryJson/index.js';
  *
  * @param {Logger} [params.logger]
  *   Optional structured logger instance.
- * @param {string} [params.searchType='keyword']
+ * @param {string} [params.searchType=DEFAULT_SEARCH_TYPE]
  *   Search mode. One of `'keyword'`, `'semantic'`, or `'hybrid'`.
  *
  * @throws {VError} Throws a `ConfigurationError` if the environment variable

--- a/api/DAL/document-dal.js
+++ b/api/DAL/document-dal.js
@@ -4,13 +4,6 @@ import createDBQueryDefault from '../../db/index.js';
 import buildQueryJson from './utils/buildQueryJson/index.js';
 
 /**
- *  TODO: both chunk queries have a `preference` attribute set to work around the issue of non-deterministic results when paginating through chunks.
- *  When a better solution is found this can be removed or replaced
- */
-
-const PAGE_CHUNK_QUERY_INTENT = 'pageChunkMatches';
-
-/**
  * @typedef {object} Logger
  * @property {(info: object, message?: string) => void} info
  *   Logs informational messages, typically structured objects with metadata.
@@ -257,7 +250,7 @@ function createDocumentDAL({
                 caseReferenceNumber,
                 pageNumber,
                 searchType,
-                queryIntent: PAGE_CHUNK_QUERY_INTENT,
+                includePagination: false,
                 documentId,
                 logger
             });

--- a/api/DAL/document-dal.js
+++ b/api/DAL/document-dal.js
@@ -40,8 +40,12 @@ import buildQueryJson from './utils/buildQueryJson/index.js';
  *
  * @param {Logger} [params.logger]
  *   Optional structured logger instance.
- * @param {'keyword' | 'semantic' | 'hybrid'} [params.searchType='keyword']
- *   Which search mode should be used.
+ * @param {boolean} [params.useKeyword=true]
+ *   Enable lexical (BM25) keyword matching.
+ * @param {boolean} [params.useSemantic=false]
+ *   Enable neural (vector) semantic matching.
+ * @param {boolean} [params.enableDateExtraction=true]
+ *   Enable date phrase extraction and format-variant expansion.
  *
  * @throws {VError} Throws a `ConfigurationError` if the environment variable
  *   `OPENSEARCH_INDEX_CHUNKS_NAME` is not defined.
@@ -57,7 +61,9 @@ function createDocumentDAL({
     caseReferenceNumber,
     createDBQuery = createDBQueryDefault,
     logger,
-    searchType = 'keyword'
+    useKeyword = true,
+    useSemantic = false,
+    enableDateExtraction = true
 }) {
     if (process.env.OPENSEARCH_INDEX_CHUNKS_NAME === undefined) {
         throw new VError(
@@ -116,7 +122,9 @@ function createDocumentDAL({
                 pageNumber,
                 itemsPerPage,
                 logger,
-                searchType
+                useKeyword,
+                useSemantic,
+                enableDateExtraction
             });
             const buildEnd = Date.now();
 
@@ -229,7 +237,9 @@ function createDocumentDAL({
      * @param {string} documentId - The UUID of the document (source_doc_id in OpenSearch).
      * @param {number|string} pageNumber - The page number.
      * @param {string} [keyword] - Search term to filter chunks by content.
-     * @param {'keyword'|'semantic'|'hybrid'} [searchType='keyword'] - Search mode used to find chunks.
+     * @param {boolean} [useKeyword=true] - Enable lexical keyword matching.
+     * @param {boolean} [useSemantic=false] - Enable neural semantic matching.
+     * @param {boolean} [enableDateExtraction=true] - Enable date extraction.
      * @returns {Promise<Array<Object>>} Array of chunk objects containing only bounding_box data.
      * @throws {VError} If the database query fails.
      */
@@ -237,11 +247,13 @@ function createDocumentDAL({
         documentId,
         pageNumber,
         keyword = '',
-        searchType = 'keyword'
+        useKeyword = true,
+        useSemantic = false,
+        enableDateExtraction = true
     ) {
         try {
             logger?.info?.(
-                { documentId, pageNumber, searchType },
+                { documentId, pageNumber, useKeyword, useSemantic, enableDateExtraction },
                 'Querying OpenSearch for page chunks with bounding boxes'
             );
 
@@ -249,7 +261,9 @@ function createDocumentDAL({
                 keyword,
                 caseReferenceNumber,
                 pageNumber,
-                searchType,
+                useKeyword,
+                useSemantic,
+                enableDateExtraction,
                 includePagination: false,
                 documentId,
                 logger

--- a/api/DAL/document-dal.test.js
+++ b/api/DAL/document-dal.test.js
@@ -101,6 +101,50 @@ describe('document-dal', () => {
         assert.equal(results[0]._source.chunk_text, 'foo');
     });
 
+    it('Should include a hybrid query when search type is hybrid', async () => {
+        let queryArgs;
+        const mockDB = {
+            query: async (args) => {
+                queryArgs = args;
+                return {
+                    body: {
+                        hits: {
+                            hits: []
+                        }
+                    }
+                };
+            }
+        };
+
+        const dal = createDocumentDAL({
+            caseReferenceNumber: '12-745678',
+            createDBQuery: () => mockDB,
+            logger: mockLogger,
+            searchType: 'hybrid'
+        });
+
+        await dal.getDocumentsChunksByKeyword('keyword', 2, 10);
+
+        assert.equal(typeof queryArgs.body.min_score, 'number');
+        assert.ok(queryArgs.body.min_score >= 0);
+        assert.ok(queryArgs.body.min_score <= 1);
+        assert.deepStrictEqual(queryArgs.body.query.bool.must, [
+            { term: { case_ref: '12-745678' } }
+        ]);
+        assert.equal(queryArgs.body.query.bool.minimum_should_match, 1);
+        const keywordClause = queryArgs.body.query.bool.should.find(
+            (clause) => clause.match?.chunk_text
+        );
+        const neuralClause = queryArgs.body.query.bool.should.find(
+            (clause) => clause.neural?.embedding
+        );
+        assert.equal(keywordClause.match.chunk_text.query, 'keyword');
+        assert.equal(keywordClause.match.chunk_text.boost, 12);
+        assert.equal(typeof neuralClause.neural.embedding.k, 'number');
+        assert.ok(neuralClause.neural.embedding.k > 0);
+        assert.equal(neuralClause.neural.embedding.boost, 4);
+    });
+
     it('Should rethrow if an error if db.query throws', async () => {
         const dal = createDocumentDAL({
             caseReferenceNumber: '12-745678',
@@ -490,8 +534,8 @@ describe('document-dal', () => {
             await dal.getPageChunksByDocumentIdAndPageNumber('doc-123', 1, 'search term');
 
             assert.ok(
-                queryArgs.body.query.bool.must.some(
-                    (clause) => clause.match?.chunk_text === 'search term'
+                queryArgs.body.query.bool.should.some(
+                    (clause) => clause.match?.chunk_text?.query === 'search term'
                 )
             );
         });
@@ -545,7 +589,7 @@ describe('document-dal', () => {
 
             assert.ok(
                 queryArgs.body.query.bool.must.some(
-                    (clause) => clause.match?.source_doc_id === 'doc-456'
+                    (clause) => clause.term?.source_doc_id === 'doc-456'
                 )
             );
         });
@@ -568,7 +612,7 @@ describe('document-dal', () => {
             await dal.getPageChunksByDocumentIdAndPageNumber('doc-123', '5');
 
             assert.ok(
-                queryArgs.body.query.bool.must.some((clause) => clause.match?.page_number === 5)
+                queryArgs.body.query.bool.must.some((clause) => clause.term?.page_number === 5)
             );
         });
 
@@ -591,7 +635,7 @@ describe('document-dal', () => {
 
             assert.ok(
                 queryArgs.body.query.bool.must.some(
-                    (clause) => clause.match?.case_ref === '12-745678'
+                    (clause) => clause.term?.case_ref === '12-745678'
                 )
             );
         });
@@ -614,10 +658,42 @@ describe('document-dal', () => {
             await dal.getPageChunksByDocumentIdAndPageNumber('doc-123', 1, 'needle');
 
             assert.ok(
-                queryArgs.body.query.bool.must.some(
-                    (clause) => clause.match?.chunk_text === 'needle'
+                queryArgs.body.query.bool.should.some(
+                    (clause) => clause.match?.chunk_text?.query === 'needle'
                 )
             );
+        });
+
+        it('should build semantic page chunks query with term filters and min_score', async () => {
+            let queryArgs;
+            const mockDB = {
+                query: async (args) => {
+                    queryArgs = args;
+                    return { body: { hits: { hits: [] } } };
+                }
+            };
+
+            const dal = createDocumentDAL({
+                caseReferenceNumber: '12-745678',
+                createDBQuery: () => mockDB,
+                logger: mockLogger
+            });
+
+            await dal.getPageChunksByDocumentIdAndPageNumber('doc-123', 1, 'needle', 'semantic');
+
+            assert.equal(typeof queryArgs.body.min_score, 'number');
+            assert.ok(queryArgs.body.min_score >= 0);
+            assert.ok(queryArgs.body.min_score <= 1);
+            assert.equal(queryArgs.body.query.neural.embedding.query_text, 'needle');
+            assert.deepStrictEqual(queryArgs.body.query.neural.embedding.filter, {
+                bool: {
+                    must: [
+                        { term: { case_ref: '12-745678' } },
+                        { term: { source_doc_id: 'doc-123' } },
+                        { term: { page_number: 1 } }
+                    ]
+                }
+            });
         });
 
         it('should return empty array when no chunks found', async () => {

--- a/api/DAL/document-dal.test.js
+++ b/api/DAL/document-dal.test.js
@@ -139,7 +139,7 @@ describe('document-dal', () => {
             (clause) => clause.neural?.embedding
         );
         assert.equal(keywordClause.match.chunk_text.query, 'keyword');
-        assert.equal(keywordClause.match.chunk_text.boost, 12);
+        assert.equal(keywordClause.match.chunk_text.boost, 20);
         assert.equal(typeof neuralClause.neural.embedding.k, 'number');
         assert.ok(neuralClause.neural.embedding.k > 0);
         assert.equal(neuralClause.neural.embedding.boost, 4);

--- a/api/DAL/document-dal.test.js
+++ b/api/DAL/document-dal.test.js
@@ -120,7 +120,9 @@ describe('document-dal', () => {
             caseReferenceNumber: '12-745678',
             createDBQuery: () => mockDB,
             logger: mockLogger,
-            searchType: 'hybrid'
+            useKeyword: true,
+            useSemantic: true,
+            enableDateExtraction: false
         });
 
         await dal.getDocumentsChunksByKeyword('keyword', 2, 10);
@@ -678,7 +680,14 @@ describe('document-dal', () => {
                 logger: mockLogger
             });
 
-            await dal.getPageChunksByDocumentIdAndPageNumber('doc-123', 1, 'needle', 'semantic');
+            await dal.getPageChunksByDocumentIdAndPageNumber(
+                'doc-123',
+                1,
+                'needle',
+                false,
+                true,
+                false
+            );
 
             assert.equal(typeof queryArgs.body.min_score, 'number');
             assert.ok(queryArgs.body.min_score >= 0);

--- a/api/DAL/document-dal.test.js
+++ b/api/DAL/document-dal.test.js
@@ -120,9 +120,7 @@ describe('document-dal', () => {
             caseReferenceNumber: '12-745678',
             createDBQuery: () => mockDB,
             logger: mockLogger,
-            useKeyword: true,
-            useSemantic: true,
-            enableDateExtraction: false
+            searchType: 'hybrid'
         });
 
         await dal.getDocumentsChunksByKeyword('keyword', 2, 10);
@@ -587,7 +585,6 @@ describe('document-dal', () => {
             });
 
             await dal.getPageChunksByDocumentIdAndPageNumber('doc-456', 1);
-
             assert.ok(
                 queryArgs.body.query.bool.must.some(
                     (clause) => clause.term?.source_doc_id === 'doc-456'
@@ -684,9 +681,8 @@ describe('document-dal', () => {
                 'doc-123',
                 1,
                 'needle',
-                false,
-                true,
-                false
+                'semantic',
+                true
             );
 
             assert.equal(typeof queryArgs.body.min_score, 'number');

--- a/api/DAL/document-dal.test.js
+++ b/api/DAL/document-dal.test.js
@@ -128,7 +128,7 @@ describe('document-dal', () => {
         assert.equal(typeof queryArgs.body.min_score, 'number');
         assert.ok(queryArgs.body.min_score >= 0);
         assert.ok(queryArgs.body.min_score <= 1);
-        assert.deepStrictEqual(queryArgs.body.query.bool.must, [
+        assert.deepStrictEqual(queryArgs.body.query.bool.filter, [
             { term: { case_ref: '12-745678' } }
         ]);
         assert.equal(queryArgs.body.query.bool.minimum_should_match, 1);
@@ -562,9 +562,9 @@ describe('document-dal', () => {
 
             await dal.getPageChunksByDocumentIdAndPageNumber('doc-123', 1, '');
 
-            const mustClauses = queryArgs.body.query.bool.must;
+            const filterClauses = queryArgs.body.query.bool.filter;
             assert.strictEqual(
-                mustClauses.some((clause) => clause.match?.chunk_text),
+                filterClauses.some((clause) => clause.match?.chunk_text),
                 false
             );
         });
@@ -586,7 +586,7 @@ describe('document-dal', () => {
 
             await dal.getPageChunksByDocumentIdAndPageNumber('doc-456', 1);
             assert.ok(
-                queryArgs.body.query.bool.must.some(
+                queryArgs.body.query.bool.filter.some(
                     (clause) => clause.term?.source_doc_id === 'doc-456'
                 )
             );
@@ -610,7 +610,7 @@ describe('document-dal', () => {
             await dal.getPageChunksByDocumentIdAndPageNumber('doc-123', '5');
 
             assert.ok(
-                queryArgs.body.query.bool.must.some((clause) => clause.term?.page_number === 5)
+                queryArgs.body.query.bool.filter.some((clause) => clause.term?.page_number === 5)
             );
         });
 
@@ -632,7 +632,7 @@ describe('document-dal', () => {
             await dal.getPageChunksByDocumentIdAndPageNumber('doc-123', 1);
 
             assert.ok(
-                queryArgs.body.query.bool.must.some(
+                queryArgs.body.query.bool.filter.some(
                     (clause) => clause.term?.case_ref === '12-745678'
                 )
             );

--- a/api/DAL/document-dal.test.js
+++ b/api/DAL/document-dal.test.js
@@ -532,7 +532,6 @@ describe('document-dal', () => {
             });
 
             await dal.getPageChunksByDocumentIdAndPageNumber('doc-123', 1, 'search term');
-
             assert.ok(
                 queryArgs.body.query.bool.should.some(
                     (clause) => clause.match?.chunk_text?.query === 'search term'

--- a/api/DAL/document-dal.test.js
+++ b/api/DAL/document-dal.test.js
@@ -691,7 +691,7 @@ describe('document-dal', () => {
             assert.equal(queryArgs.body.query.neural.embedding.query_text, 'needle');
             assert.deepStrictEqual(queryArgs.body.query.neural.embedding.filter, {
                 bool: {
-                    must: [
+                    filter: [
                         { term: { case_ref: '12-745678' } },
                         { term: { source_doc_id: 'doc-123' } },
                         { term: { page_number: 1 } }

--- a/api/DAL/utils/buildQueryJson/README.md
+++ b/api/DAL/utils/buildQueryJson/README.md
@@ -18,14 +18,14 @@ At least one of `useKeyword` or `useSemantic` must be `true`.
 |:---:|:---:|:---:|---|---|
 | ✅ | ❌ | ❌ | Keyword only | `bool` with `match` |
 | ✅ | ❌ | ✅ | Keyword + dates | `bool` with `match` + `match_phrase` date variants |
-| ❌ | ✅ | ❌ | Semantic only | standalone `neural` with filter |
+| ❌ | ✅ | ❌ | Semantic only | standalone `neural` with scoped `filter` |
 | ❌ | ✅ | ✅ | Semantic + dates | `bool` with `match_phrase` date variants + `neural` |
-| ✅ | ✅ | ❌ | Hybrid | `bool` with boosted `match` + `neural` |
-| ✅ | ✅ | ✅ | Hybrid + dates | `bool` with boosted `match` + `match_phrase` date variants + `neural` |
+| ✅ | ✅ | ❌ | Hybrid | `bool` with boosted `match` + boosted `neural` |
+| ✅ | ✅ | ✅ | Hybrid + dates | `bool` with boosted `match` + boosted `match_phrase` date variants + boosted `neural` |
 
 ## Boost constants
 
-Only relevant when `useSemantic` is `true` (hybrid modes).
+Boosts are only applied in hybrid mode (`useKeyword: true, useSemantic: true`). They have no effect in keyword-only or semantic-only modes. In semantic + dates mode (`useKeyword: false, useSemantic: true, enableDateExtraction: true`) the date clause is included but is not boosted.
 
 | Constant | Default | Controls |
 |---|---|---|
@@ -34,6 +34,15 @@ Only relevant when `useSemantic` is `true` (hybrid modes).
 | `DEFAULT_NEURAL_BOOST` | `4` | Weight of the `neural` clause |
 
 These can be overridden per-call via `keywordBoost`, `dateBoost`, and `semanticBoost` parameters.
+
+## Neural filter
+
+All queries that include a `neural` clause attach a `filter` to pre-scope the ANN (approximate nearest neighbour) search to the correct case — and optionally to a specific document page when `documentId` is supplied. Without this, OpenSearch retrieves the top `k` candidates from across all cases before the outer `bool.must` term filter discards irrelevant results, wasting the `k` budget on noise.
+
+- **Case-scoped** (search results): `filter: { term: { case_ref: '...' } }`
+- **Page-scoped** (document chunk viewer): `filter: { bool: { must: [{ term: { case_ref } }, { term: { source_doc_id } }, { term: { page_number } }] } }`
+
+When there is only a single filter clause and the keyword is non-empty (pure semantic, no `documentId`), the `bool.must` wrapper is unwrapped to a direct `term` clause.
 
 ## Usage
 
@@ -47,6 +56,18 @@ const query = buildQueryJson({
     pageNumber: 1,
     itemsPerPage: 10,
     useKeyword: true,
+    useSemantic: true,
+    enableDateExtraction: true,
+    logger
+});
+
+// Semantic + dates (neural + date phrases, no general keyword match)
+const semanticDatesQuery = buildQueryJson({
+    keyword: 'hospital visit 12/01/2020',
+    caseReferenceNumber: '26-711111',
+    pageNumber: 1,
+    itemsPerPage: 10,
+    useKeyword: false,
     useSemantic: true,
     enableDateExtraction: true,
     logger
@@ -67,12 +88,12 @@ const semanticQuery = buildQueryJson({
 
 ## How dates work
 
-When `enableDateExtraction` is `true` and `useKeyword` is `true` (or `useSemantic` is `true`):
+When `enableDateExtraction` is `true`:
 
 1. `extractDatesFromSearchString` scans the keyword for date-like phrases (e.g. `12th January 2020`, `12/01/20`).
 2. Matched phrases are removed from the remaining text.
 3. `generateDateFormatVariants` expands each phrase into multiple normalised formats.
 4. Each variant becomes a `match_phrase` clause against `chunk_text`.
-5. The remaining non-date text becomes a `match` clause (keyword mode) or is sent as `query_text` to the neural model (semantic mode).
+5. The remaining non-date text becomes a `match` clause (keyword/hybrid mode) or is sent as `query_text` to the neural model (semantic mode).
 
 Date variant counts above `VARIANT_THRESHOLD` (50) or should clause counts above `SHOULD_THRESHOLD` (50) trigger a warning log.

--- a/api/DAL/utils/buildQueryJson/README.md
+++ b/api/DAL/utils/buildQueryJson/README.md
@@ -26,13 +26,13 @@ Builds an OpenSearch query DSL object for a given `searchType`.
 
 Boosts are only applied in hybrid modes (`searchType: 'hybrid'` or `'hybrid-dates'`). They have no effect in keyword-only or semantic-only modes.
 
-| Constant | Default | Controls |
-|---|---|---|
-| `DEFAULT_LEXICAL_BOOST` | `12` | Weight of the BM25 `match` clause relative to neural |
-| `DEFAULT_DATE_BOOST` | `1` | Weight of the grouped `match_phrase` date clauses |
-| `DEFAULT_NEURAL_BOOST` | `4` | Weight of the `neural` clause |
+These values are defined in `DEFAULT_QUERY_DSL_CONFIG` and can be overridden through `queryDslConfig`:
 
-These defaults can be overridden through `queryDslConfig`.
+| Config key | Default | Controls |
+|---|---|---|
+| `lexicalBoost` | `20` | Weight of the BM25 `match` clause relative to neural |
+| `dateBoost` | `1` | Weight of the grouped `match_phrase` date clauses |
+| `neuralBoost` | `4` | Weight of the `neural` clause |
 
 ## Neural filter
 

--- a/api/DAL/utils/buildQueryJson/README.md
+++ b/api/DAL/utils/buildQueryJson/README.md
@@ -36,12 +36,12 @@ These defaults can be overridden through `queryDslConfig`.
 
 ## Neural filter
 
-All queries that include a `neural` clause attach a `filter` to pre-scope the ANN (approximate nearest neighbour) search to the correct case — and optionally to a specific document page when `documentId` is supplied. Without this, OpenSearch retrieves the top `k` candidates from across all cases before the outer `bool.must` term filter discards irrelevant results, wasting the `k` budget on noise.
+All queries that include a `neural` clause attach a `filter` to pre-scope the ANN (approximate nearest neighbour) search to the correct case — and optionally to a specific document page when `documentId` is supplied. Without this, OpenSearch retrieves the top `k` candidates from across all cases before the outer `bool.filter` term filter discards irrelevant results, wasting the `k` budget on noise.
 
 - **Case-scoped** (search results): `filter: { term: { case_ref: '...' } }`
-- **Page-scoped** (document chunk viewer): `filter: { bool: { must: [{ term: { case_ref } }, { term: { source_doc_id } }, { term: { page_number } }] } }`
+- **Page-scoped** (document chunk viewer): `filter: { bool: { filter: [{ term: { case_ref } }, { term: { source_doc_id } }, { term: { page_number } }] } }`
 
-When there is only a single filter clause and the keyword is non-empty (pure semantic, no `documentId`), the `bool.must` wrapper is unwrapped to a direct `term` clause.
+When there is only a single filter clause and the keyword is non-empty (pure semantic, no `documentId`), the `bool.filter` wrapper is unwrapped to a direct `term` clause.
 
 ## Usage
 

--- a/api/DAL/utils/buildQueryJson/README.md
+++ b/api/DAL/utils/buildQueryJson/README.md
@@ -1,31 +1,30 @@
 # buildQueryJson
 
-Builds an OpenSearch query DSL object from three independently toggled search capabilities.
+Builds an OpenSearch query DSL object for a given `searchType`.
 
-## Search flags
+## `searchType` values
 
-| Flag | Type | Default | Description |
-|---|---|---|---|
-| `useKeyword` | `boolean` | `true` | Enable lexical (BM25) matching against `chunk_text` |
-| `useSemantic` | `boolean` | `false` | Enable neural vector matching via the `embedding` field |
-| `enableDateExtraction` | `boolean` | `true` | Extract date phrases from the query and expand them into format variants (e.g. `12 Jan 2020`, `12/01/2020`) for `match_phrase` clauses |
+| `searchType` | Default | Description |
+|---|:---:|---|
+| `keyword` | | Lexical (BM25) match against `chunk_text`. No date extraction. |
+| `keyword-dates` | ✅ | Lexical match with date phrase extraction and format-variant expansion. |
+| `semantic` | | Neural vector match via the `embedding` field. No date extraction. |
+| `hybrid` | | Combined BM25 + neural with configurable per-clause boost factors. No date extraction. |
+| `hybrid-dates` | | Combined BM25 + neural with date phrase extraction and format-variant expansion. |
 
-At least one of `useKeyword` or `useSemantic` must be `true`.
+## Valid `searchType` modes
 
-## Valid combinations
-
-| `useKeyword` | `useSemantic` | `enableDateExtraction` | Effective mode | OpenSearch query type |
-|:---:|:---:|:---:|---|---|
-| ✅ | ❌ | ❌ | Keyword only | `bool` with `match` |
-| ✅ | ❌ | ✅ | Keyword + dates | `bool` with `match` + `match_phrase` date variants |
-| ❌ | ✅ | ❌ | Semantic only | standalone `neural` with scoped `filter` |
-| ❌ | ✅ | ✅ | Semantic + dates | `bool` with `match_phrase` date variants + `neural` |
-| ✅ | ✅ | ❌ | Hybrid | `bool` with boosted `match` + boosted `neural` |
-| ✅ | ✅ | ✅ | Hybrid + dates | `bool` with boosted `match` + boosted `match_phrase` date variants + boosted `neural` |
+| `searchType` | Effective mode | OpenSearch query type |
+|---|---|---|
+| `keyword` | Keyword only | `bool` with `match` |
+| `keyword-dates` | Keyword + dates | `bool` with `match` + `match_phrase` date variants |
+| `semantic` | Semantic only | standalone `neural` with scoped `filter` |
+| `hybrid` | Hybrid | `bool` with boosted `match` + boosted `neural` |
+| `hybrid-dates` | Hybrid + dates | `bool` with boosted `match` + boosted `match_phrase` date variants + boosted `neural` |
 
 ## Boost constants
 
-Boosts are only applied in hybrid mode (`useKeyword: true, useSemantic: true`). They have no effect in keyword-only or semantic-only modes. In semantic + dates mode (`useKeyword: false, useSemantic: true, enableDateExtraction: true`) the date clause is included but is not boosted.
+Boosts are only applied in hybrid modes (`searchType: 'hybrid'` or `'hybrid-dates'`). They have no effect in keyword-only or semantic-only modes.
 
 | Constant | Default | Controls |
 |---|---|---|
@@ -49,46 +48,46 @@ When there is only a single filter clause and the keyword is non-empty (pure sem
 ```js
 import buildQueryJson from './index.js';
 
-// Hybrid + dates (all capabilities on)
-const query = buildQueryJson({
+// Hybrid + dates (BM25 + neural + date phrase expansion)
+const hybridDatesQuery = buildQueryJson({
     keyword: 'knee injury 12 January 2020',
     caseReferenceNumber: '26-711111',
     pageNumber: 1,
     itemsPerPage: 10,
-    useKeyword: true,
-    useSemantic: true,
-    enableDateExtraction: true,
-    logger
+    options: { searchType: 'hybrid-dates', logger }
 });
 
-// Semantic + dates (neural + date phrases, no general keyword match)
-const semanticDatesQuery = buildQueryJson({
+// Keyword + dates (BM25 match + date phrase expansion)
+const keywordDatesQuery = buildQueryJson({
     keyword: 'hospital visit 12/01/2020',
     caseReferenceNumber: '26-711111',
     pageNumber: 1,
     itemsPerPage: 10,
-    useKeyword: false,
-    useSemantic: true,
-    enableDateExtraction: true,
-    logger
+    options: { searchType: 'keyword-dates', logger }
 });
 
-// Pure semantic (no lexical, no date expansion)
+// Pure semantic (neural only, no date expansion)
 const semanticQuery = buildQueryJson({
     keyword: 'what injuries did the applicant suffer?',
     caseReferenceNumber: '26-711111',
     pageNumber: 1,
     itemsPerPage: 10,
-    useKeyword: false,
-    useSemantic: true,
-    enableDateExtraction: false,
-    logger
+    options: { searchType: 'semantic', logger }
+});
+
+// Keyword only (BM25, no date expansion)
+const keywordQuery = buildQueryJson({
+    keyword: 'physiotherapy report',
+    caseReferenceNumber: '26-711111',
+    pageNumber: 1,
+    itemsPerPage: 10,
+    options: { searchType: 'keyword', logger }
 });
 ```
 
 ## How dates work
 
-When `enableDateExtraction` is `true`:
+When `searchType` is `keyword-dates` or `hybrid-dates`:
 
 1. `extractDatesFromSearchString` scans the keyword for date-like phrases (e.g. `12th January 2020`, `12/01/20`).
 2. Matched phrases are removed from the remaining text.

--- a/api/DAL/utils/buildQueryJson/README.md
+++ b/api/DAL/utils/buildQueryJson/README.md
@@ -32,7 +32,7 @@ Boosts are only applied in hybrid modes (`searchType: 'hybrid'` or `'hybrid-date
 | `DEFAULT_DATE_BOOST` | `1` | Weight of the grouped `match_phrase` date clauses |
 | `DEFAULT_NEURAL_BOOST` | `4` | Weight of the `neural` clause |
 
-These can be overridden per-call via `keywordBoost`, `dateBoost`, and `semanticBoost` parameters.
+These defaults can be overridden through `queryDslConfig`.
 
 ## Neural filter
 

--- a/api/DAL/utils/buildQueryJson/README.md
+++ b/api/DAL/utils/buildQueryJson/README.md
@@ -1,0 +1,78 @@
+# buildQueryJson
+
+Builds an OpenSearch query DSL object from three independently toggled search capabilities.
+
+## Search flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `useKeyword` | `boolean` | `true` | Enable lexical (BM25) matching against `chunk_text` |
+| `useSemantic` | `boolean` | `false` | Enable neural vector matching via the `embedding` field |
+| `enableDateExtraction` | `boolean` | `true` | Extract date phrases from the query and expand them into format variants (e.g. `12 Jan 2020`, `12/01/2020`) for `match_phrase` clauses |
+
+At least one of `useKeyword` or `useSemantic` must be `true`.
+
+## Valid combinations
+
+| `useKeyword` | `useSemantic` | `enableDateExtraction` | Effective mode | OpenSearch query type |
+|:---:|:---:|:---:|---|---|
+| ✅ | ❌ | ❌ | Keyword only | `bool` with `match` |
+| ✅ | ❌ | ✅ | Keyword + dates | `bool` with `match` + `match_phrase` date variants |
+| ❌ | ✅ | ❌ | Semantic only | standalone `neural` with filter |
+| ❌ | ✅ | ✅ | Semantic + dates | `bool` with `match_phrase` date variants + `neural` |
+| ✅ | ✅ | ❌ | Hybrid | `bool` with boosted `match` + `neural` |
+| ✅ | ✅ | ✅ | Hybrid + dates | `bool` with boosted `match` + `match_phrase` date variants + `neural` |
+
+## Boost constants
+
+Only relevant when `useSemantic` is `true` (hybrid modes).
+
+| Constant | Default | Controls |
+|---|---|---|
+| `DEFAULT_LEXICAL_BOOST` | `12` | Weight of the BM25 `match` clause relative to neural |
+| `DEFAULT_DATE_BOOST` | `1` | Weight of the grouped `match_phrase` date clauses |
+| `DEFAULT_NEURAL_BOOST` | `4` | Weight of the `neural` clause |
+
+These can be overridden per-call via `keywordBoost`, `dateBoost`, and `semanticBoost` parameters.
+
+## Usage
+
+```js
+import buildQueryJson from './index.js';
+
+// Hybrid + dates (all capabilities on)
+const query = buildQueryJson({
+    keyword: 'knee injury 12 January 2020',
+    caseReferenceNumber: '26-711111',
+    pageNumber: 1,
+    itemsPerPage: 10,
+    useKeyword: true,
+    useSemantic: true,
+    enableDateExtraction: true,
+    logger
+});
+
+// Pure semantic (no lexical, no date expansion)
+const semanticQuery = buildQueryJson({
+    keyword: 'what injuries did the applicant suffer?',
+    caseReferenceNumber: '26-711111',
+    pageNumber: 1,
+    itemsPerPage: 10,
+    useKeyword: false,
+    useSemantic: true,
+    enableDateExtraction: false,
+    logger
+});
+```
+
+## How dates work
+
+When `enableDateExtraction` is `true` and `useKeyword` is `true` (or `useSemantic` is `true`):
+
+1. `extractDatesFromSearchString` scans the keyword for date-like phrases (e.g. `12th January 2020`, `12/01/20`).
+2. Matched phrases are removed from the remaining text.
+3. `generateDateFormatVariants` expands each phrase into multiple normalised formats.
+4. Each variant becomes a `match_phrase` clause against `chunk_text`.
+5. The remaining non-date text becomes a `match` clause (keyword mode) or is sent as `query_text` to the neural model (semantic mode).
+
+Date variant counts above `VARIANT_THRESHOLD` (50) or should clause counts above `SHOULD_THRESHOLD` (50) trigger a warning log.

--- a/api/DAL/utils/buildQueryJson/README.md
+++ b/api/DAL/utils/buildQueryJson/README.md
@@ -7,10 +7,10 @@ Builds an OpenSearch query DSL object for a given `searchType`.
 | `searchType` | Default | Description |
 |---|:---:|---|
 | `keyword` | | Lexical (BM25) match against `chunk_text`. No date extraction. |
-| `keyword-dates` | ✅ | Lexical match with date phrase extraction and format-variant expansion. |
+| `keyword-dates` | | Lexical match with date phrase extraction and format-variant expansion. |
 | `semantic` | | Neural vector match via the `embedding` field. No date extraction. |
 | `hybrid` | | Combined BM25 + neural with configurable per-clause boost factors. No date extraction. |
-| `hybrid-dates` | | Combined BM25 + neural with date phrase extraction and format-variant expansion. |
+| `hybrid-dates` | ✅ | Combined BM25 + neural with date phrase extraction and format-variant expansion. |
 
 ## Valid `searchType` modes
 

--- a/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
+++ b/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
@@ -29,7 +29,7 @@ describe('buildQueryJson', () => {
                         { match_phrase: { chunk_text: '2024 May 12' } },
                         {
                             match: {
-                                chunk_text: { query: 'Meeting on at office', operator: 'or' }
+                                chunk_text: { query: 'Meeting on at office' }
                             }
                         }
                     ],
@@ -56,9 +56,7 @@ describe('buildQueryJson', () => {
             query: {
                 bool: {
                     must: [{ term: { case_ref: '26-711111' } }],
-                    should: [
-                        { match: { chunk_text: { query: 'Important meeting', operator: 'or' } } }
-                    ],
+                    should: [{ match: { chunk_text: { query: 'Important meeting' } } }],
                     minimum_should_match: 1
                 }
             }
@@ -110,8 +108,7 @@ describe('buildQueryJson', () => {
                         {
                             match: {
                                 chunk_text: {
-                                    query: 'Event dates: , in the calendar',
-                                    operator: 'or'
+                                    query: 'Event dates: , in the calendar'
                                 }
                             }
                         }
@@ -152,8 +149,7 @@ describe('buildQueryJson', () => {
                         {
                             match: {
                                 chunk_text: {
-                                    query: 'Dates: 50/04/92, , 17/10/123',
-                                    operator: 'or'
+                                    query: 'Dates: 50/04/92, , 17/10/123'
                                 }
                             }
                         }
@@ -209,7 +205,7 @@ describe('buildQueryJson', () => {
                         { match_phrase: { chunk_text: '2024 5 14' } },
                         { match_phrase: { chunk_text: '2024 05 14' } },
                         { match_phrase: { chunk_text: '2024 May 14' } },
-                        { match: { chunk_text: { query: 'Dates:,,', operator: 'or' } } }
+                        { match: { chunk_text: { query: 'Dates:,,' } } }
                     ],
                     minimum_should_match: 1
                 }
@@ -256,7 +252,7 @@ describe('buildQueryJson', () => {
                         { match_phrase: { chunk_text: '2024 06 13' } },
                         { match_phrase: { chunk_text: '2024 Jun 13' } },
                         { match_phrase: { chunk_text: '2024 June 13' } },
-                        { match: { chunk_text: { query: 'project discussion', operator: 'or' } } }
+                        { match: { chunk_text: { query: 'project discussion' } } }
                     ],
                     minimum_should_match: 1
                 }
@@ -273,6 +269,164 @@ describe('buildQueryJson', () => {
             caseReferenceNumber: '26-711111',
             pageNumber: 1,
             itemsPerPage: 10
+        };
+
+        const expected = {
+            from: 0,
+            size: 10,
+            query: {
+                bool: {
+                    must: [{ term: { case_ref: '26-711111' } }]
+                }
+            }
+        };
+
+        const result = buildQueryJson(params);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('Should build a hybrid query when search type is hybrid', () => {
+        const params = {
+            keyword: 'Important meeting',
+            caseReferenceNumber: '26-711111',
+            pageNumber: 2,
+            itemsPerPage: 5,
+            searchType: 'hybrid'
+        };
+
+        const expected = {
+            from: 5,
+            size: 5,
+            query: {
+                bool: {
+                    must: [{ term: { case_ref: '26-711111' } }],
+                    should: [
+                        {
+                            match: {
+                                chunk_text: {
+                                    query: 'Important meeting',
+                                    boost: 12
+                                }
+                            }
+                        },
+                        {
+                            neural: {
+                                embedding: {
+                                    query_text: 'Important meeting',
+                                    boost: 4
+                                }
+                            }
+                        }
+                    ],
+                    minimum_should_match: 1
+                }
+            }
+        };
+
+        const result = buildQueryJson(params);
+        assert.equal(typeof result.min_score, 'number');
+        assert.ok(result.min_score >= 0);
+        assert.ok(result.min_score <= 1);
+
+        const { min_score: _hybridMinScore, ...resultWithoutMinScore } = result;
+        const hybridNeuralClause = resultWithoutMinScore.query.bool.should.find(
+            (clause) => clause.neural?.embedding
+        );
+        const { k: hybridK, ...hybridEmbeddingWithoutK } = hybridNeuralClause.neural.embedding;
+        assert.equal(typeof hybridK, 'number');
+        assert.ok(hybridK > 0);
+        hybridNeuralClause.neural.embedding = hybridEmbeddingWithoutK;
+        assert.deepStrictEqual(resultWithoutMinScore, expected);
+    });
+
+    it('Should build a semantic query when search type is semantic', () => {
+        const params = {
+            keyword: 'Important meeting',
+            caseReferenceNumber: '26-711111',
+            pageNumber: 2,
+            itemsPerPage: 5,
+            searchType: 'semantic'
+        };
+
+        const expected = {
+            from: 5,
+            size: 5,
+            query: {
+                neural: {
+                    embedding: {
+                        query_text: 'Important meeting',
+                        filter: {
+                            term: {
+                                case_ref: '26-711111'
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        const result = buildQueryJson(params);
+        assert.equal(typeof result.min_score, 'number');
+        assert.ok(result.min_score >= 0);
+        assert.ok(result.min_score <= 1);
+
+        const { min_score: _semanticMinScore, ...resultWithoutMinScore } = result;
+        const { k: semanticK, ...semanticEmbeddingWithoutK } =
+            resultWithoutMinScore.query.neural.embedding;
+        assert.equal(typeof semanticK, 'number');
+        assert.ok(semanticK > 0);
+        resultWithoutMinScore.query.neural.embedding = semanticEmbeddingWithoutK;
+        assert.deepStrictEqual(resultWithoutMinScore, expected);
+    });
+
+    it('Should apply separate boosts for date and keyword clauses in hybrid mode', () => {
+        const params = {
+            keyword: 'brain injury september 2021',
+            caseReferenceNumber: '26-711111',
+            pageNumber: 1,
+            itemsPerPage: 5,
+            searchType: 'hybrid'
+        };
+
+        const result = buildQueryJson(params);
+        const lexicalMust = result.query.bool.must;
+        const hybridShould = result.query.bool.should;
+        const dateBoolClause = hybridShould.find(
+            (clause) => clause.bool && Array.isArray(clause.bool.should)
+        );
+        const keywordClause = hybridShould.find((clause) => clause.match?.chunk_text);
+        const neuralClause = hybridShould.find((clause) => clause.neural?.embedding);
+
+        assert.strictEqual(lexicalMust[0].term.case_ref, '26-711111');
+        assert.strictEqual(result.query.bool.minimum_should_match, 1);
+        assert.strictEqual(dateBoolClause.bool.boost, 1);
+        assert.strictEqual(dateBoolClause.bool.minimum_should_match, 1);
+        assert.strictEqual(keywordClause.match.chunk_text.boost, 12);
+        assert.strictEqual(neuralClause.neural.embedding.boost, 4);
+    });
+
+    it('Should correctly compute hybrid pagination when page params are strings', () => {
+        const result = buildQueryJson({
+            keyword: 'Important meeting',
+            caseReferenceNumber: '26-711111',
+            pageNumber: '2',
+            itemsPerPage: '5',
+            searchType: 'hybrid'
+        });
+
+        assert.strictEqual(result.from, 5);
+        assert.strictEqual(result.size, 5);
+        assert.strictEqual(result.query.bool.must[0].term.case_ref, '26-711111');
+        assert.strictEqual(result.query.bool.minimum_should_match, 1);
+    });
+
+    it('Should not build semantic or hybrid query for an empty keyword even when type is semantic', () => {
+        const params = {
+            keyword: '',
+            caseReferenceNumber: '26-711111',
+            pageNumber: 1,
+            itemsPerPage: 10,
+            searchType: 'semantic'
         };
 
         const expected = {
@@ -394,7 +548,7 @@ describe('buildQueryJson', () => {
                         { match_phrase: { chunk_text: '2024 Oct 09' } },
                         { match_phrase: { chunk_text: '2024 October 9' } },
                         { match_phrase: { chunk_text: '2024 October 09' } },
-                        { match: { chunk_text: { query: 'Dates:', operator: 'or' } } }
+                        { match: { chunk_text: { query: 'Dates:' } } }
                     ],
                     minimum_should_match: 1
                 }
@@ -452,8 +606,7 @@ describe('buildQueryJson', () => {
                         {
                             match: {
                                 chunk_text: {
-                                    query: 'Dates: , through to the end of , with a review on',
-                                    operator: 'or'
+                                    query: 'Dates: , through to the end of , with a review on'
                                 }
                             }
                         }
@@ -485,8 +638,7 @@ describe('buildQueryJson', () => {
                         {
                             match: {
                                 chunk_text: {
-                                    query: 'Event on 17102024 was successful',
-                                    operator: 'or'
+                                    query: 'Event on 17102024 was successful'
                                 }
                             }
                         }
@@ -571,5 +723,39 @@ describe('buildQueryJson', () => {
                     Object.hasOwn(condition, 'match_phrase')
                 )
         );
+    });
+
+    it('Should omit from and size for page chunk matches intent', () => {
+        const params = {
+            keyword: 'Important meeting',
+            caseReferenceNumber: '26-711111',
+            pageNumber: 2,
+            itemsPerPage: 5,
+            queryIntent: 'pageChunkMatches'
+        };
+
+        const result = buildQueryJson(params);
+
+        assert.strictEqual(Object.hasOwn(result, 'from'), false);
+        assert.strictEqual(Object.hasOwn(result, 'size'), false);
+        assert.deepStrictEqual(result.query.bool.must, [{ term: { case_ref: '26-711111' } }]);
+    });
+
+    it('Should omit from and size for semantic page chunk matches intent', () => {
+        const params = {
+            keyword: 'Important meeting',
+            caseReferenceNumber: '26-711111',
+            pageNumber: 2,
+            itemsPerPage: 5,
+            searchType: 'semantic',
+            queryIntent: 'pageChunkMatches'
+        };
+
+        const result = buildQueryJson(params);
+
+        assert.strictEqual(Object.hasOwn(result, 'from'), false);
+        assert.strictEqual(Object.hasOwn(result, 'size'), false);
+        assert.strictEqual(typeof result.query.neural.embedding.k, 'number');
+        assert.ok(result.query.neural.embedding.k > 0);
     });
 });

--- a/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
+++ b/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
@@ -330,7 +330,7 @@ describe('buildQueryJson', () => {
                 }),
             {
                 message:
-                    'Invalid searchType "invalid". Must be one of: keyword, keyword-dates, semantic, hybrid, hybrid-dates'
+                    'Invalid searchType "invalid". Must be one of: hybrid-dates, keyword-dates, hybrid, keyword, semantic'
             }
         );
     });

--- a/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
+++ b/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
@@ -1,6 +1,12 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
+import SEARCH_TYPES from '../../../search/constants/searchTypes.js';
 import buildQueryJson from './index.js';
+import {
+    buildDateAwareShouldClauses,
+    buildSemanticQuery,
+    createQueryTypeBuilders
+} from './queryTypeBuilders.js';
 
 describe('buildQueryJson', () => {
     it('Should build query with match_phrase for a single valid numeric date', () => {
@@ -853,5 +859,246 @@ describe('buildQueryJson', () => {
         assert.strictEqual(dateClause.bool.boost, 2);
         assert.strictEqual(neuralClause.neural.embedding.boost, 9);
         assert.strictEqual(neuralClause.neural.embedding.k, 7);
+    });
+
+    it('Should log queryTypeBuilder parameters and output when logger is provided', () => {
+        const originalPrettyFlag = process.env.APP_LOG_PRETTY_JSON;
+        const debugCalls = [];
+        const infoCalls = [];
+        const warnCalls = [];
+        const logger = {
+            debug(...args) {
+                debugCalls.push(args);
+            },
+            info(...args) {
+                infoCalls.push(args);
+            },
+            warn(...args) {
+                warnCalls.push(args);
+            }
+        };
+
+        process.env.APP_LOG_PRETTY_JSON = 'true';
+
+        const result = buildQueryJson({
+            keyword: 'Important meeting',
+            caseReferenceNumber: '26-711111',
+            pageNumber: 1,
+            itemsPerPage: 5,
+            options: {
+                logger,
+                searchType: 'keyword'
+            }
+        });
+
+        if (originalPrettyFlag === undefined) {
+            delete process.env.APP_LOG_PRETTY_JSON;
+        } else {
+            process.env.APP_LOG_PRETTY_JSON = originalPrettyFlag;
+        }
+
+        assert.strictEqual(result.query.bool.filter[0].term.case_ref, '26-711111');
+        assert.ok(debugCalls.length >= 5);
+        assert.strictEqual(infoCalls.length, 1);
+        assert.strictEqual(warnCalls.length, 0);
+
+        const debugMessages = debugCalls.map((call) => call[1]).filter(Boolean);
+
+        assert.ok(debugMessages.some((message) => message.includes('Built query JSON')));
+        assert.ok(
+            debugMessages.some((message) =>
+                message.includes('[BuildQueryJson] keyword queryTypeBuilder parameters')
+            )
+        );
+        assert.ok(
+            debugMessages.some((message) =>
+                message.includes('[BuildQueryJson] keyword queryTypeBuilder output')
+            )
+        );
+    });
+
+    it('Should fallback to original extracted phrase when no date variants are produced', () => {
+        const result = buildDateAwareShouldClauses({
+            keyword: '31/02/2024',
+            enableDateExtraction: true
+        });
+
+        assert.deepStrictEqual(result.phrases, ['31/02/2024']);
+        assert.deepStrictEqual(result.phrasesVariants, ['31/02/2024']);
+        assert.deepStrictEqual(result.shouldClauses, [
+            { match_phrase: { chunk_text: '31/02/2024' } }
+        ]);
+    });
+
+    it('Should append document filters in keyword query builder when documentId is provided', () => {
+        const queryTypeBuilders = createQueryTypeBuilders();
+        const result = queryTypeBuilders[SEARCH_TYPES.KEYWORD]({
+            keyword: 'Important meeting',
+            caseReferenceNumber: '26-711111',
+            safePageNumber: 3,
+            documentId: 'a-doc-id'
+        });
+
+        assert.deepStrictEqual(result.queryJson.query.bool.filter, [
+            { term: { case_ref: '26-711111' } },
+            { term: { source_doc_id: 'a-doc-id' } },
+            { term: { page_number: 3 } }
+        ]);
+    });
+
+    it('Should execute logger debug branches for all query type builders', () => {
+        const debugCalls = [];
+        const logger = {
+            debug(...args) {
+                debugCalls.push(args);
+            }
+        };
+        const queryTypeBuilders = createQueryTypeBuilders();
+
+        queryTypeBuilders[SEARCH_TYPES.KEYWORD]({
+            keyword: 'keyword mode',
+            caseReferenceNumber: '26-711111',
+            safePageNumber: 1,
+            logger
+        });
+        queryTypeBuilders[SEARCH_TYPES.KEYWORD_DATES]({
+            keyword: 'keyword-dates 12/05/2024',
+            caseReferenceNumber: '26-711111',
+            safePageNumber: 1,
+            logger
+        });
+        queryTypeBuilders[SEARCH_TYPES.SEMANTIC]({
+            keyword: 'semantic mode',
+            caseReferenceNumber: '26-711111',
+            safePageNumber: 1,
+            logger
+        });
+        queryTypeBuilders[SEARCH_TYPES.HYBRID]({
+            keyword: 'hybrid mode',
+            caseReferenceNumber: '26-711111',
+            safePageNumber: 1,
+            logger
+        });
+        queryTypeBuilders[SEARCH_TYPES.HYBRID_DATES]({
+            keyword: 'hybrid-dates 12/05/2024',
+            caseReferenceNumber: '26-711111',
+            safePageNumber: 1,
+            logger
+        });
+
+        const debugMessages = debugCalls.map((call) => call[1]).filter(Boolean);
+
+        assert.ok(
+            debugMessages.some((message) =>
+                message.includes('[QueryTypeBuilder] Building keyword query')
+            )
+        );
+        assert.ok(
+            debugMessages.some((message) =>
+                message.includes('[QueryTypeBuilder] Building keyword-dates query')
+            )
+        );
+        assert.ok(
+            debugMessages.some((message) =>
+                message.includes('[QueryTypeBuilder] Building semantic query')
+            )
+        );
+        assert.ok(
+            debugMessages.some((message) =>
+                message.includes('[QueryTypeBuilder] Building hybrid query')
+            )
+        );
+        assert.ok(
+            debugMessages.some((message) =>
+                message.includes('[QueryTypeBuilder] Building hybrid-dates query')
+            )
+        );
+    });
+
+    it('Should build semantic bool query with date match clauses and document scoping', () => {
+        const result = buildSemanticQuery({
+            keyword: 'injury on 12/05/2024',
+            caseReferenceNumber: '26-711111',
+            safePageNumber: 4,
+            documentId: 'doc-123',
+            matchPhraseClauses: [{ match_phrase: { chunk_text: '12 May 2024' } }],
+            queryDslConfig: {
+                semanticK: 9,
+                semanticMinScore: 0.77
+            }
+        });
+
+        assert.strictEqual(result.min_score, 0.77);
+        assert.deepStrictEqual(result.query.bool.filter, [
+            { term: { case_ref: '26-711111' } },
+            { term: { source_doc_id: 'doc-123' } },
+            { term: { page_number: 4 } }
+        ]);
+        assert.deepStrictEqual(result.query.bool.should[0], {
+            bool: {
+                should: [{ match_phrase: { chunk_text: '12 May 2024' } }],
+                minimum_should_match: 1
+            }
+        });
+        assert.deepStrictEqual(result.query.bool.should[1], {
+            neural: {
+                embedding: {
+                    query_text: 'injury on 12/05/2024',
+                    k: 9,
+                    filter: {
+                        bool: {
+                            filter: [
+                                { term: { case_ref: '26-711111' } },
+                                { term: { source_doc_id: 'doc-123' } },
+                                { term: { page_number: 4 } }
+                            ]
+                        }
+                    }
+                }
+            }
+        });
+    });
+
+    it('Should build pure semantic query with document-scoped neural filter', () => {
+        const result = buildSemanticQuery({
+            keyword: 'injury details',
+            caseReferenceNumber: '26-711111',
+            safePageNumber: 2,
+            documentId: 'doc-456',
+            queryDslConfig: {
+                semanticK: 11,
+                semanticMinScore: 0.66
+            }
+        });
+
+        assert.strictEqual(result.min_score, 0.66);
+        assert.deepStrictEqual(result.query.neural.embedding.filter, {
+            bool: {
+                filter: [
+                    { term: { case_ref: '26-711111' } },
+                    { term: { source_doc_id: 'doc-456' } },
+                    { term: { page_number: 2 } }
+                ]
+            }
+        });
+    });
+
+    it('Should append document filters in hybrid query builder when documentId is provided', () => {
+        const result = buildQueryJson({
+            keyword: 'important meeting',
+            caseReferenceNumber: '26-711111',
+            pageNumber: 1,
+            itemsPerPage: 10,
+            options: {
+                searchType: SEARCH_TYPES.HYBRID,
+                documentId: 'doc-789'
+            }
+        });
+
+        assert.deepStrictEqual(result.query.bool.filter, [
+            { term: { case_ref: '26-711111' } },
+            { term: { source_doc_id: 'doc-789' } },
+            { term: { page_number: 1 } }
+        ]);
     });
 });

--- a/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
+++ b/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
@@ -285,13 +285,15 @@ describe('buildQueryJson', () => {
         assert.deepStrictEqual(result, expected);
     });
 
-    it('Should build a hybrid query when search type is hybrid', () => {
+    it('Should build a hybrid query when both useKeyword and useSemantic are true', () => {
         const params = {
             keyword: 'Important meeting',
             caseReferenceNumber: '26-711111',
             pageNumber: 2,
             itemsPerPage: 5,
-            searchType: 'hybrid'
+            useKeyword: true,
+            useSemantic: true,
+            enableDateExtraction: false
         };
 
         const expected = {
@@ -339,13 +341,15 @@ describe('buildQueryJson', () => {
         assert.deepStrictEqual(resultWithoutMinScore, expected);
     });
 
-    it('Should build a semantic query when search type is semantic', () => {
+    it('Should build a semantic query when only useSemantic is true', () => {
         const params = {
             keyword: 'Important meeting',
             caseReferenceNumber: '26-711111',
             pageNumber: 2,
             itemsPerPage: 5,
-            searchType: 'semantic'
+            useKeyword: false,
+            useSemantic: true,
+            enableDateExtraction: false
         };
 
         const expected = {
@@ -385,7 +389,8 @@ describe('buildQueryJson', () => {
             caseReferenceNumber: '26-711111',
             pageNumber: 1,
             itemsPerPage: 5,
-            searchType: 'hybrid'
+            useKeyword: true,
+            useSemantic: true
         };
 
         const result = buildQueryJson(params);
@@ -411,7 +416,9 @@ describe('buildQueryJson', () => {
             caseReferenceNumber: '26-711111',
             pageNumber: '2',
             itemsPerPage: '5',
-            searchType: 'hybrid'
+            useKeyword: true,
+            useSemantic: true,
+            enableDateExtraction: false
         });
 
         assert.strictEqual(result.from, 5);
@@ -420,13 +427,15 @@ describe('buildQueryJson', () => {
         assert.strictEqual(result.query.bool.minimum_should_match, 1);
     });
 
-    it('Should not build semantic or hybrid query for an empty keyword even when type is semantic', () => {
+    it('Should not build semantic or hybrid query for an empty keyword even when useSemantic is true', () => {
         const params = {
             keyword: '',
             caseReferenceNumber: '26-711111',
             pageNumber: 1,
             itemsPerPage: 10,
-            searchType: 'semantic'
+            useKeyword: false,
+            useSemantic: true,
+            enableDateExtraction: false
         };
 
         const expected = {
@@ -747,7 +756,9 @@ describe('buildQueryJson', () => {
             caseReferenceNumber: '26-711111',
             pageNumber: 2,
             itemsPerPage: 5,
-            searchType: 'semantic',
+            useKeyword: false,
+            useSemantic: true,
+            enableDateExtraction: false,
             includePagination: false
         };
 

--- a/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
+++ b/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
@@ -1126,4 +1126,79 @@ describe('buildQueryJson', () => {
         // Should use the default semanticMinScore (0.55) not undefined
         assert.strictEqual(result.min_score, 0.55);
     });
+
+    it('Should remove min_score from hybrid query when keyword is empty with no date phrases', () => {
+        // When keyword is empty and there are no date phrases, the hybrid query has
+        // no scoring clauses (only filter clauses). min_score must be removed to
+        // prevent filtering out all results from a filter-only query.
+        const result = buildQueryJson({
+            keyword: '',
+            caseReferenceNumber: '26-711111',
+            pageNumber: 1,
+            itemsPerPage: 10,
+            options: { searchType: SEARCH_TYPES.HYBRID }
+        });
+
+        const expected = {
+            from: 0,
+            size: 10,
+            query: {
+                bool: {
+                    filter: [{ term: { case_ref: '26-711111' } }]
+                }
+            }
+        };
+
+        // min_score should be removed (undefined)
+        assert.strictEqual(result.min_score, undefined);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('Should remove min_score from hybrid-dates query when keyword is empty with no date phrases', () => {
+        // Even with hybrid-dates searchType, when keyword is empty and date extraction
+        // finds no dates, the result is filter-only. min_score must be removed.
+        const result = buildQueryJson({
+            keyword: '',
+            caseReferenceNumber: '26-711111',
+            pageNumber: 1,
+            itemsPerPage: 10,
+            options: { searchType: SEARCH_TYPES.HYBRID_DATES }
+        });
+
+        const expected = {
+            from: 0,
+            size: 10,
+            query: {
+                bool: {
+                    filter: [{ term: { case_ref: '26-711111' } }]
+                }
+            }
+        };
+
+        // min_score should be removed (undefined)
+        assert.strictEqual(result.min_score, undefined);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('Should keep min_score in hybrid query when there are scoring clauses despite empty keyword', () => {
+        // If date phrases are extracted (keyword is not truly empty in content),
+        // min_score should be kept since there are scoring clauses.
+        const result = buildQueryJson({
+            keyword: '12/05/2024',
+            caseReferenceNumber: '26-711111',
+            pageNumber: 1,
+            itemsPerPage: 10,
+            options: { searchType: SEARCH_TYPES.HYBRID_DATES }
+        });
+
+        // min_score should be present since there are date phrase clauses
+        assert.strictEqual(typeof result.min_score, 'number');
+        assert.ok(result.min_score > 0);
+        // Should have date phrase scoring clauses
+        assert.ok(
+            result.query.bool.should.some((clause) =>
+                clause.bool?.should?.some((c) => c.match_phrase)
+            )
+        );
+    });
 });

--- a/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
+++ b/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
@@ -731,7 +731,7 @@ describe('buildQueryJson', () => {
             caseReferenceNumber: '26-711111',
             pageNumber: 2,
             itemsPerPage: 5,
-            queryIntent: 'pageChunkMatches'
+            includePagination: false
         };
 
         const result = buildQueryJson(params);
@@ -748,7 +748,7 @@ describe('buildQueryJson', () => {
             pageNumber: 2,
             itemsPerPage: 5,
             searchType: 'semantic',
-            queryIntent: 'pageChunkMatches'
+            includePagination: false
         };
 
         const result = buildQueryJson(params);

--- a/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
+++ b/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
@@ -285,6 +285,59 @@ describe('buildQueryJson', () => {
         assert.deepStrictEqual(result, expected);
     });
 
+    it('Should suppress date extraction when enableDateExtraction is false (keyword only mode)', () => {
+        // Keyword contains a date but enableDateExtraction: false — should produce a plain
+        // match clause with no match_phrase clauses, confirming the flag is respected.
+        const params = {
+            keyword: 'Meeting on 12/05/2024 at office',
+            caseReferenceNumber: '26-711111',
+            pageNumber: 1,
+            itemsPerPage: 10,
+            useKeyword: true,
+            useSemantic: false,
+            enableDateExtraction: false
+        };
+
+        const expected = {
+            from: 0,
+            size: 10,
+            query: {
+                bool: {
+                    must: [{ term: { case_ref: '26-711111' } }],
+                    should: [
+                        { match: { chunk_text: { query: 'Meeting on 12/05/2024 at office' } } }
+                    ],
+                    minimum_should_match: 1
+                }
+            }
+        };
+
+        const result = buildQueryJson(params);
+        assert.deepStrictEqual(result, expected);
+        assert.ok(
+            !result.query.bool.should.some((c) => c.match_phrase),
+            'No match_phrase clauses should be present when enableDateExtraction is false'
+        );
+    });
+
+    it('Should throw when all of useKeyword, useSemantic, and enableDateExtraction are false', () => {
+        assert.throws(
+            () =>
+                buildQueryJson({
+                    keyword: 'test',
+                    caseReferenceNumber: '26-711111',
+                    pageNumber: 1,
+                    itemsPerPage: 10,
+                    useKeyword: false,
+                    useSemantic: false,
+                    enableDateExtraction: false
+                }),
+            {
+                message: 'At least one of useKeyword or useSemantic must be enabled'
+            }
+        );
+    });
+
     it('Should build a hybrid query when both useKeyword and useSemantic are true', () => {
         const params = {
             keyword: 'Important meeting',
@@ -315,6 +368,7 @@ describe('buildQueryJson', () => {
                             neural: {
                                 embedding: {
                                     query_text: 'Important meeting',
+                                    filter: { term: { case_ref: '26-711111' } },
                                     boost: 4
                                 }
                             }
@@ -339,6 +393,45 @@ describe('buildQueryJson', () => {
         assert.ok(hybridK > 0);
         hybridNeuralClause.neural.embedding = hybridEmbeddingWithoutK;
         assert.deepStrictEqual(resultWithoutMinScore, expected);
+    });
+
+    it('Should build a semantic+dates query when useSemantic is true and enableDateExtraction is true', () => {
+        const params = {
+            keyword: 'Meeting on 12/05/2024',
+            caseReferenceNumber: '26-711111',
+            pageNumber: 1,
+            itemsPerPage: 5,
+            useKeyword: false,
+            useSemantic: true,
+            enableDateExtraction: true
+        };
+
+        const result = buildQueryJson(params);
+
+        assert.equal(typeof result.min_score, 'number');
+        assert.ok(result.min_score >= 0 && result.min_score <= 1);
+
+        // Should be a bool query (not a raw neural query) when dates are present
+        assert.ok(result.query.bool, 'Expected a bool query wrapping neural + date clauses');
+        assert.deepStrictEqual(result.query.bool.must, [{ term: { case_ref: '26-711111' } }]);
+        assert.strictEqual(result.query.bool.minimum_should_match, 1);
+
+        const should = result.query.bool.should;
+        const dateClause = should.find((c) => c.bool?.should?.some((s) => s.match_phrase));
+        const neuralClause = should.find((c) => c.neural?.embedding);
+
+        assert.ok(dateClause, 'Expected a date bool should clause');
+        assert.ok(
+            dateClause.bool.should.every((c) => c.match_phrase),
+            'All date clauses should be match_phrase'
+        );
+
+        assert.ok(neuralClause, 'Expected a neural clause');
+        assert.strictEqual(neuralClause.neural.embedding.query_text, 'Meeting on 12/05/2024');
+        assert.ok(neuralClause.neural.embedding.filter, 'Neural clause should have a filter');
+        assert.deepStrictEqual(neuralClause.neural.embedding.filter, {
+            term: { case_ref: '26-711111' }
+        });
     });
 
     it('Should build a semantic query when only useSemantic is true', () => {

--- a/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
+++ b/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
@@ -822,4 +822,34 @@ describe('buildQueryJson', () => {
         assert.strictEqual(typeof result.query.neural.embedding.k, 'number');
         assert.ok(result.query.neural.embedding.k > 0);
     });
+
+    it('Should apply queryDslConfig overrides for min score, k and default boosts', () => {
+        const result = buildQueryJson({
+            keyword: 'acute 28/11/2022',
+            caseReferenceNumber: '26-711111',
+            pageNumber: 1,
+            itemsPerPage: 10,
+            options: {
+                searchType: 'hybrid-dates',
+                queryDslConfig: {
+                    semanticMinScore: 0.91,
+                    semanticK: 7,
+                    lexicalBoost: 31,
+                    dateBoost: 2,
+                    neuralBoost: 9
+                }
+            }
+        });
+
+        const shouldClauses = result.query.bool.should;
+        const keywordClause = shouldClauses.find((clause) => clause.match?.chunk_text);
+        const dateClause = shouldClauses.find((clause) => clause.bool?.should);
+        const neuralClause = shouldClauses.find((clause) => clause.neural?.embedding);
+
+        assert.strictEqual(result.min_score, 0.91);
+        assert.strictEqual(keywordClause.match.chunk_text.boost, 31);
+        assert.strictEqual(dateClause.bool.boost, 2);
+        assert.strictEqual(neuralClause.neural.embedding.boost, 9);
+        assert.strictEqual(neuralClause.neural.embedding.k, 7);
+    });
 });

--- a/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
+++ b/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
@@ -8,7 +8,8 @@ describe('buildQueryJson', () => {
             keyword: 'Meeting on 12/05/2024 at office',
             caseReferenceNumber: '26-711111',
             pageNumber: 2,
-            itemsPerPage: 10
+            itemsPerPage: 10,
+            options: { searchType: 'keyword-dates' }
         };
 
         const expected = {
@@ -47,7 +48,8 @@ describe('buildQueryJson', () => {
             keyword: 'Important meeting',
             caseReferenceNumber: '26-711111',
             pageNumber: 1,
-            itemsPerPage: 5
+            itemsPerPage: 5,
+            options: { searchType: 'keyword-dates' }
         };
 
         const expected = {
@@ -71,7 +73,8 @@ describe('buildQueryJson', () => {
             keyword: 'Event dates: 12/01/2024, 13-02-24 in the calendar',
             caseReferenceNumber: '26-711111',
             pageNumber: 1,
-            itemsPerPage: 10
+            itemsPerPage: 10,
+            options: { searchType: 'keyword-dates' }
         };
 
         const expected = {
@@ -127,7 +130,8 @@ describe('buildQueryJson', () => {
             keyword: 'Dates: 50/04/92, 12/05/2024, 17/10/123',
             caseReferenceNumber: '26-711111',
             pageNumber: 1,
-            itemsPerPage: 10
+            itemsPerPage: 10,
+            options: { searchType: 'keyword-dates' }
         };
 
         const expected = {
@@ -168,7 +172,8 @@ describe('buildQueryJson', () => {
             keyword: 'Dates:12/05/2024,13/05/2024,14/05/2024',
             caseReferenceNumber: '26-711111',
             pageNumber: 1,
-            itemsPerPage: 10
+            itemsPerPage: 10,
+            options: { searchType: 'keyword-dates' }
         };
 
         const expected = {
@@ -221,7 +226,8 @@ describe('buildQueryJson', () => {
             keyword: '12/05/2024 project discussion 13/06/2024',
             caseReferenceNumber: '26-711111',
             pageNumber: 1,
-            itemsPerPage: 10
+            itemsPerPage: 10,
+            options: { searchType: 'keyword-dates' }
         };
 
         const expected = {
@@ -268,7 +274,8 @@ describe('buildQueryJson', () => {
             keyword: '',
             caseReferenceNumber: '26-711111',
             pageNumber: 1,
-            itemsPerPage: 10
+            itemsPerPage: 10,
+            options: { searchType: 'keyword-dates' }
         };
 
         const expected = {
@@ -678,7 +685,8 @@ describe('buildQueryJson', () => {
             keyword: 'Event on 17102024 was successful',
             caseReferenceNumber: '26-711111',
             pageNumber: 1,
-            itemsPerPage: 10
+            itemsPerPage: 10,
+            options: { searchType: 'keyword-dates' }
         };
 
         const expected = {
@@ -729,7 +737,8 @@ describe('buildQueryJson', () => {
             keyword: 'Review scheduled in March 2024',
             caseReferenceNumber: '26-711111',
             pageNumber: 1,
-            itemsPerPage: 10
+            itemsPerPage: 10,
+            options: { searchType: 'keyword-dates' }
         };
         const result = buildQueryJson(params);
         assert.strictEqual(result.from, 0);
@@ -747,7 +756,8 @@ describe('buildQueryJson', () => {
             keyword: 'Event on 2024-05-12 at venue',
             caseReferenceNumber: '26-711111',
             pageNumber: 1,
-            itemsPerPage: 10
+            itemsPerPage: 10,
+            options: { searchType: 'keyword-dates' }
         };
         const result = buildQueryJson(params);
         assert.strictEqual(result.from, 0);
@@ -765,7 +775,8 @@ describe('buildQueryJson', () => {
             keyword: 'Hearing on 5th May 2024 at court',
             caseReferenceNumber: '26-711111',
             pageNumber: 1,
-            itemsPerPage: 10
+            itemsPerPage: 10,
+            options: { searchType: 'keyword-dates' }
         };
         const result = buildQueryJson(params);
         assert.strictEqual(result.from, 0);

--- a/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
+++ b/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
@@ -362,7 +362,7 @@ describe('buildQueryJson', () => {
                             match: {
                                 chunk_text: {
                                     query: 'Important meeting',
-                                    boost: 12
+                                    boost: 20
                                 }
                             }
                         },
@@ -459,7 +459,7 @@ describe('buildQueryJson', () => {
         assert.strictEqual(result.query.bool.minimum_should_match, 1);
         assert.strictEqual(dateBoolClause.bool.boost, 1);
         assert.strictEqual(dateBoolClause.bool.minimum_should_match, 1);
-        assert.strictEqual(keywordClause.match.chunk_text.boost, 12);
+        assert.strictEqual(keywordClause.match.chunk_text.boost, 20);
         assert.strictEqual(neuralClause.neural.embedding.boost, 4);
     });
 

--- a/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
+++ b/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
@@ -17,7 +17,7 @@ describe('buildQueryJson', () => {
             size: 10,
             query: {
                 bool: {
-                    must: [{ term: { case_ref: '26-711111' } }],
+                    filter: [{ term: { case_ref: '26-711111' } }],
                     should: [
                         { match_phrase: { chunk_text: '12 5 24' } },
                         { match_phrase: { chunk_text: '12 5 2024' } },
@@ -57,7 +57,7 @@ describe('buildQueryJson', () => {
             size: 5,
             query: {
                 bool: {
-                    must: [{ term: { case_ref: '26-711111' } }],
+                    filter: [{ term: { case_ref: '26-711111' } }],
                     should: [{ match: { chunk_text: { query: 'Important meeting' } } }],
                     minimum_should_match: 1
                 }
@@ -82,7 +82,7 @@ describe('buildQueryJson', () => {
             size: 10,
             query: {
                 bool: {
-                    must: [{ term: { case_ref: '26-711111' } }],
+                    filter: [{ term: { case_ref: '26-711111' } }],
                     should: [
                         { match_phrase: { chunk_text: '12 1 24' } },
                         { match_phrase: { chunk_text: '12 1 2024' } },
@@ -139,7 +139,7 @@ describe('buildQueryJson', () => {
             size: 10,
             query: {
                 bool: {
-                    must: [{ term: { case_ref: '26-711111' } }],
+                    filter: [{ term: { case_ref: '26-711111' } }],
                     should: [
                         { match_phrase: { chunk_text: '12 5 24' } },
                         { match_phrase: { chunk_text: '12 5 2024' } },
@@ -181,7 +181,7 @@ describe('buildQueryJson', () => {
             size: 10,
             query: {
                 bool: {
-                    must: [{ term: { case_ref: '26-711111' } }],
+                    filter: [{ term: { case_ref: '26-711111' } }],
                     should: [
                         { match_phrase: { chunk_text: '12 5 24' } },
                         { match_phrase: { chunk_text: '12 5 2024' } },
@@ -235,7 +235,7 @@ describe('buildQueryJson', () => {
             size: 10,
             query: {
                 bool: {
-                    must: [{ term: { case_ref: '26-711111' } }],
+                    filter: [{ term: { case_ref: '26-711111' } }],
                     should: [
                         { match_phrase: { chunk_text: '12 5 24' } },
                         { match_phrase: { chunk_text: '12 5 2024' } },
@@ -283,7 +283,7 @@ describe('buildQueryJson', () => {
             size: 10,
             query: {
                 bool: {
-                    must: [{ term: { case_ref: '26-711111' } }]
+                    filter: [{ term: { case_ref: '26-711111' } }]
                 }
             }
         };
@@ -308,7 +308,7 @@ describe('buildQueryJson', () => {
             size: 10,
             query: {
                 bool: {
-                    must: [{ term: { case_ref: '26-711111' } }],
+                    filter: [{ term: { case_ref: '26-711111' } }],
                     should: [
                         { match: { chunk_text: { query: 'Meeting on 12/05/2024 at office' } } }
                     ],
@@ -356,7 +356,7 @@ describe('buildQueryJson', () => {
             size: 5,
             query: {
                 bool: {
-                    must: [{ term: { case_ref: '26-711111' } }],
+                    filter: [{ term: { case_ref: '26-711111' } }],
                     should: [
                         {
                             match: {
@@ -394,6 +394,8 @@ describe('buildQueryJson', () => {
         assert.equal(typeof hybridK, 'number');
         assert.ok(hybridK > 0);
         hybridNeuralClause.neural.embedding = hybridEmbeddingWithoutK;
+        // Update expected filter to match what code now produces
+        expected.query.bool.filter = [{ term: { case_ref: '26-711111' } }];
         assert.deepStrictEqual(resultWithoutMinScore, expected);
     });
 
@@ -447,7 +449,6 @@ describe('buildQueryJson', () => {
         };
 
         const result = buildQueryJson(params);
-        const lexicalMust = result.query.bool.must;
         const hybridShould = result.query.bool.should;
         const dateBoolClause = hybridShould.find(
             (clause) => clause.bool && Array.isArray(clause.bool.should)
@@ -455,7 +456,8 @@ describe('buildQueryJson', () => {
         const keywordClause = hybridShould.find((clause) => clause.match?.chunk_text);
         const neuralClause = hybridShould.find((clause) => clause.neural?.embedding);
 
-        assert.strictEqual(lexicalMust[0].term.case_ref, '26-711111');
+        const lexicalFilter = result.query.bool.filter;
+        assert.ok(Array.isArray(lexicalFilter) && lexicalFilter[0]?.term?.case_ref === '26-711111');
         assert.strictEqual(result.query.bool.minimum_should_match, 1);
         assert.strictEqual(dateBoolClause.bool.boost, 1);
         assert.strictEqual(dateBoolClause.bool.minimum_should_match, 1);
@@ -474,7 +476,7 @@ describe('buildQueryJson', () => {
 
         assert.strictEqual(result.from, 5);
         assert.strictEqual(result.size, 5);
-        assert.strictEqual(result.query.bool.must[0].term.case_ref, '26-711111');
+        assert.strictEqual(result.query.bool.filter[0].term.case_ref, '26-711111');
         assert.strictEqual(result.query.bool.minimum_should_match, 1);
     });
 
@@ -491,8 +493,8 @@ describe('buildQueryJson', () => {
             from: 0,
             size: 10,
             query: {
-                bool: {
-                    must: [{ term: { case_ref: '26-711111' } }]
+                term: {
+                    case_ref: '26-711111'
                 }
             }
         };
@@ -515,7 +517,7 @@ describe('buildQueryJson', () => {
             size: 10,
             query: {
                 bool: {
-                    must: [{ term: { case_ref: '26-711111' } }],
+                    filter: [{ term: { case_ref: '26-711111' } }],
                     should: [
                         { match_phrase: { chunk_text: '1 2 24' } },
                         { match_phrase: { chunk_text: '1 2 2024' } },
@@ -633,7 +635,7 @@ describe('buildQueryJson', () => {
             size: 10,
             query: {
                 bool: {
-                    must: [{ term: { case_ref: '26-711111' } }],
+                    filter: [{ term: { case_ref: '26-711111' } }],
                     should: [
                         { match_phrase: { chunk_text: '20 4 22' } },
                         { match_phrase: { chunk_text: '20 4 2022' } },
@@ -694,7 +696,7 @@ describe('buildQueryJson', () => {
             size: 10,
             query: {
                 bool: {
-                    must: [{ term: { case_ref: '26-711111' } }],
+                    filter: [{ term: { case_ref: '26-711111' } }],
                     should: [
                         {
                             match: {
@@ -724,7 +726,7 @@ describe('buildQueryJson', () => {
         const result = buildQueryJson(params);
         assert.strictEqual(result.from, 0);
         assert.strictEqual(result.size, 10);
-        assert.strictEqual(result.query.bool.must[0].term.case_ref, '26-711111');
+        assert.strictEqual(result.query.bool.filter[0].term.case_ref, '26-711111');
         assert.ok(
             Array.isArray(result.query.bool.should) &&
                 result.query.bool.should.some((condition) =>
@@ -743,7 +745,7 @@ describe('buildQueryJson', () => {
         const result = buildQueryJson(params);
         assert.strictEqual(result.from, 0);
         assert.strictEqual(result.size, 10);
-        assert.strictEqual(result.query.bool.must[0].term.case_ref, '26-711111');
+        assert.strictEqual(result.query.bool.filter[0].term.case_ref, '26-711111');
         assert.ok(
             Array.isArray(result.query.bool.should) &&
                 result.query.bool.should.some((condition) =>
@@ -762,7 +764,7 @@ describe('buildQueryJson', () => {
         const result = buildQueryJson(params);
         assert.strictEqual(result.from, 0);
         assert.strictEqual(result.size, 10);
-        assert.strictEqual(result.query.bool.must[0].term.case_ref, '26-711111');
+        assert.strictEqual(result.query.bool.filter[0].term.case_ref, '26-711111');
         assert.ok(
             Array.isArray(result.query.bool.should) &&
                 result.query.bool.should.some((condition) =>
@@ -781,7 +783,7 @@ describe('buildQueryJson', () => {
         const result = buildQueryJson(params);
         assert.strictEqual(result.from, 0);
         assert.strictEqual(result.size, 10);
-        assert.strictEqual(result.query.bool.must[0].term.case_ref, '26-711111');
+        assert.strictEqual(result.query.bool.filter[0].term.case_ref, '26-711111');
         assert.ok(
             Array.isArray(result.query.bool.should) &&
                 result.query.bool.should.some((condition) =>
@@ -803,7 +805,7 @@ describe('buildQueryJson', () => {
 
         assert.strictEqual(Object.hasOwn(result, 'from'), false);
         assert.strictEqual(Object.hasOwn(result, 'size'), false);
-        assert.deepStrictEqual(result.query.bool.must, [{ term: { case_ref: '26-711111' } }]);
+        assert.deepStrictEqual(result.query.bool.filter, [{ term: { case_ref: '26-711111' } }]);
     });
 
     it('Should omit from and size for semantic page chunk matches intent', () => {

--- a/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
+++ b/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
@@ -1101,4 +1101,29 @@ describe('buildQueryJson', () => {
             { term: { page_number: 1 } }
         ]);
     });
+
+    it('Should fall back to defaults when queryDslConfig contains undefined values', () => {
+        // When overrides contain undefined values, they should not replace defaults.
+        // This ensures partial config objects like { semanticK: undefined } don't break queries.
+        const result = buildQueryJson({
+            keyword: 'test search',
+            caseReferenceNumber: '26-711111',
+            pageNumber: 1,
+            itemsPerPage: 10,
+            options: {
+                searchType: SEARCH_TYPES.SEMANTIC,
+                queryDslConfig: {
+                    semanticK: undefined,
+                    semanticMinScore: undefined
+                    // other fields omitted to test partial override
+                }
+            }
+        });
+
+        const neuralEmbedding = result.query.neural.embedding;
+        // Should use the default semanticK (15) not undefined
+        assert.strictEqual(neuralEmbedding.k, 15);
+        // Should use the default semanticMinScore (0.55) not undefined
+        assert.strictEqual(result.min_score, 0.55);
+    });
 });

--- a/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
+++ b/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
@@ -285,17 +285,15 @@ describe('buildQueryJson', () => {
         assert.deepStrictEqual(result, expected);
     });
 
-    it('Should suppress date extraction when enableDateExtraction is false (keyword only mode)', () => {
-        // Keyword contains a date but enableDateExtraction: false — should produce a plain
-        // match clause with no match_phrase clauses, confirming the flag is respected.
+    it('Should suppress date extraction when using keyword only mode', () => {
+        // Keyword contains a date but should produce a plain match clause
+        // with no match_phrase clauses, confirming the flag is respected.
         const params = {
             keyword: 'Meeting on 12/05/2024 at office',
             caseReferenceNumber: '26-711111',
             pageNumber: 1,
             itemsPerPage: 10,
-            useKeyword: true,
-            useSemantic: false,
-            enableDateExtraction: false
+            options: { searchType: 'keyword' }
         };
 
         const expected = {
@@ -316,11 +314,11 @@ describe('buildQueryJson', () => {
         assert.deepStrictEqual(result, expected);
         assert.ok(
             !result.query.bool.should.some((c) => c.match_phrase),
-            'No match_phrase clauses should be present when enableDateExtraction is false'
+            'No match_phrase clauses should be present when date extraction is disabled'
         );
     });
 
-    it('Should throw when all of useKeyword, useSemantic, and enableDateExtraction are false', () => {
+    it('Should throw when an invalid searchType is provided', () => {
         assert.throws(
             () =>
                 buildQueryJson({
@@ -328,25 +326,22 @@ describe('buildQueryJson', () => {
                     caseReferenceNumber: '26-711111',
                     pageNumber: 1,
                     itemsPerPage: 10,
-                    useKeyword: false,
-                    useSemantic: false,
-                    enableDateExtraction: false
+                    options: { searchType: 'invalid' }
                 }),
             {
-                message: 'At least one of useKeyword or useSemantic must be enabled'
+                message:
+                    'Invalid searchType "invalid". Must be one of: keyword, keyword-dates, semantic, hybrid, hybrid-dates'
             }
         );
     });
 
-    it('Should build a hybrid query when both useKeyword and useSemantic are true', () => {
+    it('Should build a hybrid query when searchType is hybrid', () => {
         const params = {
             keyword: 'Important meeting',
             caseReferenceNumber: '26-711111',
             pageNumber: 2,
             itemsPerPage: 5,
-            useKeyword: true,
-            useSemantic: true,
-            enableDateExtraction: false
+            options: { searchType: 'hybrid' }
         };
 
         const expected = {
@@ -395,54 +390,13 @@ describe('buildQueryJson', () => {
         assert.deepStrictEqual(resultWithoutMinScore, expected);
     });
 
-    it('Should build a semantic+dates query when useSemantic is true and enableDateExtraction is true', () => {
-        const params = {
-            keyword: 'Meeting on 12/05/2024',
-            caseReferenceNumber: '26-711111',
-            pageNumber: 1,
-            itemsPerPage: 5,
-            useKeyword: false,
-            useSemantic: true,
-            enableDateExtraction: true
-        };
-
-        const result = buildQueryJson(params);
-
-        assert.equal(typeof result.min_score, 'number');
-        assert.ok(result.min_score >= 0 && result.min_score <= 1);
-
-        // Should be a bool query (not a raw neural query) when dates are present
-        assert.ok(result.query.bool, 'Expected a bool query wrapping neural + date clauses');
-        assert.deepStrictEqual(result.query.bool.must, [{ term: { case_ref: '26-711111' } }]);
-        assert.strictEqual(result.query.bool.minimum_should_match, 1);
-
-        const should = result.query.bool.should;
-        const dateClause = should.find((c) => c.bool?.should?.some((s) => s.match_phrase));
-        const neuralClause = should.find((c) => c.neural?.embedding);
-
-        assert.ok(dateClause, 'Expected a date bool should clause');
-        assert.ok(
-            dateClause.bool.should.every((c) => c.match_phrase),
-            'All date clauses should be match_phrase'
-        );
-
-        assert.ok(neuralClause, 'Expected a neural clause');
-        assert.strictEqual(neuralClause.neural.embedding.query_text, 'Meeting on 12/05/2024');
-        assert.ok(neuralClause.neural.embedding.filter, 'Neural clause should have a filter');
-        assert.deepStrictEqual(neuralClause.neural.embedding.filter, {
-            term: { case_ref: '26-711111' }
-        });
-    });
-
-    it('Should build a semantic query when only useSemantic is true', () => {
+    it('Should build a semantic query when searchType is semantic', () => {
         const params = {
             keyword: 'Important meeting',
             caseReferenceNumber: '26-711111',
             pageNumber: 2,
             itemsPerPage: 5,
-            useKeyword: false,
-            useSemantic: true,
-            enableDateExtraction: false
+            options: { searchType: 'semantic' }
         };
 
         const expected = {
@@ -482,8 +436,7 @@ describe('buildQueryJson', () => {
             caseReferenceNumber: '26-711111',
             pageNumber: 1,
             itemsPerPage: 5,
-            useKeyword: true,
-            useSemantic: true
+            options: { searchType: 'hybrid-dates' }
         };
 
         const result = buildQueryJson(params);
@@ -509,9 +462,7 @@ describe('buildQueryJson', () => {
             caseReferenceNumber: '26-711111',
             pageNumber: '2',
             itemsPerPage: '5',
-            useKeyword: true,
-            useSemantic: true,
-            enableDateExtraction: false
+            options: { searchType: 'hybrid' }
         });
 
         assert.strictEqual(result.from, 5);
@@ -520,15 +471,13 @@ describe('buildQueryJson', () => {
         assert.strictEqual(result.query.bool.minimum_should_match, 1);
     });
 
-    it('Should not build semantic or hybrid query for an empty keyword even when useSemantic is true', () => {
+    it('Should not build semantic or hybrid query for an empty keyword', () => {
         const params = {
             keyword: '',
             caseReferenceNumber: '26-711111',
             pageNumber: 1,
             itemsPerPage: 10,
-            useKeyword: false,
-            useSemantic: true,
-            enableDateExtraction: false
+            options: { searchType: 'semantic' }
         };
 
         const expected = {
@@ -550,7 +499,8 @@ describe('buildQueryJson', () => {
             keyword: 'Dates: 01/02/2024 03-04-24 07 / 08 / 2024 09 – 10 – 2024',
             caseReferenceNumber: '26-711111',
             pageNumber: 1,
-            itemsPerPage: 10
+            itemsPerPage: 10,
+            options: { searchType: 'keyword-dates' }
         };
 
         const expected = {
@@ -667,7 +617,8 @@ describe('buildQueryJson', () => {
                 'Dates: 20/04/2022, through to the end of June 2022, with a review on 2022-07-15',
             caseReferenceNumber: '26-711111',
             pageNumber: 1,
-            itemsPerPage: 10
+            itemsPerPage: 10,
+            options: { searchType: 'keyword-dates' }
         };
 
         const expected = {
@@ -759,7 +710,8 @@ describe('buildQueryJson', () => {
             keyword: 'Meeting on 5 January 2024 at office',
             caseReferenceNumber: '26-711111',
             pageNumber: 1,
-            itemsPerPage: 10
+            itemsPerPage: 10,
+            options: { searchType: 'keyword-dates' }
         };
         const result = buildQueryJson(params);
         assert.strictEqual(result.from, 0);
@@ -833,7 +785,7 @@ describe('buildQueryJson', () => {
             caseReferenceNumber: '26-711111',
             pageNumber: 2,
             itemsPerPage: 5,
-            includePagination: false
+            options: { includePagination: false }
         };
 
         const result = buildQueryJson(params);
@@ -849,10 +801,7 @@ describe('buildQueryJson', () => {
             caseReferenceNumber: '26-711111',
             pageNumber: 2,
             itemsPerPage: 5,
-            useKeyword: false,
-            useSemantic: true,
-            enableDateExtraction: false,
-            includePagination: false
+            options: { searchType: 'semantic', includePagination: false }
         };
 
         const result = buildQueryJson(params);

--- a/api/DAL/utils/buildQueryJson/index.js
+++ b/api/DAL/utils/buildQueryJson/index.js
@@ -2,6 +2,216 @@ import crypto from 'node:crypto';
 import extractDatesFromSearchString from '../extractDatesFromSearchString/index.js';
 import generateDateFormatVariants from '../generateDateFormatVariants/index.js';
 
+const SEMANTIC_MIN_SCORE = 0.1; // Needs to be worked out through experimentation or dropped in favour of a low K value
+const DEFAULT_SEMANTIC_K = 5; // Too high and we get a lot of poor quality results - noise
+const VARIANT_THRESHOLD = 50; // date variant count above which we log a warning, as this could indicate an explosion in the number of should clauses and potential performance issues
+const SHOULD_THRESHOLD = 50; // should clause count above which we log a warning, as this could indicate an explosion in the number of should clauses and potential performance issues
+const DEFAULT_LEXICAL_BOOST = 12; // lexical search results to appear most relevant
+const DEFAULT_DATE_BOOST = 1; // weightings to be determined
+const DEFAULT_NEURAL_BOOST = 4; // weightings to be determined
+
+// the highlighting features need to use the same query as the search (see bug:CICADS-655),
+// use this intent to set the scope of the query single page or all matching pages
+const QUERY_INTENTS = Object.freeze({
+    SEARCH_RESULTS: 'searchResults',
+    PAGE_CHUNK_MATCHES: 'pageChunkMatches'
+});
+
+/**
+ * Determines whether pagination fields should be emitted.
+ *
+ * @param {'searchResults' | 'pageChunkMatches'} queryIntent - Query purpose.
+ * @returns {boolean}
+ */
+function shouldApplyPagination(queryIntent) {
+    return queryIntent === QUERY_INTENTS.SEARCH_RESULTS;
+}
+
+/**
+ * Creates the lexical query shell scoped to the case reference.
+ *
+ * @param {string} caseReferenceNumber - Case reference filter value.
+ * @returns {Object}
+ */
+function createLexicalQuery(caseReferenceNumber) {
+    return {
+        bool: {
+            must: [{ term: { case_ref: caseReferenceNumber } }]
+        }
+    };
+}
+
+/**
+ * Creates the semantic neural query (scoped to the case reference).
+ *
+ * @param {Object} params - Semantic query options.
+ * @param {string} params.keyword - Raw search text.
+ * @param {string} params.caseReferenceNumber - Case reference filter value.
+ * @returns {Object}
+ */
+function createNeuralQuery({ keyword, caseReferenceNumber }) {
+    return {
+        neural: {
+            embedding: {
+                query_text: keyword,
+                k: DEFAULT_SEMANTIC_K,
+                filter: {
+                    term: { case_ref: caseReferenceNumber }
+                }
+            }
+        }
+    };
+}
+
+/**
+ * Builds lexical should clauses and date-processing metrics.
+ *
+ * @param {Object} params - Date processing options.
+ * @param {string} params.keyword - Raw search string.
+ * @param {boolean} [params.enableDateExtraction=true] - Whether to extract and expand dates.
+ * @returns {Object}
+ */
+function buildDateAwareShouldClauses({ keyword, enableDateExtraction = true }) {
+    const extractStart = Date.now();
+
+    let phrases = [];
+    let remainingText = keyword;
+    let matchedPatterns = [];
+
+    if (enableDateExtraction) {
+        const extractionResult = extractDatesFromSearchString(keyword);
+        phrases = extractionResult.dates;
+        remainingText = extractionResult.remainingText;
+        matchedPatterns = extractionResult.matchedPatterns;
+    }
+
+    const extractEnd = Date.now();
+
+    const variantStart = Date.now();
+    let phrasesVariants = [];
+
+    if (enableDateExtraction) {
+        // Build variants for each extracted phrase, falling back to the
+        // original phrase if no variants are produced, and then
+        // deduplicate (via the Set) across all phrases.
+        phrasesVariants = Array.from(
+            new Set(
+                phrases.flatMap((phrase, index) => {
+                    const variants = generateDateFormatVariants(phrase, matchedPatterns[index]);
+                    if (!variants || variants.length === 0) {
+                        return [phrase];
+                    }
+                    return variants;
+                })
+            )
+        );
+    }
+
+    const variantEnd = Date.now();
+
+    const shouldClauses = [];
+
+    if (phrasesVariants.length > 0) {
+        phrasesVariants.forEach((phrase) => {
+            shouldClauses.push({
+                match_phrase: {
+                    chunk_text: phrase
+                }
+            });
+        });
+    }
+
+    if (remainingText) {
+        shouldClauses.push({
+            match: {
+                chunk_text: {
+                    query: remainingText
+                }
+            }
+        });
+    }
+
+    return {
+        shouldClauses,
+        phrases,
+        phrasesVariants,
+        extractStart,
+        extractEnd,
+        variantStart,
+        variantEnd
+    };
+}
+
+/**
+ * Computes and logs query metrics with threshold warnings.
+ *
+ * @param {Object} params - Logging inputs.
+ * @param {Object} params.queryJson - Final query payload.
+ * @param {string} params.keyword - Raw search string.
+ * @param {Array<string>} params.phrases - Extracted date phrases.
+ * @param {Array<string>} params.phrasesVariants - Expanded phrase variants.
+ * @param {Array<Object>} params.shouldClauses - Generated lexical clauses.
+ * @param {number} params.startBuild - Build start timestamp.
+ * @param {number} params.buildEnd - Build end timestamp.
+ * @param {number} params.extractStart - Extraction start timestamp.
+ * @param {number} params.extractEnd - Extraction end timestamp.
+ * @param {number} params.variantStart - Variant generation start timestamp.
+ * @param {number} params.variantEnd - Variant generation end timestamp.
+ * @param {Logger} [params.logger] - Optional structured logger.
+ * @param {string} params.caseReferenceNumber - Case reference scope for logs.
+ * @returns {void}
+ */
+function logQueryMetrics({
+    queryJson,
+    keyword,
+    phrases,
+    phrasesVariants,
+    shouldClauses,
+    startBuild,
+    buildEnd,
+    extractStart,
+    extractEnd,
+    variantStart,
+    variantEnd,
+    logger,
+    caseReferenceNumber
+}) {
+    const metrics = {
+        queryHash: crypto.createHash('sha256').update(keyword).digest('hex').slice(0, 8),
+        phraseCount: phrases.length,
+        variantCount: phrasesVariants.length,
+        shouldClauseCount: shouldClauses.length,
+        payloadSize: JSON.stringify(queryJson).length,
+        extractMs: extractEnd - extractStart,
+        variantMs: variantEnd - variantStart,
+        buildMs: buildEnd - startBuild
+    };
+
+    if (!logger) {
+        return;
+    }
+
+    logger.info(
+        {
+            caseReferenceNumber,
+            ...metrics
+        },
+        '[QueryBuilder] Query metrics'
+    );
+
+    if (metrics.variantCount > VARIANT_THRESHOLD || metrics.shouldClauseCount > SHOULD_THRESHOLD) {
+        logger.warn(
+            {
+                caseReferenceNumber,
+                queryHash: metrics.queryHash,
+                variantCount: metrics.variantCount,
+                shouldClauseCount: metrics.shouldClauseCount
+            },
+            '[QueryBuilder] Variant/clause count exceeds safe threshold'
+        );
+    }
+}
+
 /**
  * Builds an OpenSearch  query JSON object based on the provided search parameters.
  *
@@ -17,122 +227,174 @@ import generateDateFormatVariants from '../generateDateFormatVariants/index.js';
  * @param {number} params.pageNumber - The current page number (1-based).
  * @param {number} params.itemsPerPage - Number of results to return per page.
  * @param {Logger} [params.logger] - Optional structured logger instance.
+ * @param {'keyword' | 'semantic' | 'hybrid'} [params.searchType='keyword'] - Which search mode to use.
+ * @param {'searchResults' | 'pageChunkMatches'} [params.queryIntent='searchResults'] - Query purpose.
+ * @param {boolean} [params.enableDateExtraction=true] - Enables date extraction and variant matching.
+ * @param {number} [params.keywordBoost] - Boost multiplier for the lexical sub-query in hybrid mode.
+ * @param {number} [params.dateBoost] - Boost multiplier for date variant clauses in hybrid mode.
+ * @param {number} [params.semanticBoost] - Boost multiplier for the neural sub-query in hybrid mode.
+ * @param {string} [params.documentId] - Document UUID to scope results to a single document. Required when queryIntent is pageChunkMatches.
  *
  * @returns {Object} OpenSearch query DSL JSON object.
  */
-function buildQueryJson({ keyword, caseReferenceNumber, pageNumber, itemsPerPage, logger }) {
+function buildQueryJson({
+    keyword,
+    caseReferenceNumber,
+    pageNumber,
+    itemsPerPage,
+    logger,
+    searchType = 'keyword',
+    queryIntent = QUERY_INTENTS.SEARCH_RESULTS,
+    enableDateExtraction = true,
+    keywordBoost = DEFAULT_LEXICAL_BOOST,
+    dateBoost = DEFAULT_DATE_BOOST,
+    semanticBoost = DEFAULT_NEURAL_BOOST,
+    documentId
+}) {
     const startBuild = Date.now();
-    const queryJson = {
-        from: itemsPerPage * (pageNumber - 1),
-        size: itemsPerPage,
-        query: {
-            bool: {
-                // `term` is used for exact matching of the case reference
-                // number, otherwise it will be tokenised.
-                must: [{ term: { case_ref: caseReferenceNumber } }]
-            }
-        }
-    };
+    const queryJson = {};
+    const applyPagination = shouldApplyPagination(queryIntent);
+    const normalizedPageNumber = Number.parseInt(pageNumber, 10);
+    const normalizedItemsPerPage = Number.parseInt(itemsPerPage, 10);
+    const safePageNumber =
+        Number.isFinite(normalizedPageNumber) && normalizedPageNumber > 0
+            ? normalizedPageNumber
+            : 1;
+    const safeItemsPerPage =
+        Number.isFinite(normalizedItemsPerPage) && normalizedItemsPerPage > 0
+            ? normalizedItemsPerPage
+            : 10;
 
-    const extractStart = Date.now();
+    if (applyPagination) {
+        queryJson.from = safeItemsPerPage * (safePageNumber - 1);
+        queryJson.size = safeItemsPerPage;
+    }
+
+    // When the intent is a single-page chunk lookup, scope the query to the specific
+    // document and page. These filters are injected into every query branch below.
+    const pageChunkScopeFilters =
+        queryIntent === QUERY_INTENTS.PAGE_CHUNK_MATCHES && documentId
+            ? [{ term: { source_doc_id: documentId } }, { term: { page_number: safePageNumber } }]
+            : [];
+
+    const lexicalQuery = createLexicalQuery(caseReferenceNumber);
+    if (pageChunkScopeFilters.length > 0) {
+        lexicalQuery.bool.must.push(...pageChunkScopeFilters);
+    }
+
     const {
-        dates: phrases,
-        remainingText,
-        matchedPatterns
-    } = extractDatesFromSearchString(keyword);
-    const extractEnd = Date.now();
-
-    const shouldClauses = [];
-
-    const variantStart = Date.now();
-    // build variants for each extracted phrase, falling back to the
-    // original phrase if no variants are produced, and then
-    // deduplicate (via the new Set) across all phrases.
-    const phrasesVariants = Array.from(
-        new Set(
-            phrases.flatMap((phrase, index) => {
-                const variants = generateDateFormatVariants(phrase, matchedPatterns[index]);
-                if (!variants || variants.length === 0) {
-                    return [phrase];
-                }
-                return variants;
-            })
-        )
-    );
-    const variantEnd = Date.now();
-
-    // add match_phrase queries for each extracted date phrase.
-    if (phrasesVariants.length !== 0) {
-        phrasesVariants.forEach((phrase) => {
-            shouldClauses.push({
-                match_phrase: {
-                    chunk_text: phrase
-                }
-            });
-        });
-    }
-
-    // add match query for remaining text.
-    if (remainingText) {
-        shouldClauses.push({
-            match: {
-                chunk_text: {
-                    query: remainingText,
-                    operator: 'or'
-                }
-            }
-        });
-    }
+        shouldClauses,
+        phrases,
+        phrasesVariants,
+        extractStart,
+        extractEnd,
+        variantStart,
+        variantEnd
+    } = buildDateAwareShouldClauses({ keyword, enableDateExtraction });
 
     if (shouldClauses.length > 0) {
-        queryJson.query.bool.should = shouldClauses;
-        queryJson.query.bool.minimum_should_match = 1;
+        lexicalQuery.bool.should = shouldClauses;
+        lexicalQuery.bool.minimum_should_match = 1;
     }
 
-    // metrics.
-    const buildEnd = Date.now();
-    const phraseCount = phrases.length;
-    const variantCount = phrasesVariants.length;
-    const shouldClauseCount = shouldClauses.length;
-    const payloadSize = JSON.stringify(queryJson).length;
-    const extractMs = extractEnd - extractStart;
-    const variantMs = variantEnd - variantStart;
-    const buildMs = buildEnd - startBuild;
+    const hasKeyword = keyword.trim().length > 0;
+    const runKeywordSearch = searchType === 'keyword' || searchType === 'hybrid';
+    const runSemanticSearch = (searchType === 'semantic' || searchType === 'hybrid') && hasKeyword;
 
-    // thresholds.
-    const VARIANT_THRESHOLD = 50;
-    const SHOULD_THRESHOLD = 50;
+    if (runSemanticSearch) {
+        queryJson.min_score = SEMANTIC_MIN_SCORE;
+    }
 
-    // safe query hash for correlation, not raw text.
-    const queryHash = crypto.createHash('sha256').update(keyword).digest('hex').slice(0, 8);
-    if (logger) {
-        logger.info(
-            {
-                caseReferenceNumber,
-                queryHash,
-                phraseCount,
-                variantCount,
-                shouldClauseCount,
-                payloadSize,
-                extractMs,
-                variantMs,
-                buildMs
-            },
-            '[QueryBuilder] Query metrics'
+    const neuralQuery = createNeuralQuery({
+        keyword,
+        caseReferenceNumber
+    });
+
+    if (pageChunkScopeFilters.length > 0) {
+        neuralQuery.neural.embedding.filter = {
+            bool: {
+                must: [{ term: { case_ref: caseReferenceNumber } }, ...pageChunkScopeFilters]
+            }
+        };
+    }
+
+    // For hybrid mode we build a single bool query that combines lexical and
+    // semantic clauses under should so the query is paginatable via from/size.
+    if (runKeywordSearch && runSemanticSearch) {
+        const lexicalMustClauses = [
+            { term: { case_ref: caseReferenceNumber } },
+            ...pageChunkScopeFilters
+        ];
+        const hybridShouldClauses = [];
+        const dateShouldClauses = shouldClauses.filter((clause) =>
+            Object.hasOwn(clause, 'match_phrase')
         );
-        if (variantCount > VARIANT_THRESHOLD || shouldClauseCount > SHOULD_THRESHOLD) {
-            logger.warn(
-                {
-                    caseReferenceNumber,
-                    queryHash,
-                    variantCount,
-                    shouldClauseCount
-                },
-                '[QueryBuilder] Variant/clause count exceeds safe threshold'
-            );
+        const keywordMatchClause = shouldClauses.find((clause) => Object.hasOwn(clause, 'match'));
+
+        if (dateShouldClauses.length > 0) {
+            hybridShouldClauses.push({
+                bool: {
+                    should: dateShouldClauses,
+                    minimum_should_match: 1,
+                    boost: dateBoost
+                }
+            });
         }
+
+        if (keywordMatchClause?.match?.chunk_text) {
+            hybridShouldClauses.push({
+                match: {
+                    chunk_text: {
+                        ...keywordMatchClause.match.chunk_text,
+                        boost: keywordBoost
+                    }
+                }
+            });
+        }
+
+        hybridShouldClauses.push({
+            neural: {
+                embedding: {
+                    query_text: keyword,
+                    k: DEFAULT_SEMANTIC_K,
+                    boost: semanticBoost
+                }
+            }
+        });
+
+        queryJson.query = {
+            bool: {
+                must: lexicalMustClauses,
+                should: hybridShouldClauses,
+                minimum_should_match: 1
+            }
+        };
+    } else if (runSemanticSearch) {
+        // just a semantic search
+        queryJson.query = neuralQuery;
+    } else {
+        // just a keyword search
+        queryJson.query = lexicalQuery;
     }
 
+    const buildEnd = Date.now();
+    logQueryMetrics({
+        queryJson,
+        keyword,
+        phrases,
+        phrasesVariants,
+        shouldClauses,
+        startBuild,
+        buildEnd,
+        extractStart,
+        extractEnd,
+        variantStart,
+        variantEnd,
+        logger,
+        caseReferenceNumber
+    });
+
+    console.log(JSON.stringify(queryJson, null, 2));
     return queryJson;
 }
 

--- a/api/DAL/utils/buildQueryJson/index.js
+++ b/api/DAL/utils/buildQueryJson/index.js
@@ -1,6 +1,6 @@
 import SEARCH_TYPES, { DEFAULT_SEARCH_TYPE } from '../../../search/constants/searchTypes.js';
 import logQueryMetrics from '../logQueryMetrics/index.js';
-import { createQueryTypeBuilders, resolveQueryDslConfig } from './queryTypeBuilders.js';
+import { createQueryTypeBuilders } from './queryTypeBuilders.js';
 
 /**
  * Normalises raw pageNumber and itemsPerPage inputs to safe integer values.
@@ -72,8 +72,7 @@ function buildQueryJson({
 }) {
     const buildStart = Date.now();
 
-    const effectiveQueryDslConfig = resolveQueryDslConfig(queryDslConfig);
-    const queryTypeBuilders = createQueryTypeBuilders({ queryDslConfig: effectiveQueryDslConfig });
+    const queryTypeBuilders = createQueryTypeBuilders({ queryDslConfig });
 
     // dispatch to the appropriate mode-specific builder. Each builder handles
     // its own date preprocessing (keyword and hybrid extract dates, semantic
@@ -129,7 +128,7 @@ function buildQueryJson({
         caseReferenceNumber,
         safePageNumber,
         documentId,
-        effectiveQueryDslConfig
+        queryDslConfig
     };
     const prettyJsonEnabled = process.env.APP_LOG_PRETTY_JSON === 'true';
     const paramsPrettyJson = prettyJsonEnabled

--- a/api/DAL/utils/buildQueryJson/index.js
+++ b/api/DAL/utils/buildQueryJson/index.js
@@ -93,7 +93,8 @@ function buildQueryJson({
         caseReferenceNumber,
         safePageNumber,
         documentId,
-        boostConfig: { keywordBoost, dateBoost, semanticBoost }
+        boostConfig: { keywordBoost, dateBoost, semanticBoost },
+        logger
     };
 
     const { queryJson, phrases, phrasesVariants, shouldClauses, extractMs, variantMs } =
@@ -125,7 +126,21 @@ function buildQueryJson({
         searchType
     });
 
-    console.log(JSON.stringify(queryJson, null, 4)); // TEMP logging for verification during development.
+    logger?.debug?.({ queryJson }, 'Built query JSON');
+
+    // TEMP logging for verification during development. Remove or replace with appropriate structured logging as needed.
+    console.log(`[BuildQueryJson] Temp log - ${searchType} queryTypeBuilder parameters`, {
+        keyword,
+        caseReferenceNumber,
+        safePageNumber,
+        documentId,
+        boostConfig: { keywordBoost, dateBoost, semanticBoost }
+    });
+    // TEMP logging for verification during development. Remove or replace with appropriate structured logging as needed.
+    console.log(
+        `[BuildQueryJson] Temp log - ${searchType} queryTypeBuilder output`,
+        JSON.stringify(queryJson, null, 4)
+    );
 
     return queryJson;
 }

--- a/api/DAL/utils/buildQueryJson/index.js
+++ b/api/DAL/utils/buildQueryJson/index.js
@@ -1,180 +1,6 @@
-import crypto from 'node:crypto';
-import extractDatesFromSearchString from '../extractDatesFromSearchString/index.js';
-import generateDateFormatVariants from '../generateDateFormatVariants/index.js';
-
-const SEMANTIC_MIN_SCORE = 0.1; // Needs to be worked out through experimentation or dropped in favour of a low K value
-const DEFAULT_SEMANTIC_K = 5; // Too high and we get a lot of poor quality results - noise
-const VARIANT_THRESHOLD = 50; // date variant count above which we log a warning, as this could indicate an explosion in the number of should clauses and potential performance issues
-const SHOULD_THRESHOLD = 50; // should clause count above which we log a warning, as this could indicate an explosion in the number of should clauses and potential performance issues
-const DEFAULT_LEXICAL_BOOST = 12; // lexical search results to appear most relevant
-const DEFAULT_DATE_BOOST = 1; // weightings to be determined
-const DEFAULT_NEURAL_BOOST = 4; // weightings to be determined
-
-/**
- * Creates the lexical query shell scoped to the case reference.
- *
- * @param {string} caseReferenceNumber - Case reference filter value.
- * @returns {object} Lexical query DSL object.
- */
-function createLexicalQuery({ caseReferenceNumber }) {
-    return {
-        query: {
-            bool: {
-                must: [{ term: { case_ref: caseReferenceNumber } }],
-                should: [],
-                minimum_should_match: 1
-            }
-        }
-    };
-}
-
-/**
- * Creates the semantic neural query (scoped to the case reference).
- *
- * @param {object} params - Semantic query options.
- * @param {string} params.keyword - Raw search text.
- * @param {string} params.caseReferenceNumber - Case reference filter value.
- * @returns {object} Semantic query DSL object.
- */
-function createNeuralQuery({ keyword, caseReferenceNumber }) {
-    return {
-        query: {
-            neural: {
-                embedding: {
-                    query_text: keyword,
-                    k: DEFAULT_SEMANTIC_K,
-                    filter: {
-                        bool: {
-                            must: [{ term: { case_ref: caseReferenceNumber } }]
-                        }
-                    }
-                }
-            }
-        },
-        min_score: keyword.trim().length > 0 ? SEMANTIC_MIN_SCORE : undefined
-    };
-}
-
-/**
- * Creates the hybrid query shell scoped to the case reference.
- * Used when at least one of useKeyword or useSemantic is true alongside the other.
- *
- * @param {string} caseReferenceNumber - Case reference filter value.
- * @returns {object} Hybrid query DSL object.
- */
-function createHybridQuery({ caseReferenceNumber }) {
-    return {
-        query: {
-            bool: {
-                must: [{ term: { case_ref: caseReferenceNumber } }],
-                should: [],
-                minimum_should_match: 1
-            }
-        },
-        min_score: SEMANTIC_MIN_SCORE
-    };
-}
-
-/**
- * Builds the neural filter object that pre-scopes the ANN search to the correct case
- * (and optionally document page) so OpenSearch does not retrieve k candidates from
- * other cases before the outer bool.must filters them out.
- *
- * @param {object} params - Filter parameters.
- * @param {string} params.caseReferenceNumber - Case reference filter value.
- * @param {string} [params.documentId] - Optional document UUID for page-level scoping.
- * @param {number} params.safePageNumber - Normalised page number for document scoping.
- * @returns {object} A single term clause or a bool.must wrapper.
- */
-function buildNeuralFilter({ caseReferenceNumber, documentId, safePageNumber }) {
-    const must = [{ term: { case_ref: caseReferenceNumber } }];
-    if (documentId) {
-        must.push(
-            { term: { source_doc_id: documentId } },
-            { term: { page_number: safePageNumber } }
-        );
-    }
-    return must.length === 1 ? must[0] : { bool: { must } };
-}
-
-/**
- * Builds lexical should clauses and date-processing metrics.
- *
- * @param {object} params - Date processing options.
- * @param {string} params.keyword - Raw search string.
- * @param {boolean} [params.enableDateExtraction=true] - Whether to extract and expand dates.
- * @returns {{ shouldClauses: Array<object>, phrases: Array<string>, phrasesVariants: Array<string>, timings: { extractMs: number, variantMs: number } }} Lexical clauses and date-processing metrics.
- */
-function buildDateAwareShouldClauses({ keyword, enableDateExtraction = true }) {
-    const extractStart = Date.now();
-
-    let phrases = [];
-    let remainingText = keyword;
-    let matchedPatterns = [];
-
-    if (enableDateExtraction) {
-        const extractionResult = extractDatesFromSearchString(keyword);
-        phrases = extractionResult.dates;
-        remainingText = extractionResult.remainingText;
-        matchedPatterns = extractionResult.matchedPatterns;
-    }
-
-    const extractEnd = Date.now();
-
-    const variantStart = Date.now();
-    let phrasesVariants = [];
-
-    if (enableDateExtraction) {
-        // Build variants for each extracted phrase, falling back to the
-        // original phrase if no variants are produced, and then
-        // deduplicate (via the Set) across all phrases.
-        phrasesVariants = Array.from(
-            new Set(
-                phrases.flatMap((phrase, index) => {
-                    const variants = generateDateFormatVariants(phrase, matchedPatterns[index]);
-                    if (!variants || variants.length === 0) {
-                        return [phrase];
-                    }
-                    return variants;
-                })
-            )
-        );
-    }
-
-    const variantEnd = Date.now();
-
-    const shouldClauses = [];
-
-    if (phrasesVariants.length > 0) {
-        phrasesVariants.forEach((phrase) => {
-            shouldClauses.push({
-                match_phrase: {
-                    chunk_text: phrase
-                }
-            });
-        });
-    }
-
-    if (remainingText) {
-        shouldClauses.push({
-            match: {
-                chunk_text: {
-                    query: remainingText
-                }
-            }
-        });
-    }
-
-    return {
-        shouldClauses,
-        phrases,
-        phrasesVariants,
-        timings: {
-            extractMs: extractEnd - extractStart,
-            variantMs: variantEnd - variantStart
-        }
-    };
-}
+import SEARCH_TYPES from '../../../search/constants/searchTypes.js';
+import logQueryMetrics from '../logQueryMetrics/index.js';
+import { queryTypeBuilders } from './queryTypeBuilders.js';
 
 /**
  * Normalises raw pageNumber and itemsPerPage inputs to safe integer values.
@@ -199,287 +25,25 @@ function normalisePagination(pageNumber, itemsPerPage) {
 }
 
 /**
- * Assembles the keyword (lexical) query, applying should clauses and optional document scoping.
- *
- * @param {object} params - Keyword query options.
- * @param {string} params.caseReferenceNumber - Case reference filter value.
- * @param {Array<object>} params.shouldClauses - Lexical should clauses from date/text extraction.
- * @param {number} params.safePageNumber - Normalised page number for document scoping.
- * @param {string} [params.documentId] - Optional document UUID to scope results to a single page.
- * @returns {object} Assembled keyword query DSL object.
- */
-function buildKeywordQuery({ caseReferenceNumber, shouldClauses, safePageNumber, documentId }) {
-    const queryJson = createLexicalQuery({ caseReferenceNumber });
-
-    queryJson.query.bool.should = shouldClauses;
-    queryJson.query.bool.minimum_should_match = shouldClauses.length > 0 ? 1 : undefined;
-
-    if (documentId) {
-        queryJson.query.bool.must.push(
-            { term: { source_doc_id: documentId } },
-            { term: { page_number: safePageNumber } }
-        );
-    }
-
-    return queryJson;
-}
-
-/**
- * Assembles the semantic (neural) query, applying optional document scoping.
- * When date match_phrase clauses are supplied, wraps the neural clause in a bool
- * query alongside the date should clauses (semantic + dates mode).
- *
- * @param {object} params - Semantic query options.
- * @param {string} params.keyword - Raw search text.
- * @param {string} params.caseReferenceNumber - Case reference filter value.
- * @param {number} params.safePageNumber - Normalised page number for document scoping.
- * @param {string} [params.documentId] - Optional document UUID to scope results to a single page.
- * @param {Array<object>} [params.matchPhraseClauses=[]] - Date match_phrase clauses to include alongside the neural clause.
- * @returns {object} Assembled semantic (or semantic + dates) query DSL object.
- */
-function buildSemanticQuery({
-    keyword,
-    caseReferenceNumber,
-    safePageNumber,
-    documentId,
-    matchPhraseClauses = []
-}) {
-    // When date phrases are present, produce a bool query with the neural clause and
-    // date phrase clauses as sibling should branches. A non-empty keyword is implied
-    // since dates cannot be extracted from an empty string.
-    if (matchPhraseClauses.length > 0) {
-        const queryJson = createHybridQuery({ caseReferenceNumber });
-
-        if (documentId) {
-            queryJson.query.bool.must.push(
-                { term: { source_doc_id: documentId } },
-                { term: { page_number: safePageNumber } }
-            );
-        }
-
-        queryJson.query.bool.should.push({
-            bool: {
-                should: matchPhraseClauses,
-                minimum_should_match: 1
-            }
-        });
-
-        const neuralFilter = buildNeuralFilter({ caseReferenceNumber, documentId, safePageNumber });
-        queryJson.query.bool.should.push({
-            neural: {
-                embedding: {
-                    query_text: keyword,
-                    k: DEFAULT_SEMANTIC_K,
-                    filter: neuralFilter
-                }
-            }
-        });
-
-        return queryJson;
-    }
-
-    // Pure neural: no date phrases (or empty keyword fallback).
-    const queryJson = createNeuralQuery({ keyword, caseReferenceNumber });
-
-    if (documentId) {
-        queryJson.query.neural.embedding.filter.bool.must.push(
-            { term: { source_doc_id: documentId } },
-            { term: { page_number: safePageNumber } }
-        );
-    }
-
-    // When there is only a single filter must clause and the keyword is non-empty,
-    // simplify the DSL by unwrapping the bool wrapper.
-    if (
-        queryJson.query.neural.embedding.filter.bool.must.length === 1 &&
-        keyword.trim().length !== 0
-    ) {
-        queryJson.query.neural.embedding.filter =
-            queryJson.query.neural.embedding.filter.bool.must[0];
-    }
-
-    // An empty keyword means the neural clause has no query text and would match
-    // everything. Promote the filter to the top-level query and drop the neural
-    // clause and min_score so the query correctly scopes to case_ref only.
-    if (keyword.trim().length === 0) {
-        queryJson.query = queryJson.query.neural.embedding.filter;
-        delete queryJson.query.neural;
-        delete queryJson.min_score;
-    }
-
-    return queryJson;
-}
-
-/**
- * Assembles the hybrid query, combining boosted lexical, date, and neural should clauses
- * with optional document scoping. Always includes both keyword (BM25) and semantic
- * (neural) branches — date phrase clauses are added when present.
- *
- * @param {object} params - Hybrid query options.
- * @param {string} params.keyword - Raw search text.
- * @param {string} params.caseReferenceNumber - Case reference filter value.
- * @param {Array<object>} params.shouldClauses - Lexical should clauses from date/text extraction.
- * @param {number} params.safePageNumber - Normalised page number for document scoping.
- * @param {string} [params.documentId] - Optional document UUID to scope results to a single page.
- * @param {number} params.keywordBoost - Boost for the lexical match clause.
- * @param {number} params.dateBoost - Boost for the grouped date variant clauses.
- * @param {number} params.semanticBoost - Boost for the neural clause.
- * @returns {object} Assembled hybrid query DSL object.
- */
-function buildHybridQuery({
-    keyword,
-    caseReferenceNumber,
-    shouldClauses,
-    safePageNumber,
-    documentId,
-    keywordBoost,
-    dateBoost,
-    semanticBoost
-}) {
-    const queryJson = createHybridQuery({ caseReferenceNumber });
-
-    const matchClause = shouldClauses.find((clause) => Object.hasOwn(clause, 'match'));
-    const matchPhraseClauses = shouldClauses.filter((clause) =>
-        Object.hasOwn(clause, 'match_phrase')
-    );
-
-    if (documentId) {
-        queryJson.query.bool.must.push(
-            { term: { source_doc_id: documentId } },
-            { term: { page_number: safePageNumber } }
-        );
-    }
-
-    // Boosted lexical match clause.
-    if (matchClause?.match?.chunk_text) {
-        queryJson.query.bool.should.push({
-            match: {
-                chunk_text: {
-                    ...matchClause.match.chunk_text,
-                    boost: keywordBoost
-                }
-            }
-        });
-    }
-
-    // Boosted date variant clauses, grouped so they share a single boost weight.
-    if (matchPhraseClauses.length > 0) {
-        queryJson.query.bool.should.push({
-            bool: {
-                should: matchPhraseClauses,
-                minimum_should_match: 1,
-                boost: dateBoost
-            }
-        });
-    }
-
-    // Boosted neural clause — only when the keyword is non-empty.
-    if (keyword.trim().length > 0) {
-        const neuralFilter = buildNeuralFilter({ caseReferenceNumber, documentId, safePageNumber });
-        queryJson.query.bool.should.push({
-            neural: {
-                embedding: {
-                    query_text: keyword,
-                    k: DEFAULT_SEMANTIC_K,
-                    filter: neuralFilter,
-                    boost: semanticBoost
-                }
-            }
-        });
-    }
-
-    return queryJson;
-}
-
-/**
- * Computes and logs query metrics with threshold warnings.
- *
- * @param {object} params - Logging inputs.
- * @param {object} params.queryJson - Final query payload.
- * @param {string} params.keyword - Raw search string.
- * @param {Array<string>} params.phrases - Extracted date phrases.
- * @param {Array<string>} params.phrasesVariants - Expanded phrase variants.
- * @param {Array<object>} params.shouldClauses - Generated lexical clauses.
- * @param {number} params.buildMs - Build duration in ms.
- * @param {number} params.extractMs - Extraction duration in ms.
- * @param {number} params.variantMs - Variant generation duration in ms.
- * @param {object} [params.logger] - Optional structured logger.
- * @param {string} params.caseReferenceNumber - Case reference scope for logs.
- * @returns {void}
- */
-function logQueryMetrics({
-    queryJson,
-    keyword,
-    phrases,
-    phrasesVariants,
-    shouldClauses,
-    buildMs,
-    extractMs,
-    variantMs,
-    logger,
-    caseReferenceNumber
-}) {
-    const metrics = {
-        queryHash: crypto.createHash('sha256').update(keyword).digest('hex').slice(0, 8),
-        phraseCount: phrases.length,
-        phraseVariantCount: phrasesVariants.length,
-        shouldClauseCount: shouldClauses.length,
-        payloadSize: JSON.stringify(queryJson).length,
-        extractMs,
-        variantMs,
-        buildMs
-    };
-
-    if (!logger) {
-        return;
-    }
-
-    logger?.info(
-        {
-            caseReferenceNumber,
-            ...metrics
-        },
-        '[QueryBuilder] Query metrics'
-    );
-
-    if (
-        metrics.phraseVariantCount > VARIANT_THRESHOLD ||
-        metrics.shouldClauseCount > SHOULD_THRESHOLD
-    ) {
-        logger.warn(
-            {
-                caseReferenceNumber,
-                queryHash: metrics.queryHash,
-                variantCount: metrics.phraseVariantCount,
-                shouldClauseCount: metrics.shouldClauseCount
-            },
-            '[QueryBuilder] Variant/clause count exceeds safe threshold'
-        );
-    }
-}
-
-/**
- * Builds an OpenSearch query JSON object based on the provided search parameters.
+ * Assembles the semantic (neural) query, applying optional document scoping.ould clauses
  *
  * The query:
  * - Filters by an exact `case_ref` using a `term` query.
  * - Applies pagination using `from` and `size`.
  * - Composes results from up to four independently toggled capabilities:
- *   - **keyword** (`useKeyword`)  — BM25 lexical matching against `chunk_text`.
- *   - **semantic** (`useSemantic`) — neural vector matching via the `embedding` field.
- *   - **dates** (`enableDateExtraction`) — date phrase extraction and format-variant expansion.
+ *   - **keyword** (`searchType`)  — BM25 lexical matching against `chunk_text`.
+ *   - **semantic** (`searchType`) — neural vector matching via the `embedding` field.
  *
  * Valid combinations:
- * | useKeyword | useSemantic | enableDateExtraction | Effective mode          |
- * |------------|-------------|----------------------|-------------------------|
- * | true       | false       | false                | keyword only            |
- * | true       | false       | true                 | keyword + dates         |
- * | false      | true        | false                | semantic only           |
- * | false      | true        | true                 | semantic + dates        | ← bool(neural + dates)
- * | true       | true        | false                | hybrid                  |
- * | true       | true        | true                 | hybrid + dates          |
+ * | searchType                    | Effective mode     |
+ * |-------------------------------|--------------------|
+ * | SEARCH_TYPES.KEYWORD          | keyword only       |
+ * | SEARCH_TYPES.KEYWORD_DATES    | keyword + dates    |
+ * | SEARCH_TYPES.SEMANTIC         | semantic only      |
+ * | SEARCH_TYPES.HYBRID           | hybrid             |
+ * | SEARCH_TYPES.HYBRID_DATES     | hybrid + dates     |
  *
- * At least one of `useKeyword` or `useSemantic` must be true.
+ * `searchType` must be one of the SEARCH_TYPES values.
  *
  * @param {object} params - Search parameters.
  * @param {string} params.keyword - Raw search string entered by the user. May contain date phrases and free text.
@@ -487,10 +51,8 @@ function logQueryMetrics({
  * @param {number} params.pageNumber - The current page number (1-based).
  * @param {number} params.itemsPerPage - Number of results to return per page.
  * @param {object} [params.logger] - Optional structured logger instance.
- * @param {boolean} [params.useKeyword=true] - Enable lexical (BM25) keyword matching.
- * @param {boolean} [params.useSemantic=false] - Enable neural (vector) semantic matching.
+ * @param {string} [params.searchType='keyword-dates'] - Search mode. One of SEARCH_TYPES.KEYWORD, SEARCH_TYPES.KEYWORD_DATES, SEARCH_TYPES.SEMANTIC, SEARCH_TYPES.HYBRID, or SEARCH_TYPES.HYBRID_DATES.
  * @param {boolean} [params.includePagination=true] - Whether to include pagination fields in the query.
- * @param {boolean} [params.enableDateExtraction=true] - Enable date extraction and variant expansion.
  * @param {number} [params.keywordBoost] - Boost multiplier for the lexical sub-query in hybrid mode.
  * @param {number} [params.dateBoost] - Boost multiplier for date variant clauses in hybrid mode.
  * @param {number} [params.semanticBoost] - Boost multiplier for the neural sub-query in hybrid mode.
@@ -502,74 +64,40 @@ function buildQueryJson({
     caseReferenceNumber,
     pageNumber,
     itemsPerPage,
-    logger,
-    useKeyword = true,
-    useSemantic = false,
-    includePagination = true,
-    enableDateExtraction = true,
-    keywordBoost = DEFAULT_LEXICAL_BOOST,
-    dateBoost = DEFAULT_DATE_BOOST,
-    semanticBoost = DEFAULT_NEURAL_BOOST,
-    documentId
+    options: {
+        logger,
+        searchType = SEARCH_TYPES.KEYWORD_DATES,
+        includePagination = true,
+        documentId,
+        keywordBoost,
+        dateBoost,
+        semanticBoost
+    } = {}
 }) {
-    if (!useKeyword && !useSemantic) {
-        throw new Error('At least one of useKeyword or useSemantic must be enabled');
-    }
-
     const buildStart = Date.now();
 
-    // Build lexical clauses when keyword matching is active, or when semantic + date
-    // extraction is active (date match_phrase clauses are added to the hybrid bool query).
-    const needsLexicalClauses = useKeyword || (useSemantic && enableDateExtraction);
-    const {
-        shouldClauses,
-        phrases,
-        phrasesVariants,
-        timings: { extractMs, variantMs }
-    } = needsLexicalClauses
-        ? buildDateAwareShouldClauses({ keyword, enableDateExtraction })
-        : {
-              shouldClauses: [],
-              phrases: [],
-              phrasesVariants: [],
-              timings: { extractMs: 0, variantMs: 0 }
-          };
+    // dispatch to the appropriate mode-specific builder. Each builder handles
+    // its own date preprocessing (keyword and hybrid extract dates, semantic
+    // skips preprocessing entirely for efficiency).
+    const queryTypeBuilder = queryTypeBuilders[searchType];
+    if (!queryTypeBuilder) {
+        throw new Error(
+            `Invalid searchType "${searchType}". Must be one of: ${Object.values(SEARCH_TYPES).join(', ')}`
+        );
+    }
 
     const { safePageNumber, safeItemsPerPage } = normalisePagination(pageNumber, itemsPerPage);
 
-    const matchPhraseClauses = shouldClauses.filter((c) => Object.hasOwn(c, 'match_phrase'));
+    const builderParams = {
+        keyword,
+        caseReferenceNumber,
+        safePageNumber,
+        documentId,
+        boostConfig: { keywordBoost, dateBoost, semanticBoost }
+    };
 
-    let queryJson;
-    if (useKeyword && !useSemantic) {
-        // Pure lexical: keyword with or without date expansion.
-        queryJson = buildKeywordQuery({
-            caseReferenceNumber,
-            shouldClauses, // date match_phrase clauses will be included here when enableDateExtraction is on.
-            safePageNumber,
-            documentId
-        });
-    } else if (!useKeyword && useSemantic) {
-        // Pure semantic: neural only, with date phrases added when enableDateExtraction is on.
-        queryJson = buildSemanticQuery({
-            keyword,
-            caseReferenceNumber,
-            safePageNumber,
-            documentId,
-            matchPhraseClauses
-        });
-    } else {
-        // Hybrid: keyword + semantic, with date phrases when enableDateExtraction is on.
-        queryJson = buildHybridQuery({
-            keyword,
-            caseReferenceNumber,
-            shouldClauses,
-            safePageNumber,
-            documentId,
-            keywordBoost,
-            dateBoost,
-            semanticBoost
-        });
-    }
+    const { queryJson, phrases, phrasesVariants, shouldClauses, extractMs, variantMs } =
+        queryTypeBuilder(builderParams);
 
     if (includePagination === true) {
         queryJson.from = safeItemsPerPage * (safePageNumber - 1);
@@ -582,6 +110,7 @@ function buildQueryJson({
     }
 
     const buildEnd = Date.now();
+
     logQueryMetrics({
         queryJson,
         keyword,
@@ -592,8 +121,11 @@ function buildQueryJson({
         extractMs,
         variantMs,
         logger,
-        caseReferenceNumber
+        caseReferenceNumber,
+        searchType
     });
+
+    console.log(JSON.stringify(queryJson, null, 4)); // TEMP logging for verification during development.
 
     return queryJson;
 }

--- a/api/DAL/utils/buildQueryJson/index.js
+++ b/api/DAL/utils/buildQueryJson/index.js
@@ -28,16 +28,12 @@ function normalisePagination(pageNumber, itemsPerPage) {
 }
 
 /**
- * Assembles the semantic (neural) query, applying optional document-scoping should clauses
+ * Assembles an OpenSearch query DSL object for the given search mode.
  *
- * The query:
- * - Filters by an exact `case_ref` using a `term` query.
- * - Applies pagination using `from` and `size`.
- * - Composes results from up to four independently toggled capabilities:
- *   - **keyword** (`searchType`)  — BM25 lexical matching against `chunk_text`.
- *   - **semantic** (`searchType`) — neural vector matching via the `embedding` field.
+ * Dispatches to the appropriate mode-specific builder based on `searchType` and
+ * applies pagination, optional document scoping, and structured logging.
  *
- * Valid combinations:
+ * Valid search modes:
  * | searchType                    | Effective mode     |
  * |-------------------------------|--------------------|
  * | SEARCH_TYPES.KEYWORD          | keyword only       |
@@ -46,18 +42,17 @@ function normalisePagination(pageNumber, itemsPerPage) {
  * | SEARCH_TYPES.HYBRID           | hybrid             |
  * | SEARCH_TYPES.HYBRID_DATES     | hybrid + dates     |
  *
- * `searchType` must be one of the SEARCH_TYPES values.
- *
  * @param {object} params - Search parameters.
  * @param {string} params.keyword - Raw search string entered by the user. May contain date phrases and free text.
  * @param {string} params.caseReferenceNumber - Exact case reference number to filter results by.
  * @param {number} params.pageNumber - The current page number (1-based).
  * @param {number} params.itemsPerPage - Number of results to return per page.
- * @param {object} [params.logger] - Optional structured logger instance.
- * @param {string} [params.searchType=DEFAULT_SEARCH_TYPE] - Search mode. One of SEARCH_TYPES.KEYWORD, SEARCH_TYPES.KEYWORD_DATES, SEARCH_TYPES.SEMANTIC, SEARCH_TYPES.HYBRID, or SEARCH_TYPES.HYBRID_DATES.
- * @param {boolean} [params.includePagination=true] - Whether to include pagination fields in the query.
- * @param {object} [params.queryDslConfig] - Optional tuning overrides for semantic thresholds, ANN k, and default boosts.
- * @param {string} [params.documentId] - Document UUID to scope results to a single document and page.
+ * @param {object} [params.options] - Optional behavioural overrides.
+ * @param {object} [params.options.logger] - Optional structured logger instance.
+ * @param {string} [params.options.searchType=DEFAULT_SEARCH_TYPE] - Search mode. One of SEARCH_TYPES.KEYWORD, SEARCH_TYPES.KEYWORD_DATES, SEARCH_TYPES.SEMANTIC, SEARCH_TYPES.HYBRID, or SEARCH_TYPES.HYBRID_DATES.
+ * @param {boolean} [params.options.includePagination=true] - Whether to include pagination fields in the query.
+ * @param {object} [params.options.queryDslConfig] - Optional tuning overrides for semantic thresholds, ANN k, and default boosts.
+ * @param {string} [params.options.documentId] - Document UUID to scope results to a single document and page.
  * @returns {object} OpenSearch query DSL JSON object.
  */
 function buildQueryJson({

--- a/api/DAL/utils/buildQueryJson/index.js
+++ b/api/DAL/utils/buildQueryJson/index.js
@@ -76,6 +76,28 @@ function createHybridQuery({ caseReferenceNumber }) {
 }
 
 /**
+ * Builds the neural filter object that pre-scopes the ANN search to the correct case
+ * (and optionally document page) so OpenSearch does not retrieve k candidates from
+ * other cases before the outer bool.must filters them out.
+ *
+ * @param {object} params - Filter parameters.
+ * @param {string} params.caseReferenceNumber - Case reference filter value.
+ * @param {string} [params.documentId] - Optional document UUID for page-level scoping.
+ * @param {number} params.safePageNumber - Normalised page number for document scoping.
+ * @returns {object} A single term clause or a bool.must wrapper.
+ */
+function buildNeuralFilter({ caseReferenceNumber, documentId, safePageNumber }) {
+    const must = [{ term: { case_ref: caseReferenceNumber } }];
+    if (documentId) {
+        must.push(
+            { term: { source_doc_id: documentId } },
+            { term: { page_number: safePageNumber } }
+        );
+    }
+    return must.length === 1 ? must[0] : { bool: { must } };
+}
+
+/**
  * Builds lexical should clauses and date-processing metrics.
  *
  * @param {object} params - Date processing options.
@@ -203,17 +225,60 @@ function buildKeywordQuery({ caseReferenceNumber, shouldClauses, safePageNumber,
 }
 
 /**
- * Assembles the semantic (neural) query, applying optional document scoping and simplifying
- * the filter DSL where possible.
+ * Assembles the semantic (neural) query, applying optional document scoping.
+ * When date match_phrase clauses are supplied, wraps the neural clause in a bool
+ * query alongside the date should clauses (semantic + dates mode).
  *
  * @param {object} params - Semantic query options.
  * @param {string} params.keyword - Raw search text.
  * @param {string} params.caseReferenceNumber - Case reference filter value.
  * @param {number} params.safePageNumber - Normalised page number for document scoping.
  * @param {string} [params.documentId] - Optional document UUID to scope results to a single page.
- * @returns {object} Assembled semantic query DSL object.
+ * @param {Array<object>} [params.matchPhraseClauses=[]] - Date match_phrase clauses to include alongside the neural clause.
+ * @returns {object} Assembled semantic (or semantic + dates) query DSL object.
  */
-function buildSemanticQuery({ keyword, caseReferenceNumber, safePageNumber, documentId }) {
+function buildSemanticQuery({
+    keyword,
+    caseReferenceNumber,
+    safePageNumber,
+    documentId,
+    matchPhraseClauses = []
+}) {
+    // When date phrases are present, produce a bool query with the neural clause and
+    // date phrase clauses as sibling should branches. A non-empty keyword is implied
+    // since dates cannot be extracted from an empty string.
+    if (matchPhraseClauses.length > 0) {
+        const queryJson = createHybridQuery({ caseReferenceNumber });
+
+        if (documentId) {
+            queryJson.query.bool.must.push(
+                { term: { source_doc_id: documentId } },
+                { term: { page_number: safePageNumber } }
+            );
+        }
+
+        queryJson.query.bool.should.push({
+            bool: {
+                should: matchPhraseClauses,
+                minimum_should_match: 1
+            }
+        });
+
+        const neuralFilter = buildNeuralFilter({ caseReferenceNumber, documentId, safePageNumber });
+        queryJson.query.bool.should.push({
+            neural: {
+                embedding: {
+                    query_text: keyword,
+                    k: DEFAULT_SEMANTIC_K,
+                    filter: neuralFilter
+                }
+            }
+        });
+
+        return queryJson;
+    }
+
+    // Pure neural: no date phrases (or empty keyword fallback).
     const queryJson = createNeuralQuery({ keyword, caseReferenceNumber });
 
     if (documentId) {
@@ -246,12 +311,9 @@ function buildSemanticQuery({ keyword, caseReferenceNumber, safePageNumber, docu
 }
 
 /**
- * Assembles the hybrid query, combining any combination of boosted lexical, date, and neural
- * should clauses with optional document scoping.
- *
- * Covers three cases driven by the flags:
- *   - useKeyword + useSemantic  → full hybrid (lexical + dates + neural)
- *   - !useKeyword + useSemantic + dates → dates only + neural (no general text match)
+ * Assembles the hybrid query, combining boosted lexical, date, and neural should clauses
+ * with optional document scoping. Always includes both keyword (BM25) and semantic
+ * (neural) branches — date phrase clauses are added when present.
  *
  * @param {object} params - Hybrid query options.
  * @param {string} params.keyword - Raw search text.
@@ -259,7 +321,6 @@ function buildSemanticQuery({ keyword, caseReferenceNumber, safePageNumber, docu
  * @param {Array<object>} params.shouldClauses - Lexical should clauses from date/text extraction.
  * @param {number} params.safePageNumber - Normalised page number for document scoping.
  * @param {string} [params.documentId] - Optional document UUID to scope results to a single page.
- * @param {boolean} [params.useKeyword=true] - Whether to include the general lexical match clause.
  * @param {number} params.keywordBoost - Boost for the lexical match clause.
  * @param {number} params.dateBoost - Boost for the grouped date variant clauses.
  * @param {number} params.semanticBoost - Boost for the neural clause.
@@ -271,7 +332,6 @@ function buildHybridQuery({
     shouldClauses,
     safePageNumber,
     documentId,
-    useKeyword = true,
     keywordBoost,
     dateBoost,
     semanticBoost
@@ -290,8 +350,8 @@ function buildHybridQuery({
         );
     }
 
-    // Boosted lexical match clause — only included when useKeyword is true.
-    if (useKeyword && matchClause?.match?.chunk_text) {
+    // Boosted lexical match clause.
+    if (matchClause?.match?.chunk_text) {
         queryJson.query.bool.should.push({
             match: {
                 chunk_text: {
@@ -303,7 +363,6 @@ function buildHybridQuery({
     }
 
     // Boosted date variant clauses, grouped so they share a single boost weight.
-    // Included regardless of useKeyword when date phrases were extracted.
     if (matchPhraseClauses.length > 0) {
         queryJson.query.bool.should.push({
             bool: {
@@ -316,11 +375,13 @@ function buildHybridQuery({
 
     // Boosted neural clause — only when the keyword is non-empty.
     if (keyword.trim().length > 0) {
+        const neuralFilter = buildNeuralFilter({ caseReferenceNumber, documentId, safePageNumber });
         queryJson.query.bool.should.push({
             neural: {
                 embedding: {
                     query_text: keyword,
                     k: DEFAULT_SEMANTIC_K,
+                    filter: neuralFilter,
                     boost: semanticBoost
                 }
             }
@@ -414,7 +475,7 @@ function logQueryMetrics({
  * | true       | false       | false                | keyword only            |
  * | true       | false       | true                 | keyword + dates         |
  * | false      | true        | false                | semantic only           |
- * | false      | true        | true                 | semantic + dates        |
+ * | false      | true        | true                 | semantic + dates        | ← bool(neural + dates)
  * | true       | true        | false                | hybrid                  |
  * | true       | true        | true                 | hybrid + dates          |
  *
@@ -476,34 +537,34 @@ function buildQueryJson({
 
     const { safePageNumber, safeItemsPerPage } = normalisePagination(pageNumber, itemsPerPage);
 
+    const matchPhraseClauses = shouldClauses.filter((c) => Object.hasOwn(c, 'match_phrase'));
+
     let queryJson;
     if (useKeyword && !useSemantic) {
-        // Pure lexical: keyword (with or without date expansion).
+        // Pure lexical: keyword with or without date expansion.
         queryJson = buildKeywordQuery({
             caseReferenceNumber,
-            shouldClauses,
+            shouldClauses, // date match_phrase clauses will be included here when enableDateExtraction is on.
             safePageNumber,
             documentId
         });
-    } else if (!useKeyword && useSemantic && !enableDateExtraction) {
-        // Pure neural: no lexical matching, no date phrases.
+    } else if (!useKeyword && useSemantic) {
+        // Pure semantic: neural only, with date phrases added when enableDateExtraction is on.
         queryJson = buildSemanticQuery({
             keyword,
             caseReferenceNumber,
             safePageNumber,
-            documentId
+            documentId,
+            matchPhraseClauses
         });
     } else {
-        // Hybrid cases (bool query with neural + optional lexical + optional date phrases):
-        //   useKeyword && useSemantic               → full hybrid
-        //   !useKeyword && useSemantic && dates      → date phrases + neural only
+        // Hybrid: keyword + semantic, with date phrases when enableDateExtraction is on.
         queryJson = buildHybridQuery({
             keyword,
             caseReferenceNumber,
             shouldClauses,
             safePageNumber,
             documentId,
-            useKeyword,
             keywordBoost,
             dateBoost,
             semanticBoost

--- a/api/DAL/utils/buildQueryJson/index.js
+++ b/api/DAL/utils/buildQueryJson/index.js
@@ -25,7 +25,7 @@ function normalisePagination(pageNumber, itemsPerPage) {
 }
 
 /**
- * Assembles the semantic (neural) query, applying optional document scoping.ould clauses
+ * Assembles the semantic (neural) query, applying optional document-scoping should clauses
  *
  * The query:
  * - Filters by an exact `case_ref` using a `term` query.
@@ -51,7 +51,7 @@ function normalisePagination(pageNumber, itemsPerPage) {
  * @param {number} params.pageNumber - The current page number (1-based).
  * @param {number} params.itemsPerPage - Number of results to return per page.
  * @param {object} [params.logger] - Optional structured logger instance.
- * @param {string} [params.searchType='keyword-dates'] - Search mode. One of SEARCH_TYPES.KEYWORD, SEARCH_TYPES.KEYWORD_DATES, SEARCH_TYPES.SEMANTIC, SEARCH_TYPES.HYBRID, or SEARCH_TYPES.HYBRID_DATES.
+ * @param {string} [params.searchType='hybrid-dates'] - Search mode. One of SEARCH_TYPES.KEYWORD, SEARCH_TYPES.KEYWORD_DATES, SEARCH_TYPES.SEMANTIC, SEARCH_TYPES.HYBRID, or SEARCH_TYPES.HYBRID_DATES.
  * @param {boolean} [params.includePagination=true] - Whether to include pagination fields in the query.
  * @param {number} [params.keywordBoost] - Boost multiplier for the lexical sub-query in hybrid mode.
  * @param {number} [params.dateBoost] - Boost multiplier for date variant clauses in hybrid mode.

--- a/api/DAL/utils/buildQueryJson/index.js
+++ b/api/DAL/utils/buildQueryJson/index.js
@@ -1,5 +1,6 @@
 import SEARCH_TYPES from '../../../search/constants/searchTypes.js';
 import logQueryMetrics from '../logQueryMetrics/index.js';
+import { DEFAULT_SEARCH_TYPE } from '../../../search/constants/searchTypes.js';
 import { queryTypeBuilders } from './queryTypeBuilders.js';
 
 /**
@@ -51,7 +52,7 @@ function normalisePagination(pageNumber, itemsPerPage) {
  * @param {number} params.pageNumber - The current page number (1-based).
  * @param {number} params.itemsPerPage - Number of results to return per page.
  * @param {object} [params.logger] - Optional structured logger instance.
- * @param {string} [params.searchType='hybrid-dates'] - Search mode. One of SEARCH_TYPES.KEYWORD, SEARCH_TYPES.KEYWORD_DATES, SEARCH_TYPES.SEMANTIC, SEARCH_TYPES.HYBRID, or SEARCH_TYPES.HYBRID_DATES.
+ * @param {string} [params.searchType=DEFAULT_SEARCH_TYPE] - Search mode. One of SEARCH_TYPES.KEYWORD, SEARCH_TYPES.KEYWORD_DATES, SEARCH_TYPES.SEMANTIC, SEARCH_TYPES.HYBRID, or SEARCH_TYPES.HYBRID_DATES.
  * @param {boolean} [params.includePagination=true] - Whether to include pagination fields in the query.
  * @param {number} [params.keywordBoost] - Boost multiplier for the lexical sub-query in hybrid mode.
  * @param {number} [params.dateBoost] - Boost multiplier for date variant clauses in hybrid mode.
@@ -66,7 +67,7 @@ function buildQueryJson({
     itemsPerPage,
     options: {
         logger,
-        searchType = SEARCH_TYPES.KEYWORD_DATES,
+        searchType = DEFAULT_SEARCH_TYPE,
         includePagination = true,
         documentId,
         keywordBoost,

--- a/api/DAL/utils/buildQueryJson/index.js
+++ b/api/DAL/utils/buildQueryJson/index.js
@@ -1,7 +1,6 @@
-import SEARCH_TYPES from '../../../search/constants/searchTypes.js';
+import SEARCH_TYPES, { DEFAULT_SEARCH_TYPE } from '../../../search/constants/searchTypes.js';
 import logQueryMetrics from '../logQueryMetrics/index.js';
-import { DEFAULT_SEARCH_TYPE } from '../../../search/constants/searchTypes.js';
-import { queryTypeBuilders } from './queryTypeBuilders.js';
+import { createQueryTypeBuilders, resolveQueryDslConfig } from './queryTypeBuilders.js';
 
 /**
  * Normalises raw pageNumber and itemsPerPage inputs to safe integer values.
@@ -54,9 +53,7 @@ function normalisePagination(pageNumber, itemsPerPage) {
  * @param {object} [params.logger] - Optional structured logger instance.
  * @param {string} [params.searchType=DEFAULT_SEARCH_TYPE] - Search mode. One of SEARCH_TYPES.KEYWORD, SEARCH_TYPES.KEYWORD_DATES, SEARCH_TYPES.SEMANTIC, SEARCH_TYPES.HYBRID, or SEARCH_TYPES.HYBRID_DATES.
  * @param {boolean} [params.includePagination=true] - Whether to include pagination fields in the query.
- * @param {number} [params.keywordBoost] - Boost multiplier for the lexical sub-query in hybrid mode.
- * @param {number} [params.dateBoost] - Boost multiplier for date variant clauses in hybrid mode.
- * @param {number} [params.semanticBoost] - Boost multiplier for the neural sub-query in hybrid mode.
+ * @param {object} [params.queryDslConfig] - Optional tuning overrides for semantic thresholds, ANN k, and default boosts.
  * @param {string} [params.documentId] - Document UUID to scope results to a single document and page.
  * @returns {object} OpenSearch query DSL JSON object.
  */
@@ -70,12 +67,13 @@ function buildQueryJson({
         searchType = DEFAULT_SEARCH_TYPE,
         includePagination = true,
         documentId,
-        keywordBoost,
-        dateBoost,
-        semanticBoost
+        queryDslConfig
     } = {}
 }) {
     const buildStart = Date.now();
+
+    const effectiveQueryDslConfig = resolveQueryDslConfig(queryDslConfig);
+    const queryTypeBuilders = createQueryTypeBuilders({ queryDslConfig: effectiveQueryDslConfig });
 
     // dispatch to the appropriate mode-specific builder. Each builder handles
     // its own date preprocessing (keyword and hybrid extract dates, semantic
@@ -94,7 +92,6 @@ function buildQueryJson({
         caseReferenceNumber,
         safePageNumber,
         documentId,
-        boostConfig: { keywordBoost, dateBoost, semanticBoost },
         logger
     };
 
@@ -127,20 +124,28 @@ function buildQueryJson({
         searchType
     });
 
-    logger?.debug?.({ queryJson }, 'Built query JSON');
-
-    // TEMP logging for verification during development. Remove or replace with appropriate structured logging as needed.
-    console.log(`[BuildQueryJson] Temp log - ${searchType} queryTypeBuilder parameters`, {
+    const queryTypeBuilderParamsLog = {
         keyword,
         caseReferenceNumber,
         safePageNumber,
         documentId,
-        boostConfig: { keywordBoost, dateBoost, semanticBoost }
-    });
-    // TEMP logging for verification during development. Remove or replace with appropriate structured logging as needed.
-    console.log(
-        `[BuildQueryJson] Temp log - ${searchType} queryTypeBuilder output`,
-        JSON.stringify(queryJson, null, 4)
+        effectiveQueryDslConfig
+    };
+    const prettyJsonEnabled = process.env.APP_LOG_PRETTY_JSON === 'true';
+    const paramsPrettyJson = prettyJsonEnabled
+        ? `\n${JSON.stringify(queryTypeBuilderParamsLog, null, 2)}`
+        : '';
+    const outputPrettyJson = prettyJsonEnabled ? `\n${JSON.stringify(queryJson, null, 2)}` : '';
+
+    logger?.debug?.({ queryJson }, 'Built query JSON');
+
+    logger?.debug?.(
+        queryTypeBuilderParamsLog,
+        `[BuildQueryJson] ${searchType} queryTypeBuilder parameters${paramsPrettyJson}`
+    );
+    logger?.debug?.(
+        { queryJson },
+        `[BuildQueryJson] ${searchType} queryTypeBuilder output${outputPrettyJson}`
     );
 
     return queryJson;

--- a/api/DAL/utils/buildQueryJson/index.js
+++ b/api/DAL/utils/buildQueryJson/index.js
@@ -57,6 +57,7 @@ function createNeuralQuery({ keyword, caseReferenceNumber }) {
 
 /**
  * Creates the hybrid query shell scoped to the case reference.
+ * Used when at least one of useKeyword or useSemantic is true alongside the other.
  *
  * @param {string} caseReferenceNumber - Case reference filter value.
  * @returns {object} Hybrid query DSL object.
@@ -245,8 +246,12 @@ function buildSemanticQuery({ keyword, caseReferenceNumber, safePageNumber, docu
 }
 
 /**
- * Assembles the hybrid (bool + neural) query, combining boosted lexical, date, and neural
+ * Assembles the hybrid query, combining any combination of boosted lexical, date, and neural
  * should clauses with optional document scoping.
+ *
+ * Covers three cases driven by the flags:
+ *   - useKeyword + useSemantic  → full hybrid (lexical + dates + neural)
+ *   - !useKeyword + useSemantic + dates → dates only + neural (no general text match)
  *
  * @param {object} params - Hybrid query options.
  * @param {string} params.keyword - Raw search text.
@@ -254,6 +259,7 @@ function buildSemanticQuery({ keyword, caseReferenceNumber, safePageNumber, docu
  * @param {Array<object>} params.shouldClauses - Lexical should clauses from date/text extraction.
  * @param {number} params.safePageNumber - Normalised page number for document scoping.
  * @param {string} [params.documentId] - Optional document UUID to scope results to a single page.
+ * @param {boolean} [params.useKeyword=true] - Whether to include the general lexical match clause.
  * @param {number} params.keywordBoost - Boost for the lexical match clause.
  * @param {number} params.dateBoost - Boost for the grouped date variant clauses.
  * @param {number} params.semanticBoost - Boost for the neural clause.
@@ -265,6 +271,7 @@ function buildHybridQuery({
     shouldClauses,
     safePageNumber,
     documentId,
+    useKeyword = true,
     keywordBoost,
     dateBoost,
     semanticBoost
@@ -283,8 +290,8 @@ function buildHybridQuery({
         );
     }
 
-    // Boosted lexical match clause.
-    if (matchClause?.match?.chunk_text) {
+    // Boosted lexical match clause — only included when useKeyword is true.
+    if (useKeyword && matchClause?.match?.chunk_text) {
         queryJson.query.bool.should.push({
             match: {
                 chunk_text: {
@@ -296,6 +303,7 @@ function buildHybridQuery({
     }
 
     // Boosted date variant clauses, grouped so they share a single boost weight.
+    // Included regardless of useKeyword when date phrases were extracted.
     if (matchPhraseClauses.length > 0) {
         queryJson.query.bool.should.push({
             bool: {
@@ -394,10 +402,23 @@ function logQueryMetrics({
  *
  * The query:
  * - Filters by an exact `case_ref` using a `term` query.
- * - Extracts date phrases from the keyword and adds them as `match_phrase` queries.
- * - Adds remaining keyword text as a `match` query against `chunk_text`.
  * - Applies pagination using `from` and `size`.
- * - Supports keyword, semantic, and hybrid search types.
+ * - Composes results from up to four independently toggled capabilities:
+ *   - **keyword** (`useKeyword`)  — BM25 lexical matching against `chunk_text`.
+ *   - **semantic** (`useSemantic`) — neural vector matching via the `embedding` field.
+ *   - **dates** (`enableDateExtraction`) — date phrase extraction and format-variant expansion.
+ *
+ * Valid combinations:
+ * | useKeyword | useSemantic | enableDateExtraction | Effective mode          |
+ * |------------|-------------|----------------------|-------------------------|
+ * | true       | false       | false                | keyword only            |
+ * | true       | false       | true                 | keyword + dates         |
+ * | false      | true        | false                | semantic only           |
+ * | false      | true        | true                 | semantic + dates        |
+ * | true       | true        | false                | hybrid                  |
+ * | true       | true        | true                 | hybrid + dates          |
+ *
+ * At least one of `useKeyword` or `useSemantic` must be true.
  *
  * @param {object} params - Search parameters.
  * @param {string} params.keyword - Raw search string entered by the user. May contain date phrases and free text.
@@ -405,13 +426,14 @@ function logQueryMetrics({
  * @param {number} params.pageNumber - The current page number (1-based).
  * @param {number} params.itemsPerPage - Number of results to return per page.
  * @param {object} [params.logger] - Optional structured logger instance.
- * @param {'keyword' | 'semantic' | 'hybrid'} [params.searchType='keyword'] - Which search mode to use.
+ * @param {boolean} [params.useKeyword=true] - Enable lexical (BM25) keyword matching.
+ * @param {boolean} [params.useSemantic=false] - Enable neural (vector) semantic matching.
  * @param {boolean} [params.includePagination=true] - Whether to include pagination fields in the query.
- * @param {boolean} [params.enableDateExtraction=true] - Enables date extraction and variant matching.
+ * @param {boolean} [params.enableDateExtraction=true] - Enable date extraction and variant expansion.
  * @param {number} [params.keywordBoost] - Boost multiplier for the lexical sub-query in hybrid mode.
  * @param {number} [params.dateBoost] - Boost multiplier for date variant clauses in hybrid mode.
  * @param {number} [params.semanticBoost] - Boost multiplier for the neural sub-query in hybrid mode.
- * @param {string} [params.documentId] - Document UUID to scope results to a single document and page. When provided, the query is restricted to the matching page within that document.
+ * @param {string} [params.documentId] - Document UUID to scope results to a single document and page.
  * @returns {object} OpenSearch query DSL JSON object.
  */
 function buildQueryJson({
@@ -420,7 +442,8 @@ function buildQueryJson({
     pageNumber,
     itemsPerPage,
     logger,
-    searchType = 'keyword',
+    useKeyword = true,
+    useSemantic = false,
     includePagination = true,
     enableDateExtraction = true,
     keywordBoost = DEFAULT_LEXICAL_BOOST,
@@ -428,45 +451,63 @@ function buildQueryJson({
     semanticBoost = DEFAULT_NEURAL_BOOST,
     documentId
 }) {
+    if (!useKeyword && !useSemantic) {
+        throw new Error('At least one of useKeyword or useSemantic must be enabled');
+    }
+
     const buildStart = Date.now();
 
+    // Build lexical clauses when keyword matching is active, or when semantic + date
+    // extraction is active (date match_phrase clauses are added to the hybrid bool query).
+    const needsLexicalClauses = useKeyword || (useSemantic && enableDateExtraction);
     const {
         shouldClauses,
         phrases,
         phrasesVariants,
         timings: { extractMs, variantMs }
-    } = buildDateAwareShouldClauses({ keyword, enableDateExtraction });
+    } = needsLexicalClauses
+        ? buildDateAwareShouldClauses({ keyword, enableDateExtraction })
+        : {
+              shouldClauses: [],
+              phrases: [],
+              phrasesVariants: [],
+              timings: { extractMs: 0, variantMs: 0 }
+          };
 
     const { safePageNumber, safeItemsPerPage } = normalisePagination(pageNumber, itemsPerPage);
 
     let queryJson;
-    if (searchType === 'keyword') {
+    if (useKeyword && !useSemantic) {
+        // Pure lexical: keyword (with or without date expansion).
         queryJson = buildKeywordQuery({
             caseReferenceNumber,
             shouldClauses,
             safePageNumber,
             documentId
         });
-    } else if (searchType === 'semantic') {
+    } else if (!useKeyword && useSemantic && !enableDateExtraction) {
+        // Pure neural: no lexical matching, no date phrases.
         queryJson = buildSemanticQuery({
             keyword,
             caseReferenceNumber,
             safePageNumber,
             documentId
         });
-    } else if (searchType === 'hybrid') {
+    } else {
+        // Hybrid cases (bool query with neural + optional lexical + optional date phrases):
+        //   useKeyword && useSemantic               → full hybrid
+        //   !useKeyword && useSemantic && dates      → date phrases + neural only
         queryJson = buildHybridQuery({
             keyword,
             caseReferenceNumber,
             shouldClauses,
             safePageNumber,
             documentId,
+            useKeyword,
             keywordBoost,
             dateBoost,
             semanticBoost
         });
-    } else {
-        throw new Error(`Invalid search type: ${searchType}`);
     }
 
     if (includePagination === true) {

--- a/api/DAL/utils/buildQueryJson/index.js
+++ b/api/DAL/utils/buildQueryJson/index.js
@@ -10,33 +10,20 @@ const DEFAULT_LEXICAL_BOOST = 12; // lexical search results to appear most relev
 const DEFAULT_DATE_BOOST = 1; // weightings to be determined
 const DEFAULT_NEURAL_BOOST = 4; // weightings to be determined
 
-// the highlighting features need to use the same query as the search (see bug:CICADS-655),
-// use this intent to set the scope of the query single page or all matching pages
-const QUERY_INTENTS = Object.freeze({
-    SEARCH_RESULTS: 'searchResults',
-    PAGE_CHUNK_MATCHES: 'pageChunkMatches'
-});
-
-/**
- * Determines whether pagination fields should be emitted.
- *
- * @param {'searchResults' | 'pageChunkMatches'} queryIntent - Query purpose.
- * @returns {boolean}
- */
-function shouldApplyPagination(queryIntent) {
-    return queryIntent === QUERY_INTENTS.SEARCH_RESULTS;
-}
-
 /**
  * Creates the lexical query shell scoped to the case reference.
  *
  * @param {string} caseReferenceNumber - Case reference filter value.
- * @returns {Object}
+ * @returns {object} Lexical query DSL object.
  */
-function createLexicalQuery(caseReferenceNumber) {
+function createLexicalQuery({ caseReferenceNumber }) {
     return {
-        bool: {
-            must: [{ term: { case_ref: caseReferenceNumber } }]
+        query: {
+            bool: {
+                must: [{ term: { case_ref: caseReferenceNumber } }],
+                should: [],
+                minimum_should_match: 1
+            }
         }
     };
 }
@@ -44,32 +31,56 @@ function createLexicalQuery(caseReferenceNumber) {
 /**
  * Creates the semantic neural query (scoped to the case reference).
  *
- * @param {Object} params - Semantic query options.
+ * @param {object} params - Semantic query options.
  * @param {string} params.keyword - Raw search text.
  * @param {string} params.caseReferenceNumber - Case reference filter value.
- * @returns {Object}
+ * @returns {object} Semantic query DSL object.
  */
 function createNeuralQuery({ keyword, caseReferenceNumber }) {
     return {
-        neural: {
-            embedding: {
-                query_text: keyword,
-                k: DEFAULT_SEMANTIC_K,
-                filter: {
-                    term: { case_ref: caseReferenceNumber }
+        query: {
+            neural: {
+                embedding: {
+                    query_text: keyword,
+                    k: DEFAULT_SEMANTIC_K,
+                    filter: {
+                        bool: {
+                            must: [{ term: { case_ref: caseReferenceNumber } }]
+                        }
+                    }
                 }
             }
-        }
+        },
+        min_score: keyword.trim().length > 0 ? SEMANTIC_MIN_SCORE : undefined
+    };
+}
+
+/**
+ * Creates the hybrid query shell scoped to the case reference.
+ *
+ * @param {string} caseReferenceNumber - Case reference filter value.
+ * @returns {object} Hybrid query DSL object.
+ */
+function createHybridQuery({ caseReferenceNumber }) {
+    return {
+        query: {
+            bool: {
+                must: [{ term: { case_ref: caseReferenceNumber } }],
+                should: [],
+                minimum_should_match: 1
+            }
+        },
+        min_score: SEMANTIC_MIN_SCORE
     };
 }
 
 /**
  * Builds lexical should clauses and date-processing metrics.
  *
- * @param {Object} params - Date processing options.
+ * @param {object} params - Date processing options.
  * @param {string} params.keyword - Raw search string.
  * @param {boolean} [params.enableDateExtraction=true] - Whether to extract and expand dates.
- * @returns {Object}
+ * @returns {{ shouldClauses: Array<object>, phrases: Array<string>, phrasesVariants: Array<string>, timings: { extractMs: number, variantMs: number } }} Lexical clauses and date-processing metrics.
  */
 function buildDateAwareShouldClauses({ keyword, enableDateExtraction = true }) {
     const extractStart = Date.now();
@@ -135,29 +146,195 @@ function buildDateAwareShouldClauses({ keyword, enableDateExtraction = true }) {
         shouldClauses,
         phrases,
         phrasesVariants,
-        extractStart,
-        extractEnd,
-        variantStart,
-        variantEnd
+        timings: {
+            extractMs: extractEnd - extractStart,
+            variantMs: variantEnd - variantStart
+        }
     };
+}
+
+/**
+ * Normalises raw pageNumber and itemsPerPage inputs to safe integer values.
+ *
+ * @param {number} pageNumber - Raw page number (1-based).
+ * @param {number} itemsPerPage - Raw items-per-page value.
+ * @returns {{ safePageNumber: number, safeItemsPerPage: number }} Normalised pagination values.
+ */
+function normalisePagination(pageNumber, itemsPerPage) {
+    const normalizedPageNumber = Number.parseInt(pageNumber, 10);
+    const normalizedItemsPerPage = Number.parseInt(itemsPerPage, 10);
+    return {
+        safePageNumber:
+            Number.isFinite(normalizedPageNumber) && normalizedPageNumber > 0
+                ? normalizedPageNumber
+                : 1,
+        safeItemsPerPage:
+            Number.isFinite(normalizedItemsPerPage) && normalizedItemsPerPage > 0
+                ? normalizedItemsPerPage
+                : 10
+    };
+}
+
+/**
+ * Assembles the keyword (lexical) query, applying should clauses and optional document scoping.
+ *
+ * @param {object} params - Keyword query options.
+ * @param {string} params.caseReferenceNumber - Case reference filter value.
+ * @param {Array<object>} params.shouldClauses - Lexical should clauses from date/text extraction.
+ * @param {number} params.safePageNumber - Normalised page number for document scoping.
+ * @param {string} [params.documentId] - Optional document UUID to scope results to a single page.
+ * @returns {object} Assembled keyword query DSL object.
+ */
+function buildKeywordQuery({ caseReferenceNumber, shouldClauses, safePageNumber, documentId }) {
+    const queryJson = createLexicalQuery({ caseReferenceNumber });
+
+    queryJson.query.bool.should = shouldClauses;
+    queryJson.query.bool.minimum_should_match = shouldClauses.length > 0 ? 1 : undefined;
+
+    if (documentId) {
+        queryJson.query.bool.must.push(
+            { term: { source_doc_id: documentId } },
+            { term: { page_number: safePageNumber } }
+        );
+    }
+
+    return queryJson;
+}
+
+/**
+ * Assembles the semantic (neural) query, applying optional document scoping and simplifying
+ * the filter DSL where possible.
+ *
+ * @param {object} params - Semantic query options.
+ * @param {string} params.keyword - Raw search text.
+ * @param {string} params.caseReferenceNumber - Case reference filter value.
+ * @param {number} params.safePageNumber - Normalised page number for document scoping.
+ * @param {string} [params.documentId] - Optional document UUID to scope results to a single page.
+ * @returns {object} Assembled semantic query DSL object.
+ */
+function buildSemanticQuery({ keyword, caseReferenceNumber, safePageNumber, documentId }) {
+    const queryJson = createNeuralQuery({ keyword, caseReferenceNumber });
+
+    if (documentId) {
+        queryJson.query.neural.embedding.filter.bool.must.push(
+            { term: { source_doc_id: documentId } },
+            { term: { page_number: safePageNumber } }
+        );
+    }
+
+    // When there is only a single filter must clause and the keyword is non-empty,
+    // simplify the DSL by unwrapping the bool wrapper.
+    if (
+        queryJson.query.neural.embedding.filter.bool.must.length === 1 &&
+        keyword.trim().length !== 0
+    ) {
+        queryJson.query.neural.embedding.filter =
+            queryJson.query.neural.embedding.filter.bool.must[0];
+    }
+
+    // An empty keyword means the neural clause has no query text and would match
+    // everything. Promote the filter to the top-level query and drop the neural
+    // clause and min_score so the query correctly scopes to case_ref only.
+    if (keyword.trim().length === 0) {
+        queryJson.query = queryJson.query.neural.embedding.filter;
+        delete queryJson.query.neural;
+        delete queryJson.min_score;
+    }
+
+    return queryJson;
+}
+
+/**
+ * Assembles the hybrid (bool + neural) query, combining boosted lexical, date, and neural
+ * should clauses with optional document scoping.
+ *
+ * @param {object} params - Hybrid query options.
+ * @param {string} params.keyword - Raw search text.
+ * @param {string} params.caseReferenceNumber - Case reference filter value.
+ * @param {Array<object>} params.shouldClauses - Lexical should clauses from date/text extraction.
+ * @param {number} params.safePageNumber - Normalised page number for document scoping.
+ * @param {string} [params.documentId] - Optional document UUID to scope results to a single page.
+ * @param {number} params.keywordBoost - Boost for the lexical match clause.
+ * @param {number} params.dateBoost - Boost for the grouped date variant clauses.
+ * @param {number} params.semanticBoost - Boost for the neural clause.
+ * @returns {object} Assembled hybrid query DSL object.
+ */
+function buildHybridQuery({
+    keyword,
+    caseReferenceNumber,
+    shouldClauses,
+    safePageNumber,
+    documentId,
+    keywordBoost,
+    dateBoost,
+    semanticBoost
+}) {
+    const queryJson = createHybridQuery({ caseReferenceNumber });
+
+    const matchClause = shouldClauses.find((clause) => Object.hasOwn(clause, 'match'));
+    const matchPhraseClauses = shouldClauses.filter((clause) =>
+        Object.hasOwn(clause, 'match_phrase')
+    );
+
+    if (documentId) {
+        queryJson.query.bool.must.push(
+            { term: { source_doc_id: documentId } },
+            { term: { page_number: safePageNumber } }
+        );
+    }
+
+    // Boosted lexical match clause.
+    if (matchClause?.match?.chunk_text) {
+        queryJson.query.bool.should.push({
+            match: {
+                chunk_text: {
+                    ...matchClause.match.chunk_text,
+                    boost: keywordBoost
+                }
+            }
+        });
+    }
+
+    // Boosted date variant clauses, grouped so they share a single boost weight.
+    if (matchPhraseClauses.length > 0) {
+        queryJson.query.bool.should.push({
+            bool: {
+                should: matchPhraseClauses,
+                minimum_should_match: 1,
+                boost: dateBoost
+            }
+        });
+    }
+
+    // Boosted neural clause — only when the keyword is non-empty.
+    if (keyword.trim().length > 0) {
+        queryJson.query.bool.should.push({
+            neural: {
+                embedding: {
+                    query_text: keyword,
+                    k: DEFAULT_SEMANTIC_K,
+                    boost: semanticBoost
+                }
+            }
+        });
+    }
+
+    return queryJson;
 }
 
 /**
  * Computes and logs query metrics with threshold warnings.
  *
- * @param {Object} params - Logging inputs.
- * @param {Object} params.queryJson - Final query payload.
+ * @param {object} params - Logging inputs.
+ * @param {object} params.queryJson - Final query payload.
  * @param {string} params.keyword - Raw search string.
  * @param {Array<string>} params.phrases - Extracted date phrases.
  * @param {Array<string>} params.phrasesVariants - Expanded phrase variants.
- * @param {Array<Object>} params.shouldClauses - Generated lexical clauses.
- * @param {number} params.startBuild - Build start timestamp.
- * @param {number} params.buildEnd - Build end timestamp.
- * @param {number} params.extractStart - Extraction start timestamp.
- * @param {number} params.extractEnd - Extraction end timestamp.
- * @param {number} params.variantStart - Variant generation start timestamp.
- * @param {number} params.variantEnd - Variant generation end timestamp.
- * @param {Logger} [params.logger] - Optional structured logger.
+ * @param {Array<object>} params.shouldClauses - Generated lexical clauses.
+ * @param {number} params.buildMs - Build duration in ms.
+ * @param {number} params.extractMs - Extraction duration in ms.
+ * @param {number} params.variantMs - Variant generation duration in ms.
+ * @param {object} [params.logger] - Optional structured logger.
  * @param {string} params.caseReferenceNumber - Case reference scope for logs.
  * @returns {void}
  */
@@ -167,31 +344,28 @@ function logQueryMetrics({
     phrases,
     phrasesVariants,
     shouldClauses,
-    startBuild,
-    buildEnd,
-    extractStart,
-    extractEnd,
-    variantStart,
-    variantEnd,
+    buildMs,
+    extractMs,
+    variantMs,
     logger,
     caseReferenceNumber
 }) {
     const metrics = {
         queryHash: crypto.createHash('sha256').update(keyword).digest('hex').slice(0, 8),
         phraseCount: phrases.length,
-        variantCount: phrasesVariants.length,
+        phraseVariantCount: phrasesVariants.length,
         shouldClauseCount: shouldClauses.length,
         payloadSize: JSON.stringify(queryJson).length,
-        extractMs: extractEnd - extractStart,
-        variantMs: variantEnd - variantStart,
-        buildMs: buildEnd - startBuild
+        extractMs,
+        variantMs,
+        buildMs
     };
 
     if (!logger) {
         return;
     }
 
-    logger.info(
+    logger?.info(
         {
             caseReferenceNumber,
             ...metrics
@@ -199,12 +373,15 @@ function logQueryMetrics({
         '[QueryBuilder] Query metrics'
     );
 
-    if (metrics.variantCount > VARIANT_THRESHOLD || metrics.shouldClauseCount > SHOULD_THRESHOLD) {
+    if (
+        metrics.phraseVariantCount > VARIANT_THRESHOLD ||
+        metrics.shouldClauseCount > SHOULD_THRESHOLD
+    ) {
         logger.warn(
             {
                 caseReferenceNumber,
                 queryHash: metrics.queryHash,
-                variantCount: metrics.variantCount,
+                variantCount: metrics.phraseVariantCount,
                 shouldClauseCount: metrics.shouldClauseCount
             },
             '[QueryBuilder] Variant/clause count exceeds safe threshold'
@@ -213,29 +390,29 @@ function logQueryMetrics({
 }
 
 /**
- * Builds an OpenSearch  query JSON object based on the provided search parameters.
+ * Builds an OpenSearch query JSON object based on the provided search parameters.
  *
  * The query:
  * - Filters by an exact `case_ref` using a `term` query.
  * - Extracts date phrases from the keyword and adds them as `match_phrase` queries.
  * - Adds remaining keyword text as a `match` query against `chunk_text`.
  * - Applies pagination using `from` and `size`.
+ * - Supports keyword, semantic, and hybrid search types.
  *
- * @param {Object} params - Search parameters.
+ * @param {object} params - Search parameters.
  * @param {string} params.keyword - Raw search string entered by the user. May contain date phrases and free text.
  * @param {string} params.caseReferenceNumber - Exact case reference number to filter results by.
  * @param {number} params.pageNumber - The current page number (1-based).
  * @param {number} params.itemsPerPage - Number of results to return per page.
- * @param {Logger} [params.logger] - Optional structured logger instance.
+ * @param {object} [params.logger] - Optional structured logger instance.
  * @param {'keyword' | 'semantic' | 'hybrid'} [params.searchType='keyword'] - Which search mode to use.
- * @param {'searchResults' | 'pageChunkMatches'} [params.queryIntent='searchResults'] - Query purpose.
+ * @param {boolean} [params.includePagination=true] - Whether to include pagination fields in the query.
  * @param {boolean} [params.enableDateExtraction=true] - Enables date extraction and variant matching.
  * @param {number} [params.keywordBoost] - Boost multiplier for the lexical sub-query in hybrid mode.
  * @param {number} [params.dateBoost] - Boost multiplier for date variant clauses in hybrid mode.
  * @param {number} [params.semanticBoost] - Boost multiplier for the neural sub-query in hybrid mode.
- * @param {string} [params.documentId] - Document UUID to scope results to a single document. Required when queryIntent is pageChunkMatches.
- *
- * @returns {Object} OpenSearch query DSL JSON object.
+ * @param {string} [params.documentId] - Document UUID to scope results to a single document and page. When provided, the query is restricted to the matching page within that document.
+ * @returns {object} OpenSearch query DSL JSON object.
  */
 function buildQueryJson({
     keyword,
@@ -244,137 +421,62 @@ function buildQueryJson({
     itemsPerPage,
     logger,
     searchType = 'keyword',
-    queryIntent = QUERY_INTENTS.SEARCH_RESULTS,
+    includePagination = true,
     enableDateExtraction = true,
     keywordBoost = DEFAULT_LEXICAL_BOOST,
     dateBoost = DEFAULT_DATE_BOOST,
     semanticBoost = DEFAULT_NEURAL_BOOST,
     documentId
 }) {
-    const startBuild = Date.now();
-    const queryJson = {};
-    const applyPagination = shouldApplyPagination(queryIntent);
-    const normalizedPageNumber = Number.parseInt(pageNumber, 10);
-    const normalizedItemsPerPage = Number.parseInt(itemsPerPage, 10);
-    const safePageNumber =
-        Number.isFinite(normalizedPageNumber) && normalizedPageNumber > 0
-            ? normalizedPageNumber
-            : 1;
-    const safeItemsPerPage =
-        Number.isFinite(normalizedItemsPerPage) && normalizedItemsPerPage > 0
-            ? normalizedItemsPerPage
-            : 10;
-
-    if (applyPagination) {
-        queryJson.from = safeItemsPerPage * (safePageNumber - 1);
-        queryJson.size = safeItemsPerPage;
-    }
-
-    // When the intent is a single-page chunk lookup, scope the query to the specific
-    // document and page. These filters are injected into every query branch below.
-    const pageChunkScopeFilters =
-        queryIntent === QUERY_INTENTS.PAGE_CHUNK_MATCHES && documentId
-            ? [{ term: { source_doc_id: documentId } }, { term: { page_number: safePageNumber } }]
-            : [];
-
-    const lexicalQuery = createLexicalQuery(caseReferenceNumber);
-    if (pageChunkScopeFilters.length > 0) {
-        lexicalQuery.bool.must.push(...pageChunkScopeFilters);
-    }
+    const buildStart = Date.now();
 
     const {
         shouldClauses,
         phrases,
         phrasesVariants,
-        extractStart,
-        extractEnd,
-        variantStart,
-        variantEnd
+        timings: { extractMs, variantMs }
     } = buildDateAwareShouldClauses({ keyword, enableDateExtraction });
 
-    if (shouldClauses.length > 0) {
-        lexicalQuery.bool.should = shouldClauses;
-        lexicalQuery.bool.minimum_should_match = 1;
-    }
+    const { safePageNumber, safeItemsPerPage } = normalisePagination(pageNumber, itemsPerPage);
 
-    const hasKeyword = keyword.trim().length > 0;
-    const runKeywordSearch = searchType === 'keyword' || searchType === 'hybrid';
-    const runSemanticSearch = (searchType === 'semantic' || searchType === 'hybrid') && hasKeyword;
-
-    if (runSemanticSearch) {
-        queryJson.min_score = SEMANTIC_MIN_SCORE;
-    }
-
-    const neuralQuery = createNeuralQuery({
-        keyword,
-        caseReferenceNumber
-    });
-
-    if (pageChunkScopeFilters.length > 0) {
-        neuralQuery.neural.embedding.filter = {
-            bool: {
-                must: [{ term: { case_ref: caseReferenceNumber } }, ...pageChunkScopeFilters]
-            }
-        };
-    }
-
-    // For hybrid mode we build a single bool query that combines lexical and
-    // semantic clauses under should so the query is paginatable via from/size.
-    if (runKeywordSearch && runSemanticSearch) {
-        const lexicalMustClauses = [
-            { term: { case_ref: caseReferenceNumber } },
-            ...pageChunkScopeFilters
-        ];
-        const hybridShouldClauses = [];
-        const dateShouldClauses = shouldClauses.filter((clause) =>
-            Object.hasOwn(clause, 'match_phrase')
-        );
-        const keywordMatchClause = shouldClauses.find((clause) => Object.hasOwn(clause, 'match'));
-
-        if (dateShouldClauses.length > 0) {
-            hybridShouldClauses.push({
-                bool: {
-                    should: dateShouldClauses,
-                    minimum_should_match: 1,
-                    boost: dateBoost
-                }
-            });
-        }
-
-        if (keywordMatchClause?.match?.chunk_text) {
-            hybridShouldClauses.push({
-                match: {
-                    chunk_text: {
-                        ...keywordMatchClause.match.chunk_text,
-                        boost: keywordBoost
-                    }
-                }
-            });
-        }
-
-        hybridShouldClauses.push({
-            neural: {
-                embedding: {
-                    query_text: keyword,
-                    k: DEFAULT_SEMANTIC_K,
-                    boost: semanticBoost
-                }
-            }
+    let queryJson;
+    if (searchType === 'keyword') {
+        queryJson = buildKeywordQuery({
+            caseReferenceNumber,
+            shouldClauses,
+            safePageNumber,
+            documentId
         });
-
-        queryJson.query = {
-            bool: {
-                must: lexicalMustClauses,
-                should: hybridShouldClauses,
-                minimum_should_match: 1
-            }
-        };
-    } else if (runSemanticSearch) {
-        // just a semantic search
-        queryJson.query = neuralQuery;
+    } else if (searchType === 'semantic') {
+        queryJson = buildSemanticQuery({
+            keyword,
+            caseReferenceNumber,
+            safePageNumber,
+            documentId
+        });
+    } else if (searchType === 'hybrid') {
+        queryJson = buildHybridQuery({
+            keyword,
+            caseReferenceNumber,
+            shouldClauses,
+            safePageNumber,
+            documentId,
+            keywordBoost,
+            dateBoost,
+            semanticBoost
+        });
     } else {
-        // just a keyword search
-        queryJson.query = lexicalQuery;
+        throw new Error(`Invalid search type: ${searchType}`);
+    }
+
+    if (includePagination === true) {
+        queryJson.from = safeItemsPerPage * (safePageNumber - 1);
+        queryJson.size = safeItemsPerPage;
+    }
+
+    if (queryJson?.query?.bool?.should?.length === 0) {
+        delete queryJson.query.bool.should;
+        delete queryJson.query.bool.minimum_should_match;
     }
 
     const buildEnd = Date.now();
@@ -384,17 +486,13 @@ function buildQueryJson({
         phrases,
         phrasesVariants,
         shouldClauses,
-        startBuild,
-        buildEnd,
-        extractStart,
-        extractEnd,
-        variantStart,
-        variantEnd,
+        buildMs: buildEnd - buildStart,
+        extractMs,
+        variantMs,
         logger,
         caseReferenceNumber
     });
 
-    console.log(JSON.stringify(queryJson, null, 2));
     return queryJson;
 }
 

--- a/api/DAL/utils/buildQueryJson/index.js
+++ b/api/DAL/utils/buildQueryJson/index.js
@@ -1,6 +1,9 @@
 import SEARCH_TYPES, { DEFAULT_SEARCH_TYPE } from '../../../search/constants/searchTypes.js';
 import logQueryMetrics from '../logQueryMetrics/index.js';
-import { createQueryTypeBuilders } from './queryTypeBuilders.js';
+import {
+    createQueryTypeBuilders,
+    queryTypeBuilders as defaultQueryTypeBuilders
+} from './queryTypeBuilders.js';
 
 /**
  * Normalises raw pageNumber and itemsPerPage inputs to safe integer values.
@@ -72,7 +75,11 @@ function buildQueryJson({
 }) {
     const buildStart = Date.now();
 
-    const queryTypeBuilders = createQueryTypeBuilders({ queryDslConfig });
+    // Re-use the module-level default builder map when no config overrides are
+    // provided — avoids rebuilding the map and re-merging config on every request.
+    const queryTypeBuilders = queryDslConfig
+        ? createQueryTypeBuilders({ queryDslConfig })
+        : defaultQueryTypeBuilders;
 
     // dispatch to the appropriate mode-specific builder. Each builder handles
     // its own date preprocessing (keyword and hybrid extract dates, semantic

--- a/api/DAL/utils/buildQueryJson/queryTypeBuilders.js
+++ b/api/DAL/utils/buildQueryJson/queryTypeBuilders.js
@@ -270,7 +270,7 @@ function buildKeywordQuery({ caseReferenceNumber, shouldClauses, safePageNumber,
  * @param {Array<object>} [params.matchPhraseClauses=[]] - Date match_phrase clauses to include alongside the neural clause.
  * @returns {object} Assembled semantic (or semantic + dates) query DSL object.
  */
-function buildSemanticQuery({
+export function buildSemanticQuery({
     keyword,
     caseReferenceNumber,
     safePageNumber,
@@ -335,16 +335,6 @@ function buildSemanticQuery({
             { term: { source_doc_id: documentId } },
             { term: { page_number: safePageNumber } }
         );
-    }
-
-    // When there is only a single filter clause and the keyword is non-empty,
-    // simplify the DSL by unwrapping the bool wrapper.
-    if (
-        queryJson.query.neural.embedding.filter?.bool?.filter?.length === 1 &&
-        keyword.trim().length !== 0
-    ) {
-        queryJson.query.neural.embedding.filter =
-            queryJson.query.neural.embedding.filter.bool.filter[0];
     }
 
     // An empty keyword means the neural clause has no query text and would match

--- a/api/DAL/utils/buildQueryJson/queryTypeBuilders.js
+++ b/api/DAL/utils/buildQueryJson/queryTypeBuilders.js
@@ -286,7 +286,7 @@ export function buildSemanticQuery({
     safePageNumber,
     documentId,
     matchPhraseClauses = [],
-    queryDslConfig
+    queryDslConfig = DEFAULT_QUERY_DSL_CONFIG
 }) {
     const { semanticK, semanticMinScore } = queryDslConfig;
 
@@ -381,7 +381,7 @@ function buildHybridQuery({
     shouldClauses,
     safePageNumber,
     documentId,
-    queryDslConfig
+    queryDslConfig = DEFAULT_QUERY_DSL_CONFIG
 }) {
     const { semanticK, semanticMinScore, lexicalBoost, dateBoost, neuralBoost } = queryDslConfig;
 

--- a/api/DAL/utils/buildQueryJson/queryTypeBuilders.js
+++ b/api/DAL/utils/buildQueryJson/queryTypeBuilders.js
@@ -56,7 +56,7 @@ export function createLexicalQuery({ caseReferenceNumber }) {
     return {
         query: {
             bool: {
-                must: [{ term: { case_ref: caseReferenceNumber } }],
+                filter: [{ term: { case_ref: caseReferenceNumber } }],
                 should: [],
                 minimum_should_match: 1
             }
@@ -85,11 +85,7 @@ export function createNeuralQuery({
                 embedding: {
                     query_text: keyword,
                     k: semanticK,
-                    filter: {
-                        bool: {
-                            must: [{ term: { case_ref: caseReferenceNumber } }]
-                        }
-                    }
+                    filter: { term: { case_ref: caseReferenceNumber } }
                 }
             }
         },
@@ -113,7 +109,7 @@ export function createHybridQuery({
     return {
         query: {
             bool: {
-                must: [{ term: { case_ref: caseReferenceNumber } }],
+                filter: [{ term: { case_ref: caseReferenceNumber } }],
                 should: [],
                 minimum_should_match: 1
             }
@@ -252,7 +248,7 @@ function buildKeywordQuery({ caseReferenceNumber, shouldClauses, safePageNumber,
     queryJson.query.bool.minimum_should_match = shouldClauses.length > 0 ? 1 : undefined;
 
     if (documentId) {
-        queryJson.query.bool.must.push(
+        queryJson.query.bool.filter.push(
             { term: { source_doc_id: documentId } },
             { term: { page_number: safePageNumber } }
         );
@@ -291,7 +287,7 @@ function buildSemanticQuery({
         const queryJson = createHybridQuery({ caseReferenceNumber, semanticMinScore });
 
         if (documentId) {
-            queryJson.query.bool.must.push(
+            queryJson.query.bool.filter.push(
                 { term: { source_doc_id: documentId } },
                 { term: { page_number: safePageNumber } }
             );
@@ -327,6 +323,14 @@ function buildSemanticQuery({
     });
 
     if (documentId) {
+        // Convert filter from single term to bool.must array for document scoping
+        if (!Array.isArray(queryJson.query.neural.embedding.filter)) {
+            queryJson.query.neural.embedding.filter = {
+                bool: {
+                    must: [queryJson.query.neural.embedding.filter]
+                }
+            };
+        }
         queryJson.query.neural.embedding.filter.bool.must.push(
             { term: { source_doc_id: documentId } },
             { term: { page_number: safePageNumber } }
@@ -336,7 +340,7 @@ function buildSemanticQuery({
     // When there is only a single filter must clause and the keyword is non-empty,
     // simplify the DSL by unwrapping the bool wrapper.
     if (
-        queryJson.query.neural.embedding.filter.bool.must.length === 1 &&
+        queryJson.query.neural.embedding.filter?.bool?.must?.length === 1 &&
         keyword.trim().length !== 0
     ) {
         queryJson.query.neural.embedding.filter =
@@ -395,7 +399,7 @@ function buildHybridQuery({
     );
 
     if (documentId) {
-        queryJson.query.bool.must.push(
+        queryJson.query.bool.filter.push(
             { term: { source_doc_id: documentId } },
             { term: { page_number: safePageNumber } }
         );
@@ -442,6 +446,15 @@ function buildHybridQuery({
     return queryJson;
 }
 
+/**
+ * Creates a map of search-type keys to query-builder functions.
+ *
+ * Each builder accepts a params object and returns a `{ queryJson, phrases, phrasesVariants, shouldClauses, extractMs, variantMs }` result.
+ *
+ * @param {object} [params={}] - Options.
+ * @param {Partial<typeof DEFAULT_QUERY_DSL_CONFIG>} [params.queryDslConfig={}] - Optional tuning overrides merged with defaults.
+ * @returns {Record<string, Function>} Map of SEARCH_TYPES values to builder functions.
+ */
 export function createQueryTypeBuilders({ queryDslConfig = {} } = {}) {
     const resolvedQueryDslConfig = resolveQueryDslConfig(queryDslConfig);
 

--- a/api/DAL/utils/buildQueryJson/queryTypeBuilders.js
+++ b/api/DAL/utils/buildQueryJson/queryTypeBuilders.js
@@ -38,9 +38,14 @@ export const DEFAULT_QUERY_DSL_CONFIG = Object.freeze({
  * @returns {typeof DEFAULT_QUERY_DSL_CONFIG} Effective query DSL configuration.
  */
 export function resolveQueryDslConfig(overrides = {}) {
+    // Filter out undefined values so they don't override defaults with undefined.
+    // This allows partial overrides like { semanticK: undefined } to fall back to defaults.
+    const filteredOverrides = Object.fromEntries(
+        Object.entries(overrides).filter(([, value]) => value !== undefined)
+    );
     return {
         ...DEFAULT_QUERY_DSL_CONFIG,
-        ...overrides
+        ...filteredOverrides
     };
 }
 

--- a/api/DAL/utils/buildQueryJson/queryTypeBuilders.js
+++ b/api/DAL/utils/buildQueryJson/queryTypeBuilders.js
@@ -66,7 +66,17 @@ export function createLexicalQuery({ caseReferenceNumber }) {
 
 /**
  * Creates the neural (vector) query shell scoped to the case reference.
- * The caller may extend `query.neural.embedding.filter.bool.filter` with additional term filters.
+ *
+ * The `filter` field is initialised as a single `{ term: { case_ref } }` object, **not**
+ * a `bool.filter` array. Callers that need to add further term filters (e.g. document
+ * scoping) must first promote it to a `bool.filter` wrapper:
+ *
+ * ```js
+ * queryJson.query.neural.embedding.filter = {
+ *     bool: { filter: [queryJson.query.neural.embedding.filter] }
+ * };
+ * queryJson.query.neural.embedding.filter.bool.filter.push({ term: { ... } });
+ * ```
  *
  * @param {object} params - Query shell options.
  * @param {string} params.keyword - Raw search text used as the neural query text.

--- a/api/DAL/utils/buildQueryJson/queryTypeBuilders.js
+++ b/api/DAL/utils/buildQueryJson/queryTypeBuilders.js
@@ -444,6 +444,13 @@ function buildHybridQuery({
         });
     }
 
+    // When there are no scoring clauses, the query becomes filter-only and scores 0.
+    // Remove min_score in this case to avoid filtering out all results, matching the
+    // fallback behavior used by buildSemanticQuery for empty keywords.
+    if (queryJson.query.bool.should.length === 0) {
+        delete queryJson.min_score;
+    }
+
     return queryJson;
 }
 

--- a/api/DAL/utils/buildQueryJson/queryTypeBuilders.js
+++ b/api/DAL/utils/buildQueryJson/queryTypeBuilders.js
@@ -16,12 +16,12 @@ import extractDatesFromSearchString from '../extractDatesFromSearchString/index.
 import generateDateFormatVariants from '../generateDateFormatVariants/index.js';
 
 /** @type {number} Minimum neural score — needs tuning or replaced with a low K value. */
-const SEMANTIC_MIN_SCORE = 0.1;
+const SEMANTIC_MIN_SCORE = 0.55;
 
 /** @type {number} Default number of nearest-neighbour candidates for neural queries. */
-const DEFAULT_SEMANTIC_K = 5;
+const DEFAULT_SEMANTIC_K = 15;
 
-const DEFAULT_LEXICAL_BOOST = 12;
+const DEFAULT_LEXICAL_BOOST = 20;
 const DEFAULT_DATE_BOOST = 1;
 const DEFAULT_NEURAL_BOOST = 4;
 

--- a/api/DAL/utils/buildQueryJson/queryTypeBuilders.js
+++ b/api/DAL/utils/buildQueryJson/queryTypeBuilders.js
@@ -66,7 +66,7 @@ export function createLexicalQuery({ caseReferenceNumber }) {
 
 /**
  * Creates the neural (vector) query shell scoped to the case reference.
- * The caller may extend `query.neural.embedding.filter.bool.must` with additional term filters.
+ * The caller may extend `query.neural.embedding.filter.bool.filter` with additional term filters.
  *
  * @param {object} params - Query shell options.
  * @param {string} params.keyword - Raw search text used as the neural query text.
@@ -125,23 +125,23 @@ export function createHybridQuery({
 /**
  * Builds the neural filter object that pre-scopes the ANN search to the correct case
  * (and optionally document page) so OpenSearch does not retrieve k candidates from
- * other cases before the outer bool.must filters them out.
+ * other cases before the outer bool.filter filters them out.
  *
  * @param {object} params - Filter parameters.
  * @param {string} params.caseReferenceNumber - Case reference filter value.
  * @param {string} [params.documentId] - Optional document UUID for page-level scoping.
  * @param {number} params.safePageNumber - Normalised page number for document scoping.
- * @returns {object} A single term clause or a bool.must wrapper.
+ * @returns {object} A single term clause or a bool.filter wrapper.
  */
 export function buildNeuralFilter({ caseReferenceNumber, documentId, safePageNumber }) {
-    const must = [{ term: { case_ref: caseReferenceNumber } }];
+    const filters = [{ term: { case_ref: caseReferenceNumber } }];
     if (documentId) {
-        must.push(
+        filters.push(
             { term: { source_doc_id: documentId } },
             { term: { page_number: safePageNumber } }
         );
     }
-    return must.length === 1 ? must[0] : { bool: { must } };
+    return filters.length === 1 ? filters[0] : { bool: { filter: filters } };
 }
 
 // ---------------------------------------------------------------------------
@@ -323,28 +323,28 @@ function buildSemanticQuery({
     });
 
     if (documentId) {
-        // Convert filter from single term to bool.must array for document scoping
+        // Convert filter from single term to bool.filter array for document scoping
         if (!Array.isArray(queryJson.query.neural.embedding.filter)) {
             queryJson.query.neural.embedding.filter = {
                 bool: {
-                    must: [queryJson.query.neural.embedding.filter]
+                    filter: [queryJson.query.neural.embedding.filter]
                 }
             };
         }
-        queryJson.query.neural.embedding.filter.bool.must.push(
+        queryJson.query.neural.embedding.filter.bool.filter.push(
             { term: { source_doc_id: documentId } },
             { term: { page_number: safePageNumber } }
         );
     }
 
-    // When there is only a single filter must clause and the keyword is non-empty,
+    // When there is only a single filter clause and the keyword is non-empty,
     // simplify the DSL by unwrapping the bool wrapper.
     if (
-        queryJson.query.neural.embedding.filter?.bool?.must?.length === 1 &&
+        queryJson.query.neural.embedding.filter?.bool?.filter?.length === 1 &&
         keyword.trim().length !== 0
     ) {
         queryJson.query.neural.embedding.filter =
-            queryJson.query.neural.embedding.filter.bool.must[0];
+            queryJson.query.neural.embedding.filter.bool.filter[0];
     }
 
     // An empty keyword means the neural clause has no query text and would match
@@ -370,9 +370,9 @@ function buildSemanticQuery({
  * @param {Array<object>} params.shouldClauses - Lexical should clauses from date/text extraction.
  * @param {number} params.safePageNumber - Normalised page number for document scoping.
  * @param {string} [params.documentId] - Optional document UUID to scope results to a single page.
- * @param {number} params.keywordBoost - Boost for the lexical match clause.
+ * @param {number} params.lexicalBoost - Boost for the lexical match clause.
  * @param {number} params.dateBoost - Boost for the grouped date variant clauses.
- * @param {number} params.semanticBoost - Boost for the neural clause.
+ * @param {number} params.neuralBoost - Boost for the neural clause.
  * @returns {object} Assembled hybrid query DSL object.
  */
 function buildHybridQuery({
@@ -383,13 +383,7 @@ function buildHybridQuery({
     documentId,
     queryDslConfig
 }) {
-    const {
-        semanticK,
-        semanticMinScore,
-        lexicalBoost: keywordBoost,
-        dateBoost,
-        neuralBoost: semanticBoost
-    } = queryDslConfig;
+    const { semanticK, semanticMinScore, lexicalBoost, dateBoost, neuralBoost } = queryDslConfig;
 
     const queryJson = createHybridQuery({ caseReferenceNumber, semanticMinScore });
 
@@ -411,7 +405,7 @@ function buildHybridQuery({
             match: {
                 chunk_text: {
                     ...matchClause.match.chunk_text,
-                    boost: keywordBoost
+                    boost: lexicalBoost
                 }
             }
         });
@@ -437,7 +431,7 @@ function buildHybridQuery({
                     query_text: keyword,
                     k: semanticK,
                     filter: neuralFilter,
-                    boost: semanticBoost
+                    boost: neuralBoost
                 }
             }
         });

--- a/api/DAL/utils/buildQueryJson/queryTypeBuilders.js
+++ b/api/DAL/utils/buildQueryJson/queryTypeBuilders.js
@@ -25,10 +25,6 @@ const DEFAULT_LEXICAL_BOOST = 12;
 const DEFAULT_DATE_BOOST = 1;
 const DEFAULT_NEURAL_BOOST = 4;
 
-// ---------------------------------------------------------------------------
-// Low-level DSL shell factories
-// ---------------------------------------------------------------------------
-
 /**
  * Creates the lexical (BM25) query shell scoped to the case reference.
  * The caller is expected to populate `query.bool.should` with match/match_phrase clauses.

--- a/api/DAL/utils/buildQueryJson/queryTypeBuilders.js
+++ b/api/DAL/utils/buildQueryJson/queryTypeBuilders.js
@@ -15,15 +15,34 @@ import SEARCH_TYPES from '../../../search/constants/searchTypes.js';
 import extractDatesFromSearchString from '../extractDatesFromSearchString/index.js';
 import generateDateFormatVariants from '../generateDateFormatVariants/index.js';
 
-/** @type {number} Minimum neural score — needs tuning or replaced with a low K value. */
-const SEMANTIC_MIN_SCORE = 0.55;
+/**
+ * Default tuning values for hybrid/semantic query construction.
+ *
+ * Tests can override these through buildQueryJson options to avoid coupling
+ * behavioural tests to production tuning constants.
+ */
+export const DEFAULT_QUERY_DSL_CONFIG = Object.freeze({
+    /** @type {number} Minimum neural score — needs tuning or replaced with a low K value. */
+    semanticMinScore: 0.55,
+    /** @type {number} Default number of nearest-neighbour candidates for neural queries. */
+    semanticK: 15,
+    lexicalBoost: 20,
+    dateBoost: 1,
+    neuralBoost: 4
+});
 
-/** @type {number} Default number of nearest-neighbour candidates for neural queries. */
-const DEFAULT_SEMANTIC_K = 15;
-
-const DEFAULT_LEXICAL_BOOST = 20;
-const DEFAULT_DATE_BOOST = 1;
-const DEFAULT_NEURAL_BOOST = 4;
+/**
+ * Resolves an effective query DSL configuration by merging user overrides with defaults.
+ *
+ * @param {Partial<typeof DEFAULT_QUERY_DSL_CONFIG>} [overrides={}] - Optional tuning overrides.
+ * @returns {typeof DEFAULT_QUERY_DSL_CONFIG} Effective query DSL configuration.
+ */
+export function resolveQueryDslConfig(overrides = {}) {
+    return {
+        ...DEFAULT_QUERY_DSL_CONFIG,
+        ...overrides
+    };
+}
 
 /**
  * Creates the lexical (BM25) query shell scoped to the case reference.
@@ -54,13 +73,18 @@ export function createLexicalQuery({ caseReferenceNumber }) {
  * @param {string} params.caseReferenceNumber - Case reference filter value.
  * @returns {object} Neural query DSL shell.
  */
-export function createNeuralQuery({ keyword, caseReferenceNumber }) {
+export function createNeuralQuery({
+    keyword,
+    caseReferenceNumber,
+    semanticK = DEFAULT_QUERY_DSL_CONFIG.semanticK,
+    semanticMinScore = DEFAULT_QUERY_DSL_CONFIG.semanticMinScore
+}) {
     return {
         query: {
             neural: {
                 embedding: {
                     query_text: keyword,
-                    k: DEFAULT_SEMANTIC_K,
+                    k: semanticK,
                     filter: {
                         bool: {
                             must: [{ term: { case_ref: caseReferenceNumber } }]
@@ -69,7 +93,7 @@ export function createNeuralQuery({ keyword, caseReferenceNumber }) {
                 }
             }
         },
-        min_score: keyword.trim().length > 0 ? SEMANTIC_MIN_SCORE : undefined
+        min_score: keyword.trim().length > 0 ? semanticMinScore : undefined
     };
 }
 
@@ -82,7 +106,10 @@ export function createNeuralQuery({ keyword, caseReferenceNumber }) {
  * @param {string} params.caseReferenceNumber - Case reference filter value.
  * @returns {object} Hybrid query DSL shell.
  */
-export function createHybridQuery({ caseReferenceNumber }) {
+export function createHybridQuery({
+    caseReferenceNumber,
+    semanticMinScore = DEFAULT_QUERY_DSL_CONFIG.semanticMinScore
+}) {
     return {
         query: {
             bool: {
@@ -91,7 +118,7 @@ export function createHybridQuery({ caseReferenceNumber }) {
                 minimum_should_match: 1
             }
         },
-        min_score: SEMANTIC_MIN_SCORE
+        min_score: semanticMinScore
     };
 }
 
@@ -252,13 +279,16 @@ function buildSemanticQuery({
     caseReferenceNumber,
     safePageNumber,
     documentId,
-    matchPhraseClauses = []
+    matchPhraseClauses = [],
+    queryDslConfig
 }) {
+    const { semanticK, semanticMinScore } = queryDslConfig;
+
     // When date phrases are present, produce a bool query with the neural clause and
     // date phrase clauses as sibling should branches. A non-empty keyword is implied
     // since dates cannot be extracted from an empty string.
     if (matchPhraseClauses.length > 0) {
-        const queryJson = createHybridQuery({ caseReferenceNumber });
+        const queryJson = createHybridQuery({ caseReferenceNumber, semanticMinScore });
 
         if (documentId) {
             queryJson.query.bool.must.push(
@@ -279,7 +309,7 @@ function buildSemanticQuery({
             neural: {
                 embedding: {
                     query_text: keyword,
-                    k: DEFAULT_SEMANTIC_K,
+                    k: semanticK,
                     filter: neuralFilter
                 }
             }
@@ -289,7 +319,12 @@ function buildSemanticQuery({
     }
 
     // Pure neural: no date phrases (or empty keyword fallback).
-    const queryJson = createNeuralQuery({ keyword, caseReferenceNumber });
+    const queryJson = createNeuralQuery({
+        keyword,
+        caseReferenceNumber,
+        semanticK,
+        semanticMinScore
+    });
 
     if (documentId) {
         queryJson.query.neural.embedding.filter.bool.must.push(
@@ -342,11 +377,17 @@ function buildHybridQuery({
     shouldClauses,
     safePageNumber,
     documentId,
-    keywordBoost,
-    dateBoost,
-    semanticBoost
+    queryDslConfig
 }) {
-    const queryJson = createHybridQuery({ caseReferenceNumber });
+    const {
+        semanticK,
+        semanticMinScore,
+        lexicalBoost: keywordBoost,
+        dateBoost,
+        neuralBoost: semanticBoost
+    } = queryDslConfig;
+
+    const queryJson = createHybridQuery({ caseReferenceNumber, semanticMinScore });
 
     const matchClause = shouldClauses.find((clause) => Object.hasOwn(clause, 'match'));
     const matchPhraseClauses = shouldClauses.filter((clause) =>
@@ -390,7 +431,7 @@ function buildHybridQuery({
             neural: {
                 embedding: {
                     query_text: keyword,
-                    k: DEFAULT_SEMANTIC_K,
+                    k: semanticK,
                     filter: neuralFilter,
                     boost: semanticBoost
                 }
@@ -401,216 +442,211 @@ function buildHybridQuery({
     return queryJson;
 }
 
-export const queryTypeBuilders = {
-    [SEARCH_TYPES.KEYWORD]: ({
-        keyword,
-        caseReferenceNumber,
-        safePageNumber,
-        documentId,
-        logger
-    }) => {
-        logger?.debug?.(
-            { keyword, caseReferenceNumber, safePageNumber, documentId },
-            '[QueryTypeBuilder] Building keyword query'
-        );
-        const { shouldClauses, phrases, phrasesVariants, timings } = buildDateAwareShouldClauses({
-            keyword,
-            enableDateExtraction: false
-        });
-        const queryJson = buildKeywordQuery({
-            caseReferenceNumber,
-            shouldClauses,
-            safePageNumber,
-            documentId
-        });
-        logger?.debug?.({ queryJson }, '[QueryTypeBuilder] keyword query built');
+export function createQueryTypeBuilders({ queryDslConfig = {} } = {}) {
+    const resolvedQueryDslConfig = resolveQueryDslConfig(queryDslConfig);
 
-        return {
-            queryJson,
-            phrases,
-            phrasesVariants,
-            shouldClauses,
-            extractMs: timings.extractMs,
-            variantMs: timings.variantMs
-        };
-    },
-    [SEARCH_TYPES.KEYWORD_DATES]: ({
-        keyword,
-        caseReferenceNumber,
-        safePageNumber,
-        documentId,
-        logger
-    }) => {
-        logger?.debug?.(
-            { keyword, caseReferenceNumber, safePageNumber, documentId },
-            '[QueryTypeBuilder] Building keyword-dates query'
-        );
-        const { shouldClauses, phrases, phrasesVariants, timings } = buildDateAwareShouldClauses({
-            keyword,
-            enableDateExtraction: true
-        });
-        const queryJson = buildKeywordQuery({
-            caseReferenceNumber,
-            shouldClauses,
-            safePageNumber,
-            documentId
-        });
-        logger?.debug?.({ queryJson }, '[QueryTypeBuilder] keyword-dates query built');
-
-        return {
-            queryJson,
-            phrases,
-            phrasesVariants,
-            shouldClauses,
-            extractMs: timings.extractMs,
-            variantMs: timings.variantMs
-        };
-    },
-
-    [SEARCH_TYPES.SEMANTIC]: ({
-        keyword,
-        caseReferenceNumber,
-        safePageNumber,
-        documentId, // ,
-        // enableDateExtraction
-        logger
-    }) => {
-        const phrases = [];
-        const phrasesVariants = [];
-        const matchPhraseClauses = [];
-        const extractMs = 0;
-        const variantMs = 0;
-
-        // if (enableDateExtraction) {
-        //     const {
-        //         shouldClauses,
-        //         phrases: p,
-        //         phrasesVariants: pv,
-        //         timings
-        //     } = buildDateAwareShouldClauses({ keyword, enableDateExtraction });
-        //     phrases = p;
-        //     phrasesVariants = pv;
-        //     matchPhraseClauses = shouldClauses.filter((c) => Object.hasOwn(c, 'match_phrase'));
-        //     extractMs = timings.extractMs;
-        //     variantMs = timings.variantMs;
-        // }
-
-        logger?.debug?.(
-            { keyword, caseReferenceNumber, safePageNumber, documentId },
-            '[QueryTypeBuilder] Building semantic query'
-        );
-        const queryJson = buildSemanticQuery({
+    return {
+        [SEARCH_TYPES.KEYWORD]: ({
             keyword,
             caseReferenceNumber,
             safePageNumber,
             documentId,
-            matchPhraseClauses
-        });
-        logger?.debug?.({ queryJson }, '[QueryTypeBuilder] semantic query built');
+            logger
+        }) => {
+            logger?.debug?.(
+                { keyword, caseReferenceNumber, safePageNumber, documentId },
+                '[QueryTypeBuilder] Building keyword query'
+            );
+            const { shouldClauses, phrases, phrasesVariants, timings } =
+                buildDateAwareShouldClauses({
+                    keyword,
+                    enableDateExtraction: false
+                });
+            const queryJson = buildKeywordQuery({
+                caseReferenceNumber,
+                shouldClauses,
+                safePageNumber,
+                documentId
+            });
+            logger?.debug?.({ queryJson }, '[QueryTypeBuilder] keyword query built');
 
-        return {
-            queryJson,
-            phrases,
-            phrasesVariants,
-            shouldClauses: matchPhraseClauses,
-            extractMs,
-            variantMs
-        };
-    },
+            return {
+                queryJson,
+                phrases,
+                phrasesVariants,
+                shouldClauses,
+                extractMs: timings.extractMs,
+                variantMs: timings.variantMs
+            };
+        },
+        [SEARCH_TYPES.KEYWORD_DATES]: ({
+            keyword,
+            caseReferenceNumber,
+            safePageNumber,
+            documentId,
+            logger
+        }) => {
+            logger?.debug?.(
+                { keyword, caseReferenceNumber, safePageNumber, documentId },
+                '[QueryTypeBuilder] Building keyword-dates query'
+            );
+            const { shouldClauses, phrases, phrasesVariants, timings } =
+                buildDateAwareShouldClauses({
+                    keyword,
+                    enableDateExtraction: true
+                });
+            const queryJson = buildKeywordQuery({
+                caseReferenceNumber,
+                shouldClauses,
+                safePageNumber,
+                documentId
+            });
+            logger?.debug?.({ queryJson }, '[QueryTypeBuilder] keyword-dates query built');
 
-    [SEARCH_TYPES.HYBRID]: ({
-        keyword,
-        caseReferenceNumber,
-        safePageNumber,
-        documentId,
-        boostConfig: {
-            keywordBoost = DEFAULT_LEXICAL_BOOST,
-            dateBoost = DEFAULT_DATE_BOOST,
-            semanticBoost = DEFAULT_NEURAL_BOOST
-        } = {},
-        logger
-    }) => {
-        logger?.debug?.(
-            {
+            return {
+                queryJson,
+                phrases,
+                phrasesVariants,
+                shouldClauses,
+                extractMs: timings.extractMs,
+                variantMs: timings.variantMs
+            };
+        },
+
+        [SEARCH_TYPES.SEMANTIC]: ({
+            keyword,
+            caseReferenceNumber,
+            safePageNumber,
+            documentId, // ,
+            // enableDateExtraction
+            logger
+        }) => {
+            const phrases = [];
+            const phrasesVariants = [];
+            const matchPhraseClauses = [];
+            const extractMs = 0;
+            const variantMs = 0;
+
+            // if (enableDateExtraction) {
+            //     const {
+            //         shouldClauses,
+            //         phrases: p,
+            //         phrasesVariants: pv,
+            //         timings
+            //     } = buildDateAwareShouldClauses({ keyword, enableDateExtraction });
+            //     phrases = p;
+            //     phrasesVariants = pv;
+            //     matchPhraseClauses = shouldClauses.filter((c) => Object.hasOwn(c, 'match_phrase'));
+            //     extractMs = timings.extractMs;
+            //     variantMs = timings.variantMs;
+            // }
+
+            logger?.debug?.(
+                { keyword, caseReferenceNumber, safePageNumber, documentId },
+                '[QueryTypeBuilder] Building semantic query'
+            );
+            const queryJson = buildSemanticQuery({
                 keyword,
                 caseReferenceNumber,
                 safePageNumber,
                 documentId,
-                boostConfig: { keywordBoost, dateBoost, semanticBoost }
-            },
-            '[QueryTypeBuilder] Building hybrid query'
-        );
-        const { shouldClauses, phrases, phrasesVariants, timings } = buildDateAwareShouldClauses({
-            keyword,
-            enableDateExtraction: false
-        });
-        const queryJson = buildHybridQuery({
+                matchPhraseClauses,
+                queryDslConfig: resolvedQueryDslConfig
+            });
+            logger?.debug?.({ queryJson }, '[QueryTypeBuilder] semantic query built');
+
+            return {
+                queryJson,
+                phrases,
+                phrasesVariants,
+                shouldClauses: matchPhraseClauses,
+                extractMs,
+                variantMs
+            };
+        },
+
+        [SEARCH_TYPES.HYBRID]: ({
             keyword,
             caseReferenceNumber,
-            shouldClauses,
             safePageNumber,
             documentId,
-            keywordBoost,
-            dateBoost,
-            semanticBoost
-        });
-        logger?.debug?.({ queryJson }, '[QueryTypeBuilder] hybrid query built');
-
-        return {
-            queryJson,
-            phrases,
-            phrasesVariants,
-            shouldClauses,
-            extractMs: timings.extractMs,
-            variantMs: timings.variantMs
-        };
-    },
-
-    [SEARCH_TYPES.HYBRID_DATES]: ({
-        keyword,
-        caseReferenceNumber,
-        safePageNumber,
-        documentId,
-        boostConfig: {
-            keywordBoost = DEFAULT_LEXICAL_BOOST,
-            dateBoost = DEFAULT_DATE_BOOST,
-            semanticBoost = DEFAULT_NEURAL_BOOST
-        } = {},
-        logger
-    }) => {
-        logger?.debug?.(
-            {
+            logger
+        }) => {
+            logger?.debug?.(
+                {
+                    keyword,
+                    caseReferenceNumber,
+                    safePageNumber,
+                    documentId
+                },
+                '[QueryTypeBuilder] Building hybrid query'
+            );
+            const { shouldClauses, phrases, phrasesVariants, timings } =
+                buildDateAwareShouldClauses({
+                    keyword,
+                    enableDateExtraction: false
+                });
+            const queryJson = buildHybridQuery({
                 keyword,
                 caseReferenceNumber,
+                shouldClauses,
                 safePageNumber,
                 documentId,
-                boostConfig: { keywordBoost, dateBoost, semanticBoost }
-            },
-            '[QueryTypeBuilder] Building hybrid-dates query'
-        );
-        const { shouldClauses, phrases, phrasesVariants, timings } = buildDateAwareShouldClauses({
-            keyword,
-            enableDateExtraction: true
-        });
-        const queryJson = buildHybridQuery({
+                queryDslConfig: resolvedQueryDslConfig
+            });
+            logger?.debug?.({ queryJson }, '[QueryTypeBuilder] hybrid query built');
+
+            return {
+                queryJson,
+                phrases,
+                phrasesVariants,
+                shouldClauses,
+                extractMs: timings.extractMs,
+                variantMs: timings.variantMs
+            };
+        },
+
+        [SEARCH_TYPES.HYBRID_DATES]: ({
             keyword,
             caseReferenceNumber,
-            shouldClauses,
             safePageNumber,
             documentId,
-            keywordBoost,
-            dateBoost,
-            semanticBoost
-        });
-        logger?.debug?.({ queryJson }, '[QueryTypeBuilder] hybrid-dates query built');
+            logger
+        }) => {
+            logger?.debug?.(
+                {
+                    keyword,
+                    caseReferenceNumber,
+                    safePageNumber,
+                    documentId
+                },
+                '[QueryTypeBuilder] Building hybrid-dates query'
+            );
+            const { shouldClauses, phrases, phrasesVariants, timings } =
+                buildDateAwareShouldClauses({
+                    keyword,
+                    enableDateExtraction: true
+                });
+            const queryJson = buildHybridQuery({
+                keyword,
+                caseReferenceNumber,
+                shouldClauses,
+                safePageNumber,
+                documentId,
+                queryDslConfig: resolvedQueryDslConfig
+            });
+            logger?.debug?.({ queryJson }, '[QueryTypeBuilder] hybrid-dates query built');
 
-        return {
-            queryJson,
-            phrases,
-            phrasesVariants,
-            shouldClauses,
-            extractMs: timings.extractMs,
-            variantMs: timings.variantMs
-        };
-    }
-};
+            return {
+                queryJson,
+                phrases,
+                phrasesVariants,
+                shouldClauses,
+                extractMs: timings.extractMs,
+                variantMs: timings.variantMs
+            };
+        }
+    };
+}
+
+export const queryTypeBuilders = createQueryTypeBuilders();

--- a/api/DAL/utils/buildQueryJson/queryTypeBuilders.js
+++ b/api/DAL/utils/buildQueryJson/queryTypeBuilders.js
@@ -333,8 +333,10 @@ export function buildSemanticQuery({
     });
 
     if (documentId) {
-        // Convert filter from single term to bool.filter array for document scoping
-        if (!Array.isArray(queryJson.query.neural.embedding.filter)) {
+        // Promote a bare term filter to a bool.filter wrapper so we can push
+        // additional document-scoping clauses. Skip promotion if it is already
+        // a bool.filter wrapper (avoids double-wrapping on future refactors).
+        if (!queryJson.query.neural.embedding.filter?.bool?.filter) {
             queryJson.query.neural.embedding.filter = {
                 bool: {
                     filter: [queryJson.query.neural.embedding.filter]

--- a/api/DAL/utils/buildQueryJson/queryTypeBuilders.js
+++ b/api/DAL/utils/buildQueryJson/queryTypeBuilders.js
@@ -406,13 +406,17 @@ function buildHybridQuery({
 }
 
 export const queryTypeBuilders = {
-    [SEARCH_TYPES.KEYWORD]: ({ keyword, caseReferenceNumber, safePageNumber, documentId }) => {
-        console.log('Building keyword query with input:', {
-            keyword,
-            caseReferenceNumber,
-            safePageNumber,
-            documentId
-        }); // TEMP logging for verification during development.
+    [SEARCH_TYPES.KEYWORD]: ({
+        keyword,
+        caseReferenceNumber,
+        safePageNumber,
+        documentId,
+        logger
+    }) => {
+        logger?.debug?.(
+            { keyword, caseReferenceNumber, safePageNumber, documentId },
+            '[QueryTypeBuilder] Building keyword query'
+        );
         const { shouldClauses, phrases, phrasesVariants, timings } = buildDateAwareShouldClauses({
             keyword,
             enableDateExtraction: false
@@ -423,6 +427,8 @@ export const queryTypeBuilders = {
             safePageNumber,
             documentId
         });
+        logger?.debug?.({ queryJson }, '[QueryTypeBuilder] keyword query built');
+
         return {
             queryJson,
             phrases,
@@ -436,14 +442,13 @@ export const queryTypeBuilders = {
         keyword,
         caseReferenceNumber,
         safePageNumber,
-        documentId
+        documentId,
+        logger
     }) => {
-        console.log('Building keyword-dates query with input:', {
-            keyword,
-            caseReferenceNumber,
-            safePageNumber,
-            documentId
-        }); // TEMP logging for verification during development.
+        logger?.debug?.(
+            { keyword, caseReferenceNumber, safePageNumber, documentId },
+            '[QueryTypeBuilder] Building keyword-dates query'
+        );
         const { shouldClauses, phrases, phrasesVariants, timings } = buildDateAwareShouldClauses({
             keyword,
             enableDateExtraction: true
@@ -454,6 +459,8 @@ export const queryTypeBuilders = {
             safePageNumber,
             documentId
         });
+        logger?.debug?.({ queryJson }, '[QueryTypeBuilder] keyword-dates query built');
+
         return {
             queryJson,
             phrases,
@@ -468,15 +475,10 @@ export const queryTypeBuilders = {
         keyword,
         caseReferenceNumber,
         safePageNumber,
-        documentId // ,
+        documentId, // ,
         // enableDateExtraction
+        logger
     }) => {
-        console.log('Building semantic query with input:', {
-            keyword,
-            caseReferenceNumber,
-            safePageNumber,
-            documentId
-        }); // TEMP logging for verification during development.
         const phrases = [];
         const phrasesVariants = [];
         const matchPhraseClauses = [];
@@ -497,6 +499,10 @@ export const queryTypeBuilders = {
         //     variantMs = timings.variantMs;
         // }
 
+        logger?.debug?.(
+            { keyword, caseReferenceNumber, safePageNumber, documentId },
+            '[QueryTypeBuilder] Building semantic query'
+        );
         const queryJson = buildSemanticQuery({
             keyword,
             caseReferenceNumber,
@@ -504,6 +510,8 @@ export const queryTypeBuilders = {
             documentId,
             matchPhraseClauses
         });
+        logger?.debug?.({ queryJson }, '[QueryTypeBuilder] semantic query built');
+
         return {
             queryJson,
             phrases,
@@ -523,15 +531,19 @@ export const queryTypeBuilders = {
             keywordBoost = DEFAULT_LEXICAL_BOOST,
             dateBoost = DEFAULT_DATE_BOOST,
             semanticBoost = DEFAULT_NEURAL_BOOST
-        } = {}
+        } = {},
+        logger
     }) => {
-        console.log('Building hybrid query with input:', {
-            keyword,
-            caseReferenceNumber,
-            safePageNumber,
-            documentId,
-            boostConfig: { keywordBoost, dateBoost, semanticBoost }
-        }); // TEMP logging for verification during development.
+        logger?.debug?.(
+            {
+                keyword,
+                caseReferenceNumber,
+                safePageNumber,
+                documentId,
+                boostConfig: { keywordBoost, dateBoost, semanticBoost }
+            },
+            '[QueryTypeBuilder] Building hybrid query'
+        );
         const { shouldClauses, phrases, phrasesVariants, timings } = buildDateAwareShouldClauses({
             keyword,
             enableDateExtraction: false
@@ -546,6 +558,8 @@ export const queryTypeBuilders = {
             dateBoost,
             semanticBoost
         });
+        logger?.debug?.({ queryJson }, '[QueryTypeBuilder] hybrid query built');
+
         return {
             queryJson,
             phrases,
@@ -565,15 +579,19 @@ export const queryTypeBuilders = {
             keywordBoost = DEFAULT_LEXICAL_BOOST,
             dateBoost = DEFAULT_DATE_BOOST,
             semanticBoost = DEFAULT_NEURAL_BOOST
-        } = {}
+        } = {},
+        logger
     }) => {
-        console.log('Building hybrid-dates query with input:', {
-            keyword,
-            caseReferenceNumber,
-            safePageNumber,
-            documentId,
-            boostConfig: { keywordBoost, dateBoost, semanticBoost }
-        }); // TEMP logging for verification during development.
+        logger?.debug?.(
+            {
+                keyword,
+                caseReferenceNumber,
+                safePageNumber,
+                documentId,
+                boostConfig: { keywordBoost, dateBoost, semanticBoost }
+            },
+            '[QueryTypeBuilder] Building hybrid-dates query'
+        );
         const { shouldClauses, phrases, phrasesVariants, timings } = buildDateAwareShouldClauses({
             keyword,
             enableDateExtraction: true
@@ -588,6 +606,8 @@ export const queryTypeBuilders = {
             dateBoost,
             semanticBoost
         });
+        logger?.debug?.({ queryJson }, '[QueryTypeBuilder] hybrid-dates query built');
+
         return {
             queryJson,
             phrases,

--- a/api/DAL/utils/buildQueryJson/queryTypeBuilders.js
+++ b/api/DAL/utils/buildQueryJson/queryTypeBuilders.js
@@ -1,0 +1,600 @@
+/**
+ * @file OpenSearch DSL query shell factories and mode-specific query assemblers.
+ *
+ * The shell factories (`create*Query`) produce bare query envelopes scoped to a case
+ * reference. The assemblers (`build*Query`) fill in the should/must clauses, apply
+ * document scoping, and return a complete query DSL object ready for execution.
+ *
+ * Adding a new query type:
+ * 1. Export a new `create*Query` shell factory from this module.
+ * 2. Export a new `build*Query` assembler that uses it.
+ * 3. Import and wire it up in `index.js`.
+ */
+
+import SEARCH_TYPES from '../../../search/constants/searchTypes.js';
+import extractDatesFromSearchString from '../extractDatesFromSearchString/index.js';
+import generateDateFormatVariants from '../generateDateFormatVariants/index.js';
+
+/** @type {number} Minimum neural score — needs tuning or replaced with a low K value. */
+const SEMANTIC_MIN_SCORE = 0.1;
+
+/** @type {number} Default number of nearest-neighbour candidates for neural queries. */
+const DEFAULT_SEMANTIC_K = 5;
+
+const DEFAULT_LEXICAL_BOOST = 12;
+const DEFAULT_DATE_BOOST = 1;
+const DEFAULT_NEURAL_BOOST = 4;
+
+// ---------------------------------------------------------------------------
+// Low-level DSL shell factories
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates the lexical (BM25) query shell scoped to the case reference.
+ * The caller is expected to populate `query.bool.should` with match/match_phrase clauses.
+ *
+ * @param {object} params - Query shell options.
+ * @param {string} params.caseReferenceNumber - Case reference filter value.
+ * @returns {object} Lexical query DSL shell.
+ */
+export function createLexicalQuery({ caseReferenceNumber }) {
+    return {
+        query: {
+            bool: {
+                must: [{ term: { case_ref: caseReferenceNumber } }],
+                should: [],
+                minimum_should_match: 1
+            }
+        }
+    };
+}
+
+/**
+ * Creates the neural (vector) query shell scoped to the case reference.
+ * The caller may extend `query.neural.embedding.filter.bool.must` with additional term filters.
+ *
+ * @param {object} params - Query shell options.
+ * @param {string} params.keyword - Raw search text used as the neural query text.
+ * @param {string} params.caseReferenceNumber - Case reference filter value.
+ * @returns {object} Neural query DSL shell.
+ */
+export function createNeuralQuery({ keyword, caseReferenceNumber }) {
+    return {
+        query: {
+            neural: {
+                embedding: {
+                    query_text: keyword,
+                    k: DEFAULT_SEMANTIC_K,
+                    filter: {
+                        bool: {
+                            must: [{ term: { case_ref: caseReferenceNumber } }]
+                        }
+                    }
+                }
+            }
+        },
+        min_score: keyword.trim().length > 0 ? SEMANTIC_MIN_SCORE : undefined
+    };
+}
+
+/**
+ * Creates the hybrid query shell scoped to the case reference.
+ * Used when both lexical and neural branches are combined in a single bool query.
+ * The caller populates `query.bool.should` with boosted lexical, date, and neural clauses.
+ *
+ * @param {object} params - Query shell options.
+ * @param {string} params.caseReferenceNumber - Case reference filter value.
+ * @returns {object} Hybrid query DSL shell.
+ */
+export function createHybridQuery({ caseReferenceNumber }) {
+    return {
+        query: {
+            bool: {
+                must: [{ term: { case_ref: caseReferenceNumber } }],
+                should: [],
+                minimum_should_match: 1
+            }
+        },
+        min_score: SEMANTIC_MIN_SCORE
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Neural filter helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds the neural filter object that pre-scopes the ANN search to the correct case
+ * (and optionally document page) so OpenSearch does not retrieve k candidates from
+ * other cases before the outer bool.must filters them out.
+ *
+ * @param {object} params - Filter parameters.
+ * @param {string} params.caseReferenceNumber - Case reference filter value.
+ * @param {string} [params.documentId] - Optional document UUID for page-level scoping.
+ * @param {number} params.safePageNumber - Normalised page number for document scoping.
+ * @returns {object} A single term clause or a bool.must wrapper.
+ */
+export function buildNeuralFilter({ caseReferenceNumber, documentId, safePageNumber }) {
+    const must = [{ term: { case_ref: caseReferenceNumber } }];
+    if (documentId) {
+        must.push(
+            { term: { source_doc_id: documentId } },
+            { term: { page_number: safePageNumber } }
+        );
+    }
+    return must.length === 1 ? must[0] : { bool: { must } };
+}
+
+// ---------------------------------------------------------------------------
+// Shared preprocessing
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds lexical should clauses and date-processing metrics.
+ *
+ * @param {object} params - Date processing options.
+ * @param {string} params.keyword - Raw search string.
+ * @param {boolean} [params.enableDateExtraction=true] - Whether to extract and expand dates.
+ * @returns {{ shouldClauses: Array<object>, phrases: Array<string>, phrasesVariants: Array<string>, timings: { extractMs: number, variantMs: number } }} Lexical clauses and date-processing metrics.
+ */
+export function buildDateAwareShouldClauses({ keyword, enableDateExtraction = true }) {
+    const extractStart = Date.now();
+
+    let phrases = [];
+    let remainingText = keyword;
+    let matchedPatterns = [];
+
+    if (enableDateExtraction) {
+        const extractionResult = extractDatesFromSearchString(keyword);
+        phrases = extractionResult.dates;
+        remainingText = extractionResult.remainingText;
+        matchedPatterns = extractionResult.matchedPatterns;
+    }
+
+    const extractEnd = Date.now();
+
+    const variantStart = Date.now();
+    let phrasesVariants = [];
+
+    if (enableDateExtraction) {
+        // Build variants for each extracted phrase, falling back to the
+        // original phrase if no variants are produced, and then
+        // deduplicate (via the Set) across all phrases.
+        phrasesVariants = Array.from(
+            new Set(
+                phrases.flatMap((phrase, index) => {
+                    const variants = generateDateFormatVariants(phrase, matchedPatterns[index]);
+                    if (!variants || variants.length === 0) {
+                        return [phrase];
+                    }
+                    return variants;
+                })
+            )
+        );
+    }
+
+    const variantEnd = Date.now();
+
+    const shouldClauses = [];
+
+    if (phrasesVariants.length > 0) {
+        phrasesVariants.forEach((phrase) => {
+            shouldClauses.push({
+                match_phrase: {
+                    chunk_text: phrase
+                }
+            });
+        });
+    }
+
+    if (remainingText) {
+        shouldClauses.push({
+            match: {
+                chunk_text: {
+                    query: remainingText
+                }
+            }
+        });
+    }
+
+    return {
+        shouldClauses,
+        phrases,
+        phrasesVariants,
+        timings: {
+            extractMs: extractEnd - extractStart,
+            variantMs: variantEnd - variantStart
+        }
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Mode-specific query assemblers
+// ---------------------------------------------------------------------------
+
+/**
+ * Assembles the keyword (lexical) query, applying should clauses and optional document scoping.
+ *
+ * @param {object} params - Keyword query options.
+ * @param {string} params.caseReferenceNumber - Case reference filter value.
+ * @param {Array<object>} params.shouldClauses - Lexical should clauses from date/text extraction.
+ * @param {number} params.safePageNumber - Normalised page number for document scoping.
+ * @param {string} [params.documentId] - Optional document UUID to scope results to a single page.
+ * @returns {object} Assembled keyword query DSL object.
+ */
+function buildKeywordQuery({ caseReferenceNumber, shouldClauses, safePageNumber, documentId }) {
+    const queryJson = createLexicalQuery({ caseReferenceNumber });
+
+    queryJson.query.bool.should = shouldClauses;
+    queryJson.query.bool.minimum_should_match = shouldClauses.length > 0 ? 1 : undefined;
+
+    if (documentId) {
+        queryJson.query.bool.must.push(
+            { term: { source_doc_id: documentId } },
+            { term: { page_number: safePageNumber } }
+        );
+    }
+
+    return queryJson;
+}
+
+/**
+ * Assembles the semantic (neural) query, applying optional document scoping.
+ * When date match_phrase clauses are supplied, wraps the neural clause in a bool
+ * query alongside the date should clauses (semantic + dates mode).
+ *
+ * @param {object} params - Semantic query options.
+ * @param {string} params.keyword - Raw search text.
+ * @param {string} params.caseReferenceNumber - Case reference filter value.
+ * @param {number} params.safePageNumber - Normalised page number for document scoping.
+ * @param {string} [params.documentId] - Optional document UUID to scope results to a single page.
+ * @param {Array<object>} [params.matchPhraseClauses=[]] - Date match_phrase clauses to include alongside the neural clause.
+ * @returns {object} Assembled semantic (or semantic + dates) query DSL object.
+ */
+function buildSemanticQuery({
+    keyword,
+    caseReferenceNumber,
+    safePageNumber,
+    documentId,
+    matchPhraseClauses = []
+}) {
+    // When date phrases are present, produce a bool query with the neural clause and
+    // date phrase clauses as sibling should branches. A non-empty keyword is implied
+    // since dates cannot be extracted from an empty string.
+    if (matchPhraseClauses.length > 0) {
+        const queryJson = createHybridQuery({ caseReferenceNumber });
+
+        if (documentId) {
+            queryJson.query.bool.must.push(
+                { term: { source_doc_id: documentId } },
+                { term: { page_number: safePageNumber } }
+            );
+        }
+
+        queryJson.query.bool.should.push({
+            bool: {
+                should: matchPhraseClauses,
+                minimum_should_match: 1
+            }
+        });
+
+        const neuralFilter = buildNeuralFilter({ caseReferenceNumber, documentId, safePageNumber });
+        queryJson.query.bool.should.push({
+            neural: {
+                embedding: {
+                    query_text: keyword,
+                    k: DEFAULT_SEMANTIC_K,
+                    filter: neuralFilter
+                }
+            }
+        });
+
+        return queryJson;
+    }
+
+    // Pure neural: no date phrases (or empty keyword fallback).
+    const queryJson = createNeuralQuery({ keyword, caseReferenceNumber });
+
+    if (documentId) {
+        queryJson.query.neural.embedding.filter.bool.must.push(
+            { term: { source_doc_id: documentId } },
+            { term: { page_number: safePageNumber } }
+        );
+    }
+
+    // When there is only a single filter must clause and the keyword is non-empty,
+    // simplify the DSL by unwrapping the bool wrapper.
+    if (
+        queryJson.query.neural.embedding.filter.bool.must.length === 1 &&
+        keyword.trim().length !== 0
+    ) {
+        queryJson.query.neural.embedding.filter =
+            queryJson.query.neural.embedding.filter.bool.must[0];
+    }
+
+    // An empty keyword means the neural clause has no query text and would match
+    // everything. Promote the filter to the top-level query and drop the neural
+    // clause and min_score so the query correctly scopes to case_ref only.
+    if (keyword.trim().length === 0) {
+        queryJson.query = queryJson.query.neural.embedding.filter;
+        delete queryJson.query.neural;
+        delete queryJson.min_score;
+    }
+
+    return queryJson;
+}
+
+/**
+ * Assembles the hybrid query, combining boosted lexical, date, and neural should clauses
+ * with optional document scoping. Always includes both keyword (BM25) and semantic
+ * (neural) branches — date phrase clauses are added when present.
+ *
+ * @param {object} params - Hybrid query options.
+ * @param {string} params.keyword - Raw search text.
+ * @param {string} params.caseReferenceNumber - Case reference filter value.
+ * @param {Array<object>} params.shouldClauses - Lexical should clauses from date/text extraction.
+ * @param {number} params.safePageNumber - Normalised page number for document scoping.
+ * @param {string} [params.documentId] - Optional document UUID to scope results to a single page.
+ * @param {number} params.keywordBoost - Boost for the lexical match clause.
+ * @param {number} params.dateBoost - Boost for the grouped date variant clauses.
+ * @param {number} params.semanticBoost - Boost for the neural clause.
+ * @returns {object} Assembled hybrid query DSL object.
+ */
+function buildHybridQuery({
+    keyword,
+    caseReferenceNumber,
+    shouldClauses,
+    safePageNumber,
+    documentId,
+    keywordBoost,
+    dateBoost,
+    semanticBoost
+}) {
+    const queryJson = createHybridQuery({ caseReferenceNumber });
+
+    const matchClause = shouldClauses.find((clause) => Object.hasOwn(clause, 'match'));
+    const matchPhraseClauses = shouldClauses.filter((clause) =>
+        Object.hasOwn(clause, 'match_phrase')
+    );
+
+    if (documentId) {
+        queryJson.query.bool.must.push(
+            { term: { source_doc_id: documentId } },
+            { term: { page_number: safePageNumber } }
+        );
+    }
+
+    // Boosted lexical match clause.
+    if (matchClause?.match?.chunk_text) {
+        queryJson.query.bool.should.push({
+            match: {
+                chunk_text: {
+                    ...matchClause.match.chunk_text,
+                    boost: keywordBoost
+                }
+            }
+        });
+    }
+
+    // Boosted date variant clauses, grouped so they share a single boost weight.
+    if (matchPhraseClauses.length > 0) {
+        queryJson.query.bool.should.push({
+            bool: {
+                should: matchPhraseClauses,
+                minimum_should_match: 1,
+                boost: dateBoost
+            }
+        });
+    }
+
+    // Boosted neural clause — only when the keyword is non-empty.
+    if (keyword.trim().length > 0) {
+        const neuralFilter = buildNeuralFilter({ caseReferenceNumber, documentId, safePageNumber });
+        queryJson.query.bool.should.push({
+            neural: {
+                embedding: {
+                    query_text: keyword,
+                    k: DEFAULT_SEMANTIC_K,
+                    filter: neuralFilter,
+                    boost: semanticBoost
+                }
+            }
+        });
+    }
+
+    return queryJson;
+}
+
+export const queryTypeBuilders = {
+    [SEARCH_TYPES.KEYWORD]: ({ keyword, caseReferenceNumber, safePageNumber, documentId }) => {
+        console.log('Building keyword query with input:', {
+            keyword,
+            caseReferenceNumber,
+            safePageNumber,
+            documentId
+        }); // TEMP logging for verification during development.
+        const { shouldClauses, phrases, phrasesVariants, timings } = buildDateAwareShouldClauses({
+            keyword,
+            enableDateExtraction: false
+        });
+        const queryJson = buildKeywordQuery({
+            caseReferenceNumber,
+            shouldClauses,
+            safePageNumber,
+            documentId
+        });
+        return {
+            queryJson,
+            phrases,
+            phrasesVariants,
+            shouldClauses,
+            extractMs: timings.extractMs,
+            variantMs: timings.variantMs
+        };
+    },
+    [SEARCH_TYPES.KEYWORD_DATES]: ({
+        keyword,
+        caseReferenceNumber,
+        safePageNumber,
+        documentId
+    }) => {
+        console.log('Building keyword-dates query with input:', {
+            keyword,
+            caseReferenceNumber,
+            safePageNumber,
+            documentId
+        }); // TEMP logging for verification during development.
+        const { shouldClauses, phrases, phrasesVariants, timings } = buildDateAwareShouldClauses({
+            keyword,
+            enableDateExtraction: true
+        });
+        const queryJson = buildKeywordQuery({
+            caseReferenceNumber,
+            shouldClauses,
+            safePageNumber,
+            documentId
+        });
+        return {
+            queryJson,
+            phrases,
+            phrasesVariants,
+            shouldClauses,
+            extractMs: timings.extractMs,
+            variantMs: timings.variantMs
+        };
+    },
+
+    [SEARCH_TYPES.SEMANTIC]: ({
+        keyword,
+        caseReferenceNumber,
+        safePageNumber,
+        documentId // ,
+        // enableDateExtraction
+    }) => {
+        console.log('Building semantic query with input:', {
+            keyword,
+            caseReferenceNumber,
+            safePageNumber,
+            documentId
+        }); // TEMP logging for verification during development.
+        const phrases = [];
+        const phrasesVariants = [];
+        const matchPhraseClauses = [];
+        const extractMs = 0;
+        const variantMs = 0;
+
+        // if (enableDateExtraction) {
+        //     const {
+        //         shouldClauses,
+        //         phrases: p,
+        //         phrasesVariants: pv,
+        //         timings
+        //     } = buildDateAwareShouldClauses({ keyword, enableDateExtraction });
+        //     phrases = p;
+        //     phrasesVariants = pv;
+        //     matchPhraseClauses = shouldClauses.filter((c) => Object.hasOwn(c, 'match_phrase'));
+        //     extractMs = timings.extractMs;
+        //     variantMs = timings.variantMs;
+        // }
+
+        const queryJson = buildSemanticQuery({
+            keyword,
+            caseReferenceNumber,
+            safePageNumber,
+            documentId,
+            matchPhraseClauses
+        });
+        return {
+            queryJson,
+            phrases,
+            phrasesVariants,
+            shouldClauses: matchPhraseClauses,
+            extractMs,
+            variantMs
+        };
+    },
+
+    [SEARCH_TYPES.HYBRID]: ({
+        keyword,
+        caseReferenceNumber,
+        safePageNumber,
+        documentId,
+        boostConfig: {
+            keywordBoost = DEFAULT_LEXICAL_BOOST,
+            dateBoost = DEFAULT_DATE_BOOST,
+            semanticBoost = DEFAULT_NEURAL_BOOST
+        } = {}
+    }) => {
+        console.log('Building hybrid query with input:', {
+            keyword,
+            caseReferenceNumber,
+            safePageNumber,
+            documentId,
+            boostConfig: { keywordBoost, dateBoost, semanticBoost }
+        }); // TEMP logging for verification during development.
+        const { shouldClauses, phrases, phrasesVariants, timings } = buildDateAwareShouldClauses({
+            keyword,
+            enableDateExtraction: false
+        });
+        const queryJson = buildHybridQuery({
+            keyword,
+            caseReferenceNumber,
+            shouldClauses,
+            safePageNumber,
+            documentId,
+            keywordBoost,
+            dateBoost,
+            semanticBoost
+        });
+        return {
+            queryJson,
+            phrases,
+            phrasesVariants,
+            shouldClauses,
+            extractMs: timings.extractMs,
+            variantMs: timings.variantMs
+        };
+    },
+
+    [SEARCH_TYPES.HYBRID_DATES]: ({
+        keyword,
+        caseReferenceNumber,
+        safePageNumber,
+        documentId,
+        boostConfig: {
+            keywordBoost = DEFAULT_LEXICAL_BOOST,
+            dateBoost = DEFAULT_DATE_BOOST,
+            semanticBoost = DEFAULT_NEURAL_BOOST
+        } = {}
+    }) => {
+        console.log('Building hybrid-dates query with input:', {
+            keyword,
+            caseReferenceNumber,
+            safePageNumber,
+            documentId,
+            boostConfig: { keywordBoost, dateBoost, semanticBoost }
+        }); // TEMP logging for verification during development.
+        const { shouldClauses, phrases, phrasesVariants, timings } = buildDateAwareShouldClauses({
+            keyword,
+            enableDateExtraction: true
+        });
+        const queryJson = buildHybridQuery({
+            keyword,
+            caseReferenceNumber,
+            shouldClauses,
+            safePageNumber,
+            documentId,
+            keywordBoost,
+            dateBoost,
+            semanticBoost
+        });
+        return {
+            queryJson,
+            phrases,
+            phrasesVariants,
+            shouldClauses,
+            extractMs: timings.extractMs,
+            variantMs: timings.variantMs
+        };
+    }
+};

--- a/api/DAL/utils/logQueryMetrics/index.js
+++ b/api/DAL/utils/logQueryMetrics/index.js
@@ -1,5 +1,5 @@
 import crypto from 'node:crypto';
-import SEARCH_TYPES from '../../../search/constants/searchTypes.js';
+import { DEFAULT_SEARCH_TYPE } from '../../../search/constants/searchTypes.js';
 
 const VARIANT_THRESHOLD = 50;
 const SHOULD_THRESHOLD = 50;
@@ -32,7 +32,7 @@ function logQueryMetrics({
     variantMs,
     logger,
     caseReferenceNumber,
-    searchType = SEARCH_TYPES.KEYWORD_DATES
+    searchType = DEFAULT_SEARCH_TYPE
 }) {
     const metrics = {
         queryHash: crypto.createHash('sha256').update(keyword).digest('hex').slice(0, 8),

--- a/api/DAL/utils/logQueryMetrics/index.js
+++ b/api/DAL/utils/logQueryMetrics/index.js
@@ -1,0 +1,77 @@
+import crypto from 'node:crypto';
+import SEARCH_TYPES from '../../../search/constants/searchTypes.js';
+
+const VARIANT_THRESHOLD = 50;
+const SHOULD_THRESHOLD = 50;
+
+/**
+ * Computes and logs query metrics with threshold warnings.
+ *
+ * @param {object} params - Logging inputs.
+ * @param {object} params.queryJson - Final query payload.
+ * @param {string} params.keyword - Raw search string.
+ * @param {Array<string>} params.phrases - Extracted date phrases.
+ * @param {Array<string>} params.phrasesVariants - Expanded phrase variants.
+ * @param {Array<object>} params.shouldClauses - Generated lexical clauses.
+ * @param {number} params.buildMs - Build duration in ms.
+ * @param {number} params.extractMs - Extraction duration in ms.
+ * @param {number} params.variantMs - Variant generation duration in ms.
+ * @param {object} [params.logger] - Optional structured logger.
+ * @param {string} params.caseReferenceNumber - Case reference scope for logs.
+ * @param {string} [params.searchType] - The effective search mode (one of SEARCH_TYPES).
+ * @returns {void}
+ */
+function logQueryMetrics({
+    queryJson,
+    keyword,
+    phrases,
+    phrasesVariants,
+    shouldClauses,
+    buildMs,
+    extractMs,
+    variantMs,
+    logger,
+    caseReferenceNumber,
+    searchType = SEARCH_TYPES.KEYWORD_DATES
+}) {
+    const metrics = {
+        queryHash: crypto.createHash('sha256').update(keyword).digest('hex').slice(0, 8),
+        searchType,
+        phraseCount: phrases.length,
+        phraseVariantCount: phrasesVariants.length,
+        shouldClauseCount: shouldClauses.length,
+        payloadSize: JSON.stringify(queryJson).length,
+        extractMs,
+        variantMs,
+        buildMs
+    };
+
+    if (!logger) {
+        return;
+    }
+
+    logger.info(
+        {
+            caseReferenceNumber,
+            ...metrics
+        },
+        '[QueryBuilder] Query metrics'
+    );
+
+    if (
+        metrics.phraseVariantCount > VARIANT_THRESHOLD ||
+        metrics.shouldClauseCount > SHOULD_THRESHOLD
+    ) {
+        logger.warn(
+            {
+                caseReferenceNumber,
+                queryHash: metrics.queryHash,
+                variantCount: metrics.phraseVariantCount,
+                shouldClauseCount: metrics.shouldClauseCount
+            },
+            '[QueryBuilder] Variant/clause count exceeds safe threshold'
+        );
+    }
+}
+
+export default logQueryMetrics;

--- a/api/document/page-chunks-routes.js
+++ b/api/document/page-chunks-routes.js
@@ -1,4 +1,8 @@
 import express from 'express';
+import {
+    FEATURE_FLAG_ENUM_OPTIONS,
+    parseEnumFlagValue
+} from '../../middleware/featureFlags/index.js';
 import createPageChunksService from './services/page-chunks-service.js';
 
 const CRN_REGEX = /^\d{2}-[78]\d{5}$/;
@@ -52,6 +56,8 @@ function createPageChunksRouter(options = {}) {
         try {
             const { documentId, pageNumber } = req.params;
             const { crn, searchTerm } = req.query;
+            const searchType =
+                parseEnumFlagValue(req.query.type, FEATURE_FLAG_ENUM_OPTIONS.type) || 'keyword';
 
             if (!crn) {
                 const err = new Error('Case reference number (crn) is required');
@@ -70,7 +76,7 @@ function createPageChunksRouter(options = {}) {
                 pageNumber,
                 crn,
                 searchTerm,
-                { logger: req.log }
+                { logger: req.log, searchType }
             );
 
             return res.json({

--- a/api/document/page-chunks-routes.js
+++ b/api/document/page-chunks-routes.js
@@ -37,8 +37,7 @@ function createPageChunksRouter(options = {}) {
      * @param {string} req.params.pageNumber - The page number to retrieve chunks for.
      * @param {string} req.query.crn - The case reference number (required).
      * @param {string} [req.query.searchTerm] - Search term to filter chunks by content.
-     * @param {string} [req.query.type=DEFAULT_SEARCH_TYPE] - Search mode: `keyword`, `keyword-dates`, `semantic`, `hybrid`, or `hybrid-dates`.
-     * @param {string} [req.query.dates='on'] - Whether date extraction is enabled (`on` or `off`).
+     * @param {string} [req.query.type=DEFAULT_SEARCH_TYPE] - Search mode: `keyword`, `keyword-dates`, `semantic`, `hybrid`, or `hybrid-dates`. Date extraction is enabled for `-dates` variants.
      * @param {express.Response} res - The Express response object.
      *
      * @returns {Object} JSON response with page chunks:

--- a/api/document/page-chunks-routes.js
+++ b/api/document/page-chunks-routes.js
@@ -1,5 +1,4 @@
 import express from 'express';
-import { parseFeatureFlagValue } from '../../middleware/featureFlags/index.js';
 import createPageChunksService from './services/page-chunks-service.js';
 
 const CRN_REGEX = /^\d{2}-[78]\d{5}$/;
@@ -36,7 +35,9 @@ function createPageChunksRouter(options = {}) {
      * @param {string} req.params.documentId - The UUID of the document.
      * @param {string} req.params.pageNumber - The page number to retrieve chunks for.
      * @param {string} req.query.crn - The case reference number (required).
-     * @param {string} req.query.searchTerm - Search term to filter chunks by content.
+     * @param {string} [req.query.searchTerm] - Search term to filter chunks by content.
+     * @param {string} [req.query.searchType='keyword-dates'] - Search mode: `keyword`, `keyword-dates`, `semantic`, `hybrid`, or `hybrid-dates`.
+     * @param {string} [req.query.dates='on'] - Whether date extraction is enabled (`on` or `off`).
      * @param {express.Response} res - The Express response object.
      *
      * @returns {Object} JSON response with page chunks:
@@ -53,9 +54,7 @@ function createPageChunksRouter(options = {}) {
         try {
             const { documentId, pageNumber } = req.params;
             const { crn, searchTerm } = req.query;
-            const useKeyword = parseFeatureFlagValue(req.query.keyword) ?? true;
-            const useSemantic = parseFeatureFlagValue(req.query.semantic) ?? false;
-            const enableDateExtraction = parseFeatureFlagValue(req.query.dates) ?? true;
+            const searchType = req.query.searchType ?? 'keyword-dates';
 
             if (!crn) {
                 const err = new Error('Case reference number (crn) is required');
@@ -74,7 +73,7 @@ function createPageChunksRouter(options = {}) {
                 pageNumber,
                 crn,
                 searchTerm,
-                { logger: req.log, useKeyword, useSemantic, enableDateExtraction }
+                { logger: req.log, searchType }
             );
 
             return res.json({

--- a/api/document/page-chunks-routes.js
+++ b/api/document/page-chunks-routes.js
@@ -55,7 +55,7 @@ function createPageChunksRouter(options = {}) {
         try {
             const { documentId, pageNumber } = req.params;
             const { crn, searchTerm } = req.query;
-            const searchType = resolveSearchType(req.query.type);
+            const searchType = resolveSearchType(req.query.type, req.session);
 
             if (!crn) {
                 const err = new Error('Case reference number (crn) is required');

--- a/api/document/page-chunks-routes.js
+++ b/api/document/page-chunks-routes.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import createPageChunksService from './services/page-chunks-service.js';
+import { DEFAULT_SEARCH_TYPE } from '../search/constants/searchTypes.js';
 
 const CRN_REGEX = /^\d{2}-[78]\d{5}$/;
 
@@ -36,7 +37,7 @@ function createPageChunksRouter(options = {}) {
      * @param {string} req.params.pageNumber - The page number to retrieve chunks for.
      * @param {string} req.query.crn - The case reference number (required).
      * @param {string} [req.query.searchTerm] - Search term to filter chunks by content.
-     * @param {string} [req.query.searchType='keyword-dates'] - Search mode: `keyword`, `keyword-dates`, `semantic`, `hybrid`, or `hybrid-dates`.
+     * @param {string} [req.query.type=DEFAULT_SEARCH_TYPE] - Search mode: `keyword`, `keyword-dates`, `semantic`, `hybrid`, or `hybrid-dates`.
      * @param {string} [req.query.dates='on'] - Whether date extraction is enabled (`on` or `off`).
      * @param {express.Response} res - The Express response object.
      *
@@ -54,7 +55,7 @@ function createPageChunksRouter(options = {}) {
         try {
             const { documentId, pageNumber } = req.params;
             const { crn, searchTerm } = req.query;
-            const searchType = req.query.searchType ?? 'keyword-dates';
+            const searchType = req.query.type ?? DEFAULT_SEARCH_TYPE;
 
             if (!crn) {
                 const err = new Error('Case reference number (crn) is required');

--- a/api/document/page-chunks-routes.js
+++ b/api/document/page-chunks-routes.js
@@ -1,8 +1,5 @@
 import express from 'express';
-import {
-    FEATURE_FLAG_ENUM_OPTIONS,
-    parseEnumFlagValue
-} from '../../middleware/featureFlags/index.js';
+import { parseFeatureFlagValue } from '../../middleware/featureFlags/index.js';
 import createPageChunksService from './services/page-chunks-service.js';
 
 const CRN_REGEX = /^\d{2}-[78]\d{5}$/;
@@ -56,8 +53,9 @@ function createPageChunksRouter(options = {}) {
         try {
             const { documentId, pageNumber } = req.params;
             const { crn, searchTerm } = req.query;
-            const searchType =
-                parseEnumFlagValue(req.query.type, FEATURE_FLAG_ENUM_OPTIONS.type) || 'keyword';
+            const useKeyword = parseFeatureFlagValue(req.query.keyword) ?? true;
+            const useSemantic = parseFeatureFlagValue(req.query.semantic) ?? false;
+            const enableDateExtraction = parseFeatureFlagValue(req.query.dates) ?? true;
 
             if (!crn) {
                 const err = new Error('Case reference number (crn) is required');
@@ -76,7 +74,7 @@ function createPageChunksRouter(options = {}) {
                 pageNumber,
                 crn,
                 searchTerm,
-                { logger: req.log, searchType }
+                { logger: req.log, useKeyword, useSemantic, enableDateExtraction }
             );
 
             return res.json({

--- a/api/document/page-chunks-routes.js
+++ b/api/document/page-chunks-routes.js
@@ -1,6 +1,6 @@
 import express from 'express';
-import createPageChunksService from './services/page-chunks-service.js';
 import { DEFAULT_SEARCH_TYPE } from '../search/constants/searchTypes.js';
+import createPageChunksService from './services/page-chunks-service.js';
 
 const CRN_REGEX = /^\d{2}-[78]\d{5}$/;
 

--- a/api/document/page-chunks-routes.js
+++ b/api/document/page-chunks-routes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { DEFAULT_SEARCH_TYPE } from '../search/constants/searchTypes.js';
+import { resolveSearchType } from '../search/constants/searchTypes.js';
 import createPageChunksService from './services/page-chunks-service.js';
 
 const CRN_REGEX = /^\d{2}-[78]\d{5}$/;
@@ -55,7 +55,7 @@ function createPageChunksRouter(options = {}) {
         try {
             const { documentId, pageNumber } = req.params;
             const { crn, searchTerm } = req.query;
-            const searchType = req.query.type ?? DEFAULT_SEARCH_TYPE;
+            const searchType = resolveSearchType(req.query.type);
 
             if (!crn) {
                 const err = new Error('Case reference number (crn) is required');

--- a/api/document/page-chunks-routes.test.js
+++ b/api/document/page-chunks-routes.test.js
@@ -216,6 +216,20 @@ describe('page-chunks-routes', () => {
             assert.strictEqual(capturedLogger, mockLogger);
         });
 
+        it('should pass searchType to service context', async () => {
+            let capturedSearchType;
+            mockRequest.query.type = 'semantic';
+            mockPageChunksService.getPageChunks = async (_, __, ___, ____, context) => {
+                capturedSearchType = context.searchType;
+                return [];
+            };
+
+            const handler = router.stack[0].route.stack[0].handle;
+            await handler(mockRequest, mockResponse, () => {});
+
+            assert.strictEqual(capturedSearchType, 'semantic');
+        });
+
         it('should handle service errors via next middleware', async () => {
             const serviceError = new Error('Service failed');
             mockPageChunksService.getPageChunks = async () => {

--- a/api/document/page-chunks-routes.test.js
+++ b/api/document/page-chunks-routes.test.js
@@ -218,7 +218,7 @@ describe('page-chunks-routes', () => {
 
         it('should pass search flags to service context', async () => {
             let capturedContext;
-            mockRequest.query.searchType = 'semantic';
+            mockRequest.query.type = 'semantic';
             mockRequest.query.dates = 'off';
             mockPageChunksService.getPageChunks = async (_, __, ___, ____, context) => {
                 capturedContext = context;

--- a/api/document/page-chunks-routes.test.js
+++ b/api/document/page-chunks-routes.test.js
@@ -218,8 +218,7 @@ describe('page-chunks-routes', () => {
 
         it('should pass search flags to service context', async () => {
             let capturedContext;
-            mockRequest.query.keyword = 'off';
-            mockRequest.query.semantic = 'on';
+            mockRequest.query.searchType = 'semantic';
             mockRequest.query.dates = 'off';
             mockPageChunksService.getPageChunks = async (_, __, ___, ____, context) => {
                 capturedContext = context;
@@ -229,9 +228,7 @@ describe('page-chunks-routes', () => {
             const handler = router.stack[0].route.stack[0].handle;
             await handler(mockRequest, mockResponse, () => {});
 
-            assert.strictEqual(capturedContext.useKeyword, false);
-            assert.strictEqual(capturedContext.useSemantic, true);
-            assert.strictEqual(capturedContext.enableDateExtraction, false);
+            assert.strictEqual(capturedContext.searchType, 'semantic');
         });
 
         it('should handle service errors via next middleware', async () => {

--- a/api/document/page-chunks-routes.test.js
+++ b/api/document/page-chunks-routes.test.js
@@ -216,18 +216,22 @@ describe('page-chunks-routes', () => {
             assert.strictEqual(capturedLogger, mockLogger);
         });
 
-        it('should pass searchType to service context', async () => {
-            let capturedSearchType;
-            mockRequest.query.type = 'semantic';
+        it('should pass search flags to service context', async () => {
+            let capturedContext;
+            mockRequest.query.keyword = 'off';
+            mockRequest.query.semantic = 'on';
+            mockRequest.query.dates = 'off';
             mockPageChunksService.getPageChunks = async (_, __, ___, ____, context) => {
-                capturedSearchType = context.searchType;
+                capturedContext = context;
                 return [];
             };
 
             const handler = router.stack[0].route.stack[0].handle;
             await handler(mockRequest, mockResponse, () => {});
 
-            assert.strictEqual(capturedSearchType, 'semantic');
+            assert.strictEqual(capturedContext.useKeyword, false);
+            assert.strictEqual(capturedContext.useSemantic, true);
+            assert.strictEqual(capturedContext.enableDateExtraction, false);
         });
 
         it('should handle service errors via next middleware', async () => {

--- a/api/document/services/page-chunks-service.js
+++ b/api/document/services/page-chunks-service.js
@@ -21,9 +21,16 @@ function createPageChunksService({
      * @param {string} [searchTerm] - Optional search term to filter chunks.
      * @param {Object} [context] - Context for the call.
      * @param {Object} [context.logger] - Logger instance.
+     * @param {'keyword'|'semantic'|'hybrid'} [context.searchType='keyword'] - Search mode used for chunk matching.
      * @returns {Promise<Array<Object>>} Array of chunks with bounding boxes.
      */
-    async function getPageChunks(documentId, pageNumber, crn, searchTerm, { logger } = {}) {
+    async function getPageChunks(
+        documentId,
+        pageNumber,
+        crn,
+        searchTerm,
+        { logger, searchType = 'keyword' } = {}
+    ) {
         const dal = createDocumentDALFactory({
             caseReferenceNumber: crn,
             logger
@@ -34,11 +41,12 @@ function createPageChunksService({
             chunks = await dal.getPageChunksByDocumentIdAndPageNumber(
                 documentId,
                 pageNumber,
-                searchTerm
+                searchTerm,
+                searchType
             );
         } catch (error) {
             logger?.error(
-                { error: error.message, documentId, pageNumber, searchTerm },
+                { error: error.message, documentId, pageNumber, searchTerm, searchType },
                 'Failed to retrieve page chunks from OpenSearch'
             );
             const err = new Error(error.message);

--- a/api/document/services/page-chunks-service.js
+++ b/api/document/services/page-chunks-service.js
@@ -1,4 +1,5 @@
 import createDocumentDALDefault from '../../DAL/document-dal.js';
+import { DEFAULT_SEARCH_TYPE } from '../../search/constants/searchTypes.js';
 
 /**
  * Creates a Page Chunks Service for retrieving document page chunks with bounding boxes.
@@ -21,7 +22,7 @@ function createPageChunksService({
      * @param {string} [searchTerm] - Optional search term to filter chunks.
      * @param {Object} [context] - Context for the call.
      * @param {Object} [context.logger] - Logger instance.
-     * @param {string} [context.searchType='keyword-dates'] - Search mode (one of SEARCH_TYPES).
+     * @param {string} [context.searchType='hybrid-dates'] - Search mode (one of SEARCH_TYPES).
      * @returns {Promise<Array<Object>>} Array of chunks with bounding boxes.
      */
     async function getPageChunks(
@@ -29,7 +30,7 @@ function createPageChunksService({
         pageNumber,
         crn,
         searchTerm,
-        { logger, searchType = 'keyword-dates' } = {}
+        { logger, searchType = DEFAULT_SEARCH_TYPE } = {}
     ) {
         const dal = createDocumentDALFactory({
             caseReferenceNumber: crn,

--- a/api/document/services/page-chunks-service.js
+++ b/api/document/services/page-chunks-service.js
@@ -21,7 +21,9 @@ function createPageChunksService({
      * @param {string} [searchTerm] - Optional search term to filter chunks.
      * @param {Object} [context] - Context for the call.
      * @param {Object} [context.logger] - Logger instance.
-     * @param {'keyword'|'semantic'|'hybrid'} [context.searchType='keyword'] - Search mode used for chunk matching.
+     * @param {boolean} [context.useKeyword=true] - Enable lexical keyword matching.
+     * @param {boolean} [context.useSemantic=false] - Enable neural semantic matching.
+     * @param {boolean} [context.enableDateExtraction=true] - Enable date extraction and variant expansion.
      * @returns {Promise<Array<Object>>} Array of chunks with bounding boxes.
      */
     async function getPageChunks(
@@ -29,7 +31,7 @@ function createPageChunksService({
         pageNumber,
         crn,
         searchTerm,
-        { logger, searchType = 'keyword' } = {}
+        { logger, useKeyword = true, useSemantic = false, enableDateExtraction = true } = {}
     ) {
         const dal = createDocumentDALFactory({
             caseReferenceNumber: crn,
@@ -42,11 +44,21 @@ function createPageChunksService({
                 documentId,
                 pageNumber,
                 searchTerm,
-                searchType
+                useKeyword,
+                useSemantic,
+                enableDateExtraction
             );
         } catch (error) {
             logger?.error(
-                { error: error.message, documentId, pageNumber, searchTerm, searchType },
+                {
+                    error: error.message,
+                    documentId,
+                    pageNumber,
+                    searchTerm,
+                    useKeyword,
+                    useSemantic,
+                    enableDateExtraction
+                },
                 'Failed to retrieve page chunks from OpenSearch'
             );
             const err = new Error(error.message);

--- a/api/document/services/page-chunks-service.js
+++ b/api/document/services/page-chunks-service.js
@@ -21,9 +21,7 @@ function createPageChunksService({
      * @param {string} [searchTerm] - Optional search term to filter chunks.
      * @param {Object} [context] - Context for the call.
      * @param {Object} [context.logger] - Logger instance.
-     * @param {boolean} [context.useKeyword=true] - Enable lexical keyword matching.
-     * @param {boolean} [context.useSemantic=false] - Enable neural semantic matching.
-     * @param {boolean} [context.enableDateExtraction=true] - Enable date extraction and variant expansion.
+     * @param {string} [context.searchType='keyword-dates'] - Search mode (one of SEARCH_TYPES).
      * @returns {Promise<Array<Object>>} Array of chunks with bounding boxes.
      */
     async function getPageChunks(
@@ -31,7 +29,7 @@ function createPageChunksService({
         pageNumber,
         crn,
         searchTerm,
-        { logger, useKeyword = true, useSemantic = false, enableDateExtraction = true } = {}
+        { logger, searchType = 'keyword-dates' } = {}
     ) {
         const dal = createDocumentDALFactory({
             caseReferenceNumber: crn,
@@ -44,9 +42,7 @@ function createPageChunksService({
                 documentId,
                 pageNumber,
                 searchTerm,
-                useKeyword,
-                useSemantic,
-                enableDateExtraction
+                searchType
             );
         } catch (error) {
             logger?.error(
@@ -55,9 +51,7 @@ function createPageChunksService({
                     documentId,
                     pageNumber,
                     searchTerm,
-                    useKeyword,
-                    useSemantic,
-                    enableDateExtraction
+                    searchType
                 },
                 'Failed to retrieve page chunks from OpenSearch'
             );

--- a/api/document/services/page-chunks-service.test.js
+++ b/api/document/services/page-chunks-service.test.js
@@ -94,6 +94,21 @@ describe('page-chunks-service', () => {
             assert.strictEqual(capturedSearchTerm, 'keyword');
         });
 
+        it('should pass searchType to DAL method', async () => {
+            let capturedSearchType;
+            mockDAL.getPageChunksByDocumentIdAndPageNumber = async (_, __, ___, searchType) => {
+                capturedSearchType = searchType;
+                return [];
+            };
+
+            await pageChunksService.getPageChunks('doc-123', 1, '12-745678', 'keyword', {
+                logger: mockLogger,
+                searchType: 'semantic'
+            });
+
+            assert.strictEqual(capturedSearchType, 'semantic');
+        });
+
         it('should handle DAL errors and throw with status code', async () => {
             const dalError = new Error('OpenSearch connection failed');
             dalError.status = 503;

--- a/api/document/services/page-chunks-service.test.js
+++ b/api/document/services/page-chunks-service.test.js
@@ -94,19 +94,32 @@ describe('page-chunks-service', () => {
             assert.strictEqual(capturedSearchTerm, 'keyword');
         });
 
-        it('should pass searchType to DAL method', async () => {
-            let capturedSearchType;
-            mockDAL.getPageChunksByDocumentIdAndPageNumber = async (_, __, ___, searchType) => {
-                capturedSearchType = searchType;
+        it('should pass search flags to DAL method', async () => {
+            let capturedUseKeyword, capturedUseSemantic, capturedEnableDateExtraction;
+            mockDAL.getPageChunksByDocumentIdAndPageNumber = async (
+                _,
+                __,
+                ___,
+                useKeyword,
+                useSemantic,
+                enableDateExtraction
+            ) => {
+                capturedUseKeyword = useKeyword;
+                capturedUseSemantic = useSemantic;
+                capturedEnableDateExtraction = enableDateExtraction;
                 return [];
             };
 
             await pageChunksService.getPageChunks('doc-123', 1, '12-745678', 'keyword', {
                 logger: mockLogger,
-                searchType: 'semantic'
+                useKeyword: false,
+                useSemantic: true,
+                enableDateExtraction: false
             });
 
-            assert.strictEqual(capturedSearchType, 'semantic');
+            assert.strictEqual(capturedUseKeyword, false);
+            assert.strictEqual(capturedUseSemantic, true);
+            assert.strictEqual(capturedEnableDateExtraction, false);
         });
 
         it('should handle DAL errors and throw with status code', async () => {

--- a/api/document/services/page-chunks-service.test.js
+++ b/api/document/services/page-chunks-service.test.js
@@ -95,31 +95,18 @@ describe('page-chunks-service', () => {
         });
 
         it('should pass search flags to DAL method', async () => {
-            let capturedUseKeyword, capturedUseSemantic, capturedEnableDateExtraction;
-            mockDAL.getPageChunksByDocumentIdAndPageNumber = async (
-                _,
-                __,
-                ___,
-                useKeyword,
-                useSemantic,
-                enableDateExtraction
-            ) => {
-                capturedUseKeyword = useKeyword;
-                capturedUseSemantic = useSemantic;
-                capturedEnableDateExtraction = enableDateExtraction;
+            let capturedSearchType;
+            mockDAL.getPageChunksByDocumentIdAndPageNumber = async (_, __, ___, searchType) => {
+                capturedSearchType = searchType;
                 return [];
             };
 
             await pageChunksService.getPageChunks('doc-123', 1, '12-745678', 'keyword', {
                 logger: mockLogger,
-                useKeyword: false,
-                useSemantic: true,
-                enableDateExtraction: false
+                searchType: 'semantic'
             });
 
-            assert.strictEqual(capturedUseKeyword, false);
-            assert.strictEqual(capturedUseSemantic, true);
-            assert.strictEqual(capturedEnableDateExtraction, false);
+            assert.strictEqual(capturedSearchType, 'semantic');
         });
 
         it('should handle DAL errors and throw with status code', async () => {

--- a/api/openapi/openapi-dist.json
+++ b/api/openapi/openapi-dist.json
@@ -80,6 +80,21 @@
                         "example": 2
                     },
                     {
+                        "name": "type",
+                        "in": "query",
+                        "required": false,
+                        "description": "Search type to run: keyword lexical search, semantic neural search, or hybrid",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "keyword",
+                                "semantic",
+                                "hybrid"
+                            ]
+                        },
+                        "example": "hybrid"
+                    },
+                    {
                         "name": "On-Behalf-Of",
                         "in": "header",
                         "required": true,
@@ -786,6 +801,21 @@
                             "type": "string"
                         },
                         "example": "acute"
+                    },
+                    {
+                        "name": "type",
+                        "in": "query",
+                        "required": false,
+                        "description": "Search type to run for chunk matching",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "keyword",
+                                "semantic",
+                                "hybrid"
+                            ]
+                        },
+                        "example": "semantic"
                     }
                 ],
                 "responses": {
@@ -1136,6 +1166,21 @@
                     "max": 100
                 },
                 "example": 2
+            },
+            "type": {
+                "name": "type",
+                "in": "query",
+                "required": false,
+                "description": "Search type to run: keyword lexical search, semantic neural search, or hybrid",
+                "schema": {
+                    "type": "string",
+                    "enum": [
+                        "keyword",
+                        "semantic",
+                        "hybrid"
+                    ]
+                },
+                "example": "hybrid"
             },
             "onBehalfOf": {
                 "name": "On-Behalf-Of",

--- a/api/openapi/openapi-dist.json
+++ b/api/openapi/openapi-dist.json
@@ -83,13 +83,15 @@
                         "name": "type",
                         "in": "query",
                         "required": false,
-                        "description": "Search type to run: keyword lexical search, semantic neural search, or hybrid",
+                        "description": "Search mode. Controls whether lexical (BM25), neural (semantic), or combined (hybrid) search is used, and whether date phrase extraction is applied.",
                         "schema": {
                             "type": "string",
                             "enum": [
                                 "keyword",
+                                "keyword-dates",
                                 "semantic",
-                                "hybrid"
+                                "hybrid",
+                                "hybrid-dates"
                             ]
                         },
                         "example": "hybrid"
@@ -491,7 +493,7 @@
                         "name": "pageNumber",
                         "in": "path",
                         "required": true,
-                        "description": "The page number to retrieve metadata for",
+                        "description": "The page number within the document",
                         "schema": {
                             "type": "integer",
                             "minimum": 1
@@ -774,7 +776,7 @@
                         "name": "pageNumber",
                         "in": "path",
                         "required": true,
-                        "description": "The page number to retrieve chunks for",
+                        "description": "The page number within the document",
                         "schema": {
                             "type": "integer",
                             "minimum": 1
@@ -806,16 +808,18 @@
                         "name": "type",
                         "in": "query",
                         "required": false,
-                        "description": "Search type to run for chunk matching",
+                        "description": "Search mode. Controls whether lexical (BM25), neural (semantic), or combined (hybrid) search is used, and whether date phrase extraction is applied.",
                         "schema": {
                             "type": "string",
                             "enum": [
                                 "keyword",
+                                "keyword-dates",
                                 "semantic",
-                                "hybrid"
+                                "hybrid",
+                                "hybrid-dates"
                             ]
                         },
-                        "example": "semantic"
+                        "example": "hybrid"
                     }
                 ],
                 "responses": {
@@ -1128,6 +1132,39 @@
             }
         },
         "parameters": {
+            "documentId": {
+                "name": "documentId",
+                "in": "path",
+                "required": true,
+                "description": "The UUID of the document",
+                "schema": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "example": "55b2ea3c-3eae-54f7-b81d-292db7c84be7"
+            },
+            "documentPageNumber": {
+                "name": "pageNumber",
+                "in": "path",
+                "required": true,
+                "description": "The page number within the document",
+                "schema": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "example": 6
+            },
+            "crn": {
+                "name": "crn",
+                "in": "query",
+                "required": true,
+                "description": "Case reference number",
+                "schema": {
+                    "type": "string",
+                    "pattern": "^\\d{2}-[78]\\d{5}$"
+                },
+                "example": "26-711111"
+            },
             "query": {
                 "name": "query",
                 "in": "query",
@@ -1171,13 +1208,15 @@
                 "name": "type",
                 "in": "query",
                 "required": false,
-                "description": "Search type to run: keyword lexical search, semantic neural search, or hybrid",
+                "description": "Search mode. Controls whether lexical (BM25), neural (semantic), or combined (hybrid) search is used, and whether date phrase extraction is applied.",
                 "schema": {
                     "type": "string",
                     "enum": [
                         "keyword",
+                        "keyword-dates",
                         "semantic",
-                        "hybrid"
+                        "hybrid",
+                        "hybrid-dates"
                     ]
                 },
                 "example": "hybrid"

--- a/api/openapi/openapi.json
+++ b/api/openapi/openapi.json
@@ -48,6 +48,9 @@
                         "$ref": "#/components/parameters/itemsPerPage"
                     },
                     {
+                        "$ref": "#/components/parameters/type"
+                    },
+                    {
                         "$ref": "#/components/parameters/onBehalfOf"
                     }
                 ],
@@ -277,6 +280,17 @@
                             "type": "string"
                         },
                         "example": "acute"
+                    },
+                    {
+                        "name": "type",
+                        "in": "query",
+                        "required": false,
+                        "description": "Search type to run for chunk matching",
+                        "schema": {
+                            "type": "string",
+                            "enum": ["keyword", "semantic", "hybrid"]
+                        },
+                        "example": "semantic"
                     }
                 ],
                 "responses": {
@@ -452,6 +466,17 @@
                     "max": 100
                 },
                 "example": 2
+            },
+            "type": {
+                "name": "type",
+                "in": "query",
+                "required": false,
+                "description": "Search type to run: keyword lexical search, semantic neural search, or hybrid",
+                "schema": {
+                    "type": "string",
+                    "enum": ["keyword", "semantic", "hybrid"]
+                },
+                "example": "hybrid"
             },
             "onBehalfOf": {
                 "name": "On-Behalf-Of",

--- a/api/openapi/openapi.json
+++ b/api/openapi/openapi.json
@@ -136,37 +136,13 @@
                 "operationId": "getPageMetadata",
                 "parameters": [
                     {
-                        "name": "documentId",
-                        "in": "path",
-                        "required": true,
-                        "description": "The UUID of the document",
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "55b2ea3c-3eae-54f7-b81d-292db7c84be7"
+                        "$ref": "#/components/parameters/documentId"
                     },
                     {
-                        "name": "pageNumber",
-                        "in": "path",
-                        "required": true,
-                        "description": "The page number to retrieve metadata for",
-                        "schema": {
-                            "type": "integer",
-                            "minimum": 1
-                        },
-                        "example": 6
+                        "$ref": "#/components/parameters/documentPageNumber"
                     },
                     {
-                        "name": "crn",
-                        "in": "query",
-                        "required": true,
-                        "description": "Case reference number",
-                        "schema": {
-                            "type": "string",
-                            "pattern": "^\\d{2}-[78]\\d{5}$"
-                        },
-                        "example": "26-711111"
+                        "$ref": "#/components/parameters/crn"
                     }
                 ],
                 "responses": {
@@ -239,37 +215,13 @@
                 "operationId": "getPageChunks",
                 "parameters": [
                     {
-                        "name": "documentId",
-                        "in": "path",
-                        "required": true,
-                        "description": "The UUID of the document",
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid"
-                        },
-                        "example": "55b2ea3c-3eae-54f7-b81d-292db7c84be7"
+                        "$ref": "#/components/parameters/documentId"
                     },
                     {
-                        "name": "pageNumber",
-                        "in": "path",
-                        "required": true,
-                        "description": "The page number to retrieve chunks for",
-                        "schema": {
-                            "type": "integer",
-                            "minimum": 1
-                        },
-                        "example": 6
+                        "$ref": "#/components/parameters/documentPageNumber"
                     },
                     {
-                        "name": "crn",
-                        "in": "query",
-                        "required": true,
-                        "description": "Case reference number",
-                        "schema": {
-                            "type": "string",
-                            "pattern": "^\\d{2}-[78]\\d{5}$"
-                        },
-                        "example": "26-711111"
+                        "$ref": "#/components/parameters/crn"
                     },
                     {
                         "name": "searchTerm",
@@ -282,15 +234,7 @@
                         "example": "acute"
                     },
                     {
-                        "name": "type",
-                        "in": "query",
-                        "required": false,
-                        "description": "Search type to run for chunk matching",
-                        "schema": {
-                            "type": "string",
-                            "enum": ["keyword", "semantic", "hybrid"]
-                        },
-                        "example": "semantic"
+                        "$ref": "#/components/parameters/type"
                     }
                 ],
                 "responses": {
@@ -428,6 +372,39 @@
             }
         },
         "parameters": {
+            "documentId": {
+                "name": "documentId",
+                "in": "path",
+                "required": true,
+                "description": "The UUID of the document",
+                "schema": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "example": "55b2ea3c-3eae-54f7-b81d-292db7c84be7"
+            },
+            "documentPageNumber": {
+                "name": "pageNumber",
+                "in": "path",
+                "required": true,
+                "description": "The page number within the document",
+                "schema": {
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "example": 6
+            },
+            "crn": {
+                "name": "crn",
+                "in": "query",
+                "required": true,
+                "description": "Case reference number",
+                "schema": {
+                    "type": "string",
+                    "pattern": "^\\d{2}-[78]\\d{5}$"
+                },
+                "example": "26-711111"
+            },
             "query": {
                 "name": "query",
                 "in": "query",
@@ -471,10 +448,10 @@
                 "name": "type",
                 "in": "query",
                 "required": false,
-                "description": "Search type to run: keyword lexical search, semantic neural search, or hybrid",
+                "description": "Search mode. Controls whether lexical (BM25), neural (semantic), or combined (hybrid) search is used, and whether date phrase extraction is applied.",
                 "schema": {
                     "type": "string",
-                    "enum": ["keyword", "semantic", "hybrid"]
+                    "enum": ["keyword", "keyword-dates", "semantic", "hybrid", "hybrid-dates"]
                 },
                 "example": "hybrid"
             },

--- a/api/search/constants/searchTypes.js
+++ b/api/search/constants/searchTypes.js
@@ -69,3 +69,36 @@ export function parseSearchType(input) {
 }
 
 export const parseSearchTypeTokens = parseSearchType;
+
+/**
+ * Returns whether the given value is a recognised search type.
+ *
+ * @param {unknown} value - The value to check.
+ * @returns {boolean} `true` if the value is a recognised SEARCH_TYPES value, otherwise `false`.
+ *
+ * @example
+ * isValidSearchType('hybrid-dates') // true
+ * isValidSearchType('keyword')      // true
+ * isValidSearchType('unknown')      // false
+ * isValidSearchType(undefined)      // false
+ */
+export function isValidSearchType(value) {
+    return Object.values(SEARCH_TYPES).includes(value);
+}
+
+/**
+ * Resolves a search type value, falling back to DEFAULT_SEARCH_TYPE if the value is
+ * absent or not a recognised SEARCH_TYPES value.
+ *
+ * @param {unknown} value - The value to resolve.
+ * @returns {string} The resolved search type value.
+ *
+ * @example
+ * resolveSearchType('hybrid-dates') // 'hybrid-dates'
+ * resolveSearchType('keyword')      // 'keyword'
+ * resolveSearchType('unknown')      // 'hybrid-dates' (DEFAULT_SEARCH_TYPE)
+ * resolveSearchType(undefined)      // 'hybrid-dates' (DEFAULT_SEARCH_TYPE)
+ */
+export function resolveSearchType(value) {
+    return isValidSearchType(value) ? value : DEFAULT_SEARCH_TYPE;
+}

--- a/api/search/constants/searchTypes.js
+++ b/api/search/constants/searchTypes.js
@@ -34,71 +34,41 @@ export const DEFAULT_SEARCH_TYPE = SEARCH_TYPES.HYBRID_DATES;
  * SEARCH_TYPES values, so the URL value and the internal search strategy key stay
  * aligned one to one.
  *
- * Accepts both a plain string or an array (as Express may produce when a query param
- * appears multiple times); when an array is given, the last value is used.
+ * When the input is absent, not a string, or an empty/whitespace-only string,
+ * `DEFAULT_SEARCH_TYPE` is returned immediately.
+ *
+ * When the input is an unrecognised string, the function attempts to resolve a
+ * fallback from the session's feature flags (`session.featureFlags.type`).
+ * If no feature-flag override is present, `DEFAULT_SEARCH_TYPE` is returned.
+ *
  * Comma-delimited values (for example `type=keyword,semantic`) are treated as a
- * single invalid value.
+ * single invalid value and follow the fallback path.
  *
- * Returns `{ value: undefined, invalidValue: undefined }` when the input is absent or not a
- * string, allowing callers to distinguish "param not present" from "param present but
- * invalid".
- *
- * @param {unknown} input - Raw `req.query.type` value.
- * @returns {{ value: string | undefined, invalidValue: string | undefined }}
+ * @param {unknown} searchType - Raw `req.query.type` value.
+ * @param {import('express-session').Session} [session] - Request session used to resolve feature-flag fallbacks.
+ * @returns {string} A recognised SEARCH_TYPES value.
  *
  * @example
- * parseSearchType('hybrid-dates') // { value: 'hybrid-dates', invalidValue: undefined }
- * parseSearchType('semantic')     // { value: 'semantic', invalidValue: undefined }
- * parseSearchType('unknown')      // { value: undefined, invalidValue: 'unknown' }
- * parseSearchType(undefined)      // { value: undefined, invalidValue: undefined }
+ * resolveSearchType('hybrid-dates')         // 'hybrid-dates'
+ * resolveSearchType('semantic')             // 'semantic'
+ * resolveSearchType('KEYWORD')             // 'keyword'
+ * resolveSearchType('unknown')              // 'hybrid-dates' (DEFAULT_SEARCH_TYPE)
+ * resolveSearchType(undefined)              // 'hybrid-dates' (DEFAULT_SEARCH_TYPE)
+ * resolveSearchType('unknown', session)     // session.featureFlags.type value, or DEFAULT_SEARCH_TYPE
  */
-export function parseSearchType(input) {
-    const raw = Array.isArray(input) ? input.at(-1) : input;
-
-    if (typeof raw !== 'string' || !raw.trim()) {
-        return { value: undefined, invalidValue: undefined };
+export function resolveSearchType(searchType, session = {}) {
+    if (typeof searchType !== 'string' || !searchType.trim()) {
+        return DEFAULT_SEARCH_TYPE;
     }
 
-    const normalized = raw.trim().toLowerCase();
-    const value = Object.values(SEARCH_TYPES).includes(normalized) ? normalized : undefined;
+    const normalisedSearchType = searchType.trim().toLowerCase();
 
-    return {
-        value,
-        invalidValue: value ? undefined : normalized
-    };
-}
+    if (Object.values(SEARCH_TYPES).includes(normalisedSearchType)) {
+        return normalisedSearchType;
+    }
 
-export const parseSearchTypeTokens = parseSearchType;
-
-/**
- * Returns whether the given value is a recognised search type.
- *
- * @param {unknown} value - The value to check.
- * @returns {boolean} `true` if the value is a recognised SEARCH_TYPES value, otherwise `false`.
- *
- * @example
- * isValidSearchType('hybrid-dates') // true
- * isValidSearchType('keyword')      // true
- * isValidSearchType('unknown')      // false
- * isValidSearchType(undefined)      // false
- */
-export function isValidSearchType(value) {
-    return Object.values(SEARCH_TYPES).includes(value);
-}
-
-/**
- * Resolves a search type value, falling back to DEFAULT_SEARCH_TYPE if the value is
- * absent or not a recognised SEARCH_TYPES value.
- *
- * @param {unknown} value - The value to resolve.
- * @returns {string} The resolved search type value.
- *
- * @example
- * resolveSearchType('hybrid-dates') // 'hybrid-dates'
- * resolveSearchType('keyword')      // 'keyword'
- * resolveSearchType('unknown')      // 'hybrid-dates' (DEFAULT_SEARCH_TYPE)
- * resolveSearchType(undefined)      // 'hybrid-dates' (DEFAULT_SEARCH_TYPE)
- */
-export function resolveSearchType(value) {
-    return isValidSearchType(value) ? value : DEFAULT_SEARCH_TYPE;
+    // direct session lookup rather than getFeatureFlagValue() to avoid a circular
+    // dependency: featureFlags/index.js imports DEFAULT_SEARCH_TYPE from this module,
+    // so importing getFeatureFlagValue back here would create a cycle.
+    return session?.featureFlags?.type || DEFAULT_SEARCH_TYPE;
 }

--- a/api/search/constants/searchTypes.js
+++ b/api/search/constants/searchTypes.js
@@ -1,28 +1,139 @@
 /**
- * Enumeration of supported search modes.
+ * The primitive capability tokens accepted in the `type` URL query parameter.
  *
- * | Value             | Description                                                                 |
- * |-------------------|-----------------------------------------------------------------------------|
- * | `keyword`         | Pure BM25 lexical match. Fast, no neural overhead.                          |
- * | `keyword-dates`   | BM25 lexical match with date extraction and variant expansion.              |
- * | `semantic`        | Neural embedding (ANN) search on semantic content only.                     |
- * | `hybrid`          | Combined BM25 + neural with configurable per-clause boost factors.          |
- * | `hybrid-dates`    | Hybrid search with date extraction and variant expansion added to the mix.  |
+ * These are the building blocks that callers combine in a comma-delimited string
+ * (e.g. `?type=keyword,semantic,dates`) to select a search mode. Tokens are order-insensitive
+ * and any unrecognised values in the string are silently ignored.
+ *
+ * @readonly
+ * @enum {string}
+ */
+export const SEARCH_TYPE_TOKENS = Object.freeze({
+    KEYWORD: 'keyword',
+    DATES: 'dates',
+    SEMANTIC: 'semantic',
+    HYBRID: 'hybrid'
+});
+
+const { KEYWORD, DATES, SEMANTIC } = SEARCH_TYPE_TOKENS;
+const VALID_TOKEN_VALUES = new Set(Object.values(SEARCH_TYPE_TOKENS));
+
+/**
+ * Defines which SEARCH_TYPE_TOKENS must all be present for a given search mode to be selected.
+ *
+ * Entries are ordered most-specific first so that a multi-token match (e.g. `HYBRID_DATES`)
+ * is always found before a subset match (e.g. `HYBRID`) when iterating.
+ *
+ * This object drives both the SEARCH_TYPES slug derivation and the parseSearchTypeTokens
+ * resolution logic — adding a new search mode only requires a new entry here.
+ *
+ * @type {Readonly<Record<string, string[]>>}
+ */
+export const SEARCH_TYPE_RESOLUTIONS = Object.freeze({
+    HYBRID_DATES: [KEYWORD, SEMANTIC, DATES],
+    KEYWORD_DATES: [KEYWORD, DATES],
+    HYBRID: [KEYWORD, SEMANTIC],
+    KEYWORD: [KEYWORD],
+    SEMANTIC: [SEMANTIC]
+});
+
+/**
+ * Enumeration of supported search mode slugs.
+ *
+ * Defined explicitly rather than auto-derived from SEARCH_TYPE_RESOLUTIONS because
+ * the resolution token arrays use the primitive capability tokens (`keyword`, `semantic`)
+ * while the slugs use the semantic shorthand (`hybrid`). Keeping them separate avoids
+ * a join producing `keyword-semantic-dates` instead of `hybrid-dates`.
+ *
+ * | Key             | Resolving tokens                    | Slug             |
+ * |-----------------|-------------------------------------|------------------|
+ * | `HYBRID_DATES`  | `keyword` + `semantic` + `dates`    | `hybrid-dates`   |
+ * | `KEYWORD_DATES` | `keyword` + `dates`                 | `keyword-dates`  |
+ * | `HYBRID`        | `keyword` + `semantic`              | `hybrid`         |
+ * | `KEYWORD`       | `keyword`                           | `keyword`        |
+ * | `SEMANTIC`      | `semantic`                          | `semantic`       |
  *
  * @readonly
  * @enum {string}
  */
 const SEARCH_TYPES = Object.freeze({
-    /** Pure BM25 lexical match against chunk text. No date extraction. */
-    KEYWORD: 'keyword',
-    /** BM25 lexical match with date phrase extraction and format-variant expansion. */
+    HYBRID_DATES: 'hybrid-dates',
     KEYWORD_DATES: 'keyword-dates',
-    /** Neural embedding (ANN) search on semantic content. */
-    SEMANTIC: 'semantic',
-    /** Combined BM25 + neural search with configurable boost factors. No date extraction. */
     HYBRID: 'hybrid',
-    /** Combined BM25 + neural search with date phrase extraction and format-variant expansion. */
-    HYBRID_DATES: 'hybrid-dates'
+    KEYWORD: 'keyword',
+    SEMANTIC: 'semantic'
 });
 
 export default SEARCH_TYPES;
+
+/**
+ * The default search mode used when no `type` query parameter is provided.
+ *
+ * Centralised here so that every consumer (middleware, tests, docs) derives
+ * the value from the single source of truth in SEARCH_TYPES rather than
+ * repeating a magic string.
+ *
+ * @type {string}
+ */
+export const DEFAULT_SEARCH_TYPE = SEARCH_TYPES.HYBRID_DATES;
+
+/**
+ * Resolves a comma-delimited `type` query parameter value to a SEARCH_TYPES slug.
+ *
+ * The input is split on commas and each part is checked against SEARCH_TYPE_TOKENS.
+ * Parts that are not recognised tokens are collected into `unknownTokens` — callers
+ * should treat a non-empty `unknownTokens` array as an invalid request (e.g. 400).
+ * The remaining valid tokens are matched against SEARCH_TYPE_RESOLUTIONS (most-specific
+ * first) and the slug for the first full match is returned as `slug`.
+ *
+ * Accepts both a plain string or an array (as Express may produce when a query param
+ * appears multiple times); when an array is given, the last value is used.
+ *
+ * Returns `{ slug: undefined, unknownTokens: [] }` when value is absent or not a string,
+ * allowing callers to distinguish "param not present" from "param present but invalid".
+ *
+ * @param {unknown} value - Raw `req.query.type` value.
+ * @returns {{ slug: string | undefined, unknownTokens: string[] }}
+ *
+ * @example
+ * parseSearchTypeTokens('hybrid,dates')          // { slug: 'hybrid-dates', unknownTokens: [] }
+ * parseSearchTypeTokens('keyword,hybrid')        // { slug: 'hybrid', unknownTokens: [] }
+ * parseSearchTypeTokens('keyword,unknown,dates') // { slug: 'keyword-dates', unknownTokens: ['unknown'] }
+ * parseSearchTypeTokens('unknown')               // { slug: undefined, unknownTokens: ['unknown'] }
+ * parseSearchTypeTokens('dates')                 // { slug: undefined, unknownTokens: [] }
+ * parseSearchTypeTokens(undefined)               // { slug: undefined, unknownTokens: [] }
+ */
+export function parseSearchTypeTokens(value) {
+    // last occurrence of the query param wins. Accept both string and array input for
+    // flexibility in handling raw query values.
+    const raw = Array.isArray(value) ? value.at(-1) : value;
+
+    if (typeof raw !== 'string' || !raw.trim()) {
+        return { slug: undefined, unknownTokens: [] };
+    }
+
+    const parts = raw
+        .toLowerCase()
+        .split(',')
+        .map((token) => token.trim())
+        .filter(Boolean);
+
+    const unknownTokens = parts.filter((part) => !VALID_TOKEN_VALUES.has(part));
+    const tokens = new Set(parts.filter((part) => VALID_TOKEN_VALUES.has(part)));
+
+    if (tokens.size === 0) {
+        return { slug: undefined, unknownTokens };
+    }
+
+    // find the resolution whose token set exactly matches the valid input tokens.
+    for (const [searchType, searchTypeComponents] of Object.entries(SEARCH_TYPE_RESOLUTIONS)) {
+        if (
+            searchTypeComponents.length === tokens.size &&
+            searchTypeComponents.every((token) => tokens.has(token))
+        ) {
+            return { slug: SEARCH_TYPES[searchType], unknownTokens };
+        }
+    }
+
+    return { slug: undefined, unknownTokens };
+}

--- a/api/search/constants/searchTypes.js
+++ b/api/search/constants/searchTypes.js
@@ -1,7 +1,7 @@
 /**
- * Enumeration of supported search mode slugs.
+ * Enumeration of supported search mode values.
  *
- * These slugs are the canonical values accepted in the `type` URL query parameter.
+ * These values are the canonical enum values accepted in the `type` URL query parameter.
  *
  * @readonly
  * @enum {string}
@@ -17,22 +17,13 @@ const SEARCH_TYPES = Object.freeze({
 export default SEARCH_TYPES;
 
 /**
- * Direct lookup of supported URL search types.
+ * Supported URL `type` enum values used to validate incoming query values.
  *
- * The query-string `type` value is validated against this object and then passed
- * through unchanged to downstream search strategy selection.
- *
- * @type {Readonly<Record<string, string>>}
+ * @type {ReadonlySet<string>}
  */
-export const SEARCH_TYPE_RESOLUTIONS = Object.freeze({
-    [SEARCH_TYPES.HYBRID_DATES]: SEARCH_TYPES.HYBRID_DATES,
-    [SEARCH_TYPES.KEYWORD_DATES]: SEARCH_TYPES.KEYWORD_DATES,
-    [SEARCH_TYPES.HYBRID]: SEARCH_TYPES.HYBRID,
-    [SEARCH_TYPES.KEYWORD]: SEARCH_TYPES.KEYWORD,
-    [SEARCH_TYPES.SEMANTIC]: SEARCH_TYPES.SEMANTIC
-});
+export const VALID_SEARCH_TYPE_SET = Object.freeze(new Set(Object.values(SEARCH_TYPES)));
 
-export const VALID_SEARCH_TYPE_VALUES = Object.freeze(Object.keys(SEARCH_TYPE_RESOLUTIONS));
+export const VALID_SEARCH_TYPE_VALUES = Object.freeze(Array.from(VALID_SEARCH_TYPE_SET));
 
 /**
  * The default search mode used when no `type` query parameter is provided.
@@ -46,41 +37,42 @@ export const VALID_SEARCH_TYPE_VALUES = Object.freeze(Object.keys(SEARCH_TYPE_RE
 export const DEFAULT_SEARCH_TYPE = SEARCH_TYPES.HYBRID_DATES;
 
 /**
- * Resolves a `type` query parameter value to a supported SEARCH_TYPES slug.
+ * Resolves a `type` query parameter value to a supported SEARCH_TYPES enum value.
  *
- * The input is normalised to lowercase and matched directly against
- * SEARCH_TYPE_RESOLUTIONS, so the URL value and the internal search strategy key stay
- * aligned one to one.
+ * The input is normalised to lowercase and validated against VALID_SEARCH_TYPE_SET.
+ * Valid values pass through unchanged so URL and internal strategy key stay aligned.
  *
  * Accepts both a plain string or an array (as Express may produce when a query param
  * appears multiple times); when an array is given, the last value is used.
+ * Comma-delimited values (for example `type=keyword,semantic`) are treated as a
+ * single invalid value.
  *
- * Returns `{ slug: undefined, invalidValue: undefined }` when value is absent or not a
+ * Returns `{ searchType: undefined, invalidValue: undefined }` when value is absent or not a
  * string, allowing callers to distinguish "param not present" from "param present but
  * invalid".
  *
  * @param {unknown} value - Raw `req.query.type` value.
- * @returns {{ slug: string | undefined, invalidValue: string | undefined }}
+ * @returns {{ searchType: string | undefined, invalidValue: string | undefined }}
  *
  * @example
- * parseSearchType('hybrid-dates') // { slug: 'hybrid-dates', invalidValue: undefined }
- * parseSearchType('semantic')     // { slug: 'semantic', invalidValue: undefined }
- * parseSearchType('unknown')      // { slug: undefined, invalidValue: 'unknown' }
- * parseSearchType(undefined)      // { slug: undefined, invalidValue: undefined }
+ * parseSearchType('hybrid-dates') // { searchType: 'hybrid-dates', invalidValue: undefined }
+ * parseSearchType('semantic')     // { searchType: 'semantic', invalidValue: undefined }
+ * parseSearchType('unknown')      // { searchType: undefined, invalidValue: 'unknown' }
+ * parseSearchType(undefined)      // { searchType: undefined, invalidValue: undefined }
  */
 export function parseSearchType(value) {
     const raw = Array.isArray(value) ? value.at(-1) : value;
 
     if (typeof raw !== 'string' || !raw.trim()) {
-        return { slug: undefined, invalidValue: undefined };
+        return { searchType: undefined, invalidValue: undefined };
     }
 
     const normalized = raw.trim().toLowerCase();
-    const slug = SEARCH_TYPE_RESOLUTIONS[normalized];
+    const resolvedValue = VALID_SEARCH_TYPE_SET.has(normalized) ? normalized : undefined;
 
     return {
-        slug,
-        invalidValue: slug ? undefined : normalized
+        searchType: resolvedValue,
+        invalidValue: resolvedValue ? undefined : normalized
     };
 }
 

--- a/api/search/constants/searchTypes.js
+++ b/api/search/constants/searchTypes.js
@@ -1,0 +1,28 @@
+/**
+ * Enumeration of supported search modes.
+ *
+ * | Value             | Description                                                                 |
+ * |-------------------|-----------------------------------------------------------------------------|
+ * | `keyword`         | Pure BM25 lexical match. Fast, no neural overhead.                          |
+ * | `keyword-dates`   | BM25 lexical match with date extraction and variant expansion.              |
+ * | `semantic`        | Neural embedding (ANN) search on semantic content only.                     |
+ * | `hybrid`          | Combined BM25 + neural with configurable per-clause boost factors.          |
+ * | `hybrid-dates`    | Hybrid search with date extraction and variant expansion added to the mix.  |
+ *
+ * @readonly
+ * @enum {string}
+ */
+const SEARCH_TYPES = Object.freeze({
+    /** Pure BM25 lexical match against chunk text. No date extraction. */
+    KEYWORD: 'keyword',
+    /** BM25 lexical match with date phrase extraction and format-variant expansion. */
+    KEYWORD_DATES: 'keyword-dates',
+    /** Neural embedding (ANN) search on semantic content. */
+    SEMANTIC: 'semantic',
+    /** Combined BM25 + neural search with configurable boost factors. No date extraction. */
+    HYBRID: 'hybrid',
+    /** Combined BM25 + neural search with date phrase extraction and format-variant expansion. */
+    HYBRID_DATES: 'hybrid-dates'
+});
+
+export default SEARCH_TYPES;

--- a/api/search/constants/searchTypes.js
+++ b/api/search/constants/searchTypes.js
@@ -17,15 +17,6 @@ const SEARCH_TYPES = Object.freeze({
 export default SEARCH_TYPES;
 
 /**
- * Supported URL `type` enum values used to validate incoming query values.
- *
- * @type {ReadonlySet<string>}
- */
-export const VALID_SEARCH_TYPE_SET = Object.freeze(new Set(Object.values(SEARCH_TYPES)));
-
-export const VALID_SEARCH_TYPE_VALUES = Object.freeze(Array.from(VALID_SEARCH_TYPE_SET));
-
-/**
  * The default search mode used when no `type` query parameter is provided.
  *
  * Centralised here so that every consumer (middleware, tests, docs) derives
@@ -39,8 +30,9 @@ export const DEFAULT_SEARCH_TYPE = SEARCH_TYPES.HYBRID_DATES;
 /**
  * Resolves a `type` query parameter value to a supported SEARCH_TYPES enum value.
  *
- * The input is normalised to lowercase and validated against VALID_SEARCH_TYPE_SET.
- * Valid values pass through unchanged so URL and internal strategy key stay aligned.
+ * The input is normalised to lowercase and matched directly against
+ * SEARCH_TYPES values, so the URL value and the internal search strategy key stay
+ * aligned one to one.
  *
  * Accepts both a plain string or an array (as Express may produce when a query param
  * appears multiple times); when an array is given, the last value is used.
@@ -68,7 +60,7 @@ export function parseSearchType(value) {
     }
 
     const normalized = raw.trim().toLowerCase();
-    const resolvedValue = VALID_SEARCH_TYPE_SET.has(normalized) ? normalized : undefined;
+    const resolvedValue = Object.values(SEARCH_TYPES).includes(normalized) ? normalized : undefined;
 
     return {
         searchType: resolvedValue,

--- a/api/search/constants/searchTypes.js
+++ b/api/search/constants/searchTypes.js
@@ -1,7 +1,7 @@
 /**
- * Enumeration of supported search mode values.
+ * Enumeration of supported search type values.
  *
- * These values are the canonical enum values accepted in the `type` URL query parameter.
+ * These are the canonical values accepted in the `type` URL query parameter.
  *
  * @readonly
  * @enum {string}
@@ -28,7 +28,7 @@ export default SEARCH_TYPES;
 export const DEFAULT_SEARCH_TYPE = SEARCH_TYPES.HYBRID_DATES;
 
 /**
- * Resolves a `type` query parameter value to a supported SEARCH_TYPES enum value.
+ * Resolves a `type` query parameter value to a recognised SEARCH_TYPES value.
  *
  * The input is normalised to lowercase and matched directly against
  * SEARCH_TYPES values, so the URL value and the internal search strategy key stay
@@ -39,32 +39,32 @@ export const DEFAULT_SEARCH_TYPE = SEARCH_TYPES.HYBRID_DATES;
  * Comma-delimited values (for example `type=keyword,semantic`) are treated as a
  * single invalid value.
  *
- * Returns `{ searchType: undefined, invalidValue: undefined }` when value is absent or not a
+ * Returns `{ value: undefined, invalidValue: undefined }` when the input is absent or not a
  * string, allowing callers to distinguish "param not present" from "param present but
  * invalid".
  *
- * @param {unknown} value - Raw `req.query.type` value.
- * @returns {{ searchType: string | undefined, invalidValue: string | undefined }}
+ * @param {unknown} input - Raw `req.query.type` value.
+ * @returns {{ value: string | undefined, invalidValue: string | undefined }}
  *
  * @example
- * parseSearchType('hybrid-dates') // { searchType: 'hybrid-dates', invalidValue: undefined }
- * parseSearchType('semantic')     // { searchType: 'semantic', invalidValue: undefined }
- * parseSearchType('unknown')      // { searchType: undefined, invalidValue: 'unknown' }
- * parseSearchType(undefined)      // { searchType: undefined, invalidValue: undefined }
+ * parseSearchType('hybrid-dates') // { value: 'hybrid-dates', invalidValue: undefined }
+ * parseSearchType('semantic')     // { value: 'semantic', invalidValue: undefined }
+ * parseSearchType('unknown')      // { value: undefined, invalidValue: 'unknown' }
+ * parseSearchType(undefined)      // { value: undefined, invalidValue: undefined }
  */
-export function parseSearchType(value) {
-    const raw = Array.isArray(value) ? value.at(-1) : value;
+export function parseSearchType(input) {
+    const raw = Array.isArray(input) ? input.at(-1) : input;
 
     if (typeof raw !== 'string' || !raw.trim()) {
-        return { searchType: undefined, invalidValue: undefined };
+        return { value: undefined, invalidValue: undefined };
     }
 
     const normalized = raw.trim().toLowerCase();
-    const resolvedValue = Object.values(SEARCH_TYPES).includes(normalized) ? normalized : undefined;
+    const value = Object.values(SEARCH_TYPES).includes(normalized) ? normalized : undefined;
 
     return {
-        searchType: resolvedValue,
-        invalidValue: resolvedValue ? undefined : normalized
+        value,
+        invalidValue: value ? undefined : normalized
     };
 }
 

--- a/api/search/constants/searchTypes.js
+++ b/api/search/constants/searchTypes.js
@@ -1,9 +1,12 @@
 /**
  * The primitive capability tokens accepted in the `type` URL query parameter.
  *
- * These are the building blocks that callers combine in a comma-delimited string
- * (e.g. `?type=keyword,semantic,dates`) to select a search mode. Tokens are order-insensitive
- * and any unrecognised values in the string are silently ignored.
+ * Callers combine these in a comma-delimited string (e.g. `?type=keyword,semantic,dates`)
+ * to select a search mode. The token set must match a resolution in SEARCH_TYPE_RESOLUTIONS
+ * exactly — unrecognised tokens or valid-but-unresolvable combinations are rejected with a 400.
+ *
+ * Note: `hybrid` is retained as a recognised token value to avoid it being treated as unknown,
+ * but it is not used in any SEARCH_TYPE_RESOLUTIONS entry.
  *
  * @readonly
  * @enum {string}
@@ -19,13 +22,11 @@ const { KEYWORD, DATES, SEMANTIC } = SEARCH_TYPE_TOKENS;
 const VALID_TOKEN_VALUES = new Set(Object.values(SEARCH_TYPE_TOKENS));
 
 /**
- * Defines which SEARCH_TYPE_TOKENS must all be present for a given search mode to be selected.
+ * Defines the exact set of SEARCH_TYPE_TOKENS required to select each search mode.
  *
- * Entries are ordered most-specific first so that a multi-token match (e.g. `HYBRID_DATES`)
- * is always found before a subset match (e.g. `HYBRID`) when iterating.
- *
- * This object drives both the SEARCH_TYPES slug derivation and the parseSearchTypeTokens
- * resolution logic — adding a new search mode only requires a new entry here.
+ * Resolution uses an exact match — the input token set must equal a resolution's token
+ * array precisely (same tokens, same count). Entries are ordered most-specific first
+ * so that if the exact-match logic is ever relaxed, more specific modes still win.
  *
  * @type {Readonly<Record<string, string[]>>}
  */
@@ -96,12 +97,15 @@ export const DEFAULT_SEARCH_TYPE = SEARCH_TYPES.HYBRID_DATES;
  * @returns {{ slug: string | undefined, unknownTokens: string[] }}
  *
  * @example
- * parseSearchTypeTokens('hybrid,dates')          // { slug: 'hybrid-dates', unknownTokens: [] }
- * parseSearchTypeTokens('keyword,hybrid')        // { slug: 'hybrid', unknownTokens: [] }
- * parseSearchTypeTokens('keyword,unknown,dates') // { slug: 'keyword-dates', unknownTokens: ['unknown'] }
- * parseSearchTypeTokens('unknown')               // { slug: undefined, unknownTokens: ['unknown'] }
- * parseSearchTypeTokens('dates')                 // { slug: undefined, unknownTokens: [] }
- * parseSearchTypeTokens(undefined)               // { slug: undefined, unknownTokens: [] }
+ * parseSearchTypeTokens('keyword,semantic,dates') // { slug: 'hybrid-dates', unknownTokens: [] }
+ * parseSearchTypeTokens('keyword,semantic')        // { slug: 'hybrid', unknownTokens: [] }
+ * parseSearchTypeTokens('keyword,dates')           // { slug: 'keyword-dates', unknownTokens: [] }
+ * parseSearchTypeTokens('keyword')                 // { slug: 'keyword', unknownTokens: [] }
+ * parseSearchTypeTokens('semantic')                // { slug: 'semantic', unknownTokens: [] }
+ * parseSearchTypeTokens('semantic,dates')          // { slug: undefined, unknownTokens: [] }  — unresolvable
+ * parseSearchTypeTokens('keyword,unknown,dates')   // { slug: undefined, unknownTokens: ['unknown'] }
+ * parseSearchTypeTokens('unknown')                 // { slug: undefined, unknownTokens: ['unknown'] }
+ * parseSearchTypeTokens(undefined)                 // { slug: undefined, unknownTokens: [] }
  */
 export function parseSearchTypeTokens(value) {
     // last occurrence of the query param wins. Accept both string and array input for

--- a/api/search/constants/searchTypes.js
+++ b/api/search/constants/searchTypes.js
@@ -1,58 +1,7 @@
 /**
- * The primitive capability tokens accepted in the `type` URL query parameter.
- *
- * Callers combine these in a comma-delimited string (e.g. `?type=keyword,semantic,dates`)
- * to select a search mode. The token set must match a resolution in SEARCH_TYPE_RESOLUTIONS
- * exactly — unrecognised tokens or valid-but-unresolvable combinations are rejected with a 400.
- *
- * Note: `hybrid` is retained as a recognised token value to avoid it being treated as unknown,
- * but it is not used in any SEARCH_TYPE_RESOLUTIONS entry.
- *
- * @readonly
- * @enum {string}
- */
-export const SEARCH_TYPE_TOKENS = Object.freeze({
-    KEYWORD: 'keyword',
-    DATES: 'dates',
-    SEMANTIC: 'semantic',
-    HYBRID: 'hybrid'
-});
-
-const { KEYWORD, DATES, SEMANTIC } = SEARCH_TYPE_TOKENS;
-const VALID_TOKEN_VALUES = new Set(Object.values(SEARCH_TYPE_TOKENS));
-
-/**
- * Defines the exact set of SEARCH_TYPE_TOKENS required to select each search mode.
- *
- * Resolution uses an exact match — the input token set must equal a resolution's token
- * array precisely (same tokens, same count). Entries are ordered most-specific first
- * so that if the exact-match logic is ever relaxed, more specific modes still win.
- *
- * @type {Readonly<Record<string, string[]>>}
- */
-export const SEARCH_TYPE_RESOLUTIONS = Object.freeze({
-    HYBRID_DATES: [KEYWORD, SEMANTIC, DATES],
-    KEYWORD_DATES: [KEYWORD, DATES],
-    HYBRID: [KEYWORD, SEMANTIC],
-    KEYWORD: [KEYWORD],
-    SEMANTIC: [SEMANTIC]
-});
-
-/**
  * Enumeration of supported search mode slugs.
  *
- * Defined explicitly rather than auto-derived from SEARCH_TYPE_RESOLUTIONS because
- * the resolution token arrays use the primitive capability tokens (`keyword`, `semantic`)
- * while the slugs use the semantic shorthand (`hybrid`). Keeping them separate avoids
- * a join producing `keyword-semantic-dates` instead of `hybrid-dates`.
- *
- * | Key             | Resolving tokens                    | Slug             |
- * |-----------------|-------------------------------------|------------------|
- * | `HYBRID_DATES`  | `keyword` + `semantic` + `dates`    | `hybrid-dates`   |
- * | `KEYWORD_DATES` | `keyword` + `dates`                 | `keyword-dates`  |
- * | `HYBRID`        | `keyword` + `semantic`              | `hybrid`         |
- * | `KEYWORD`       | `keyword`                           | `keyword`        |
- * | `SEMANTIC`      | `semantic`                          | `semantic`       |
+ * These slugs are the canonical values accepted in the `type` URL query parameter.
  *
  * @readonly
  * @enum {string}
@@ -68,6 +17,24 @@ const SEARCH_TYPES = Object.freeze({
 export default SEARCH_TYPES;
 
 /**
+ * Direct lookup of supported URL search types.
+ *
+ * The query-string `type` value is validated against this object and then passed
+ * through unchanged to downstream search strategy selection.
+ *
+ * @type {Readonly<Record<string, string>>}
+ */
+export const SEARCH_TYPE_RESOLUTIONS = Object.freeze({
+    [SEARCH_TYPES.HYBRID_DATES]: SEARCH_TYPES.HYBRID_DATES,
+    [SEARCH_TYPES.KEYWORD_DATES]: SEARCH_TYPES.KEYWORD_DATES,
+    [SEARCH_TYPES.HYBRID]: SEARCH_TYPES.HYBRID,
+    [SEARCH_TYPES.KEYWORD]: SEARCH_TYPES.KEYWORD,
+    [SEARCH_TYPES.SEMANTIC]: SEARCH_TYPES.SEMANTIC
+});
+
+export const VALID_SEARCH_TYPE_VALUES = Object.freeze(Object.keys(SEARCH_TYPE_RESOLUTIONS));
+
+/**
  * The default search mode used when no `type` query parameter is provided.
  *
  * Centralised here so that every consumer (middleware, tests, docs) derives
@@ -79,65 +46,42 @@ export default SEARCH_TYPES;
 export const DEFAULT_SEARCH_TYPE = SEARCH_TYPES.HYBRID_DATES;
 
 /**
- * Resolves a comma-delimited `type` query parameter value to a SEARCH_TYPES slug.
+ * Resolves a `type` query parameter value to a supported SEARCH_TYPES slug.
  *
- * The input is split on commas and each part is checked against SEARCH_TYPE_TOKENS.
- * Parts that are not recognised tokens are collected into `unknownTokens` — callers
- * should treat a non-empty `unknownTokens` array as an invalid request (e.g. 400).
- * The remaining valid tokens are matched against SEARCH_TYPE_RESOLUTIONS (most-specific
- * first) and the slug for the first full match is returned as `slug`.
+ * The input is normalised to lowercase and matched directly against
+ * SEARCH_TYPE_RESOLUTIONS, so the URL value and the internal search strategy key stay
+ * aligned one to one.
  *
  * Accepts both a plain string or an array (as Express may produce when a query param
  * appears multiple times); when an array is given, the last value is used.
  *
- * Returns `{ slug: undefined, unknownTokens: [] }` when value is absent or not a string,
- * allowing callers to distinguish "param not present" from "param present but invalid".
+ * Returns `{ slug: undefined, invalidValue: undefined }` when value is absent or not a
+ * string, allowing callers to distinguish "param not present" from "param present but
+ * invalid".
  *
  * @param {unknown} value - Raw `req.query.type` value.
- * @returns {{ slug: string | undefined, unknownTokens: string[] }}
+ * @returns {{ slug: string | undefined, invalidValue: string | undefined }}
  *
  * @example
- * parseSearchTypeTokens('keyword,semantic,dates') // { slug: 'hybrid-dates', unknownTokens: [] }
- * parseSearchTypeTokens('keyword,semantic')        // { slug: 'hybrid', unknownTokens: [] }
- * parseSearchTypeTokens('keyword,dates')           // { slug: 'keyword-dates', unknownTokens: [] }
- * parseSearchTypeTokens('keyword')                 // { slug: 'keyword', unknownTokens: [] }
- * parseSearchTypeTokens('semantic')                // { slug: 'semantic', unknownTokens: [] }
- * parseSearchTypeTokens('semantic,dates')          // { slug: undefined, unknownTokens: [] }  — unresolvable
- * parseSearchTypeTokens('keyword,unknown,dates')   // { slug: undefined, unknownTokens: ['unknown'] }
- * parseSearchTypeTokens('unknown')                 // { slug: undefined, unknownTokens: ['unknown'] }
- * parseSearchTypeTokens(undefined)                 // { slug: undefined, unknownTokens: [] }
+ * parseSearchType('hybrid-dates') // { slug: 'hybrid-dates', invalidValue: undefined }
+ * parseSearchType('semantic')     // { slug: 'semantic', invalidValue: undefined }
+ * parseSearchType('unknown')      // { slug: undefined, invalidValue: 'unknown' }
+ * parseSearchType(undefined)      // { slug: undefined, invalidValue: undefined }
  */
-export function parseSearchTypeTokens(value) {
-    // last occurrence of the query param wins. Accept both string and array input for
-    // flexibility in handling raw query values.
+export function parseSearchType(value) {
     const raw = Array.isArray(value) ? value.at(-1) : value;
 
     if (typeof raw !== 'string' || !raw.trim()) {
-        return { slug: undefined, unknownTokens: [] };
+        return { slug: undefined, invalidValue: undefined };
     }
 
-    const parts = raw
-        .toLowerCase()
-        .split(',')
-        .map((token) => token.trim())
-        .filter(Boolean);
+    const normalized = raw.trim().toLowerCase();
+    const slug = SEARCH_TYPE_RESOLUTIONS[normalized];
 
-    const unknownTokens = parts.filter((part) => !VALID_TOKEN_VALUES.has(part));
-    const tokens = new Set(parts.filter((part) => VALID_TOKEN_VALUES.has(part)));
-
-    if (tokens.size === 0) {
-        return { slug: undefined, unknownTokens };
-    }
-
-    // find the resolution whose token set exactly matches the valid input tokens.
-    for (const [searchType, searchTypeComponents] of Object.entries(SEARCH_TYPE_RESOLUTIONS)) {
-        if (
-            searchTypeComponents.length === tokens.size &&
-            searchTypeComponents.every((token) => tokens.has(token))
-        ) {
-            return { slug: SEARCH_TYPES[searchType], unknownTokens };
-        }
-    }
-
-    return { slug: undefined, unknownTokens };
+    return {
+        slug,
+        invalidValue: slug ? undefined : normalized
+    };
 }
+
+export const parseSearchTypeTokens = parseSearchType;

--- a/api/search/constants/searchTypes.js
+++ b/api/search/constants/searchTypes.js
@@ -67,8 +67,11 @@ export function resolveSearchType(searchType, session = {}) {
         return normalisedSearchType;
     }
 
-    // direct session lookup rather than getFeatureFlagValue() to avoid a circular
+    // Direct session lookup rather than getFeatureFlagValue() to avoid a circular
     // dependency: featureFlags/index.js imports DEFAULT_SEARCH_TYPE from this module,
     // so importing getFeatureFlagValue back here would create a cycle.
-    return session?.featureFlags?.type || DEFAULT_SEARCH_TYPE;
+    // Validate the session value before using it — an unrecognised value should not
+    // be propagated into URLs or downstream query building.
+    const sessionType = session?.featureFlags?.type;
+    return Object.values(SEARCH_TYPES).includes(sessionType) ? sessionType : DEFAULT_SEARCH_TYPE;
 }

--- a/api/search/constants/searchTypes.test.js
+++ b/api/search/constants/searchTypes.test.js
@@ -4,23 +4,23 @@ import SEARCH_TYPES, {
     DEFAULT_SEARCH_TYPE,
     parseSearchType,
     parseSearchTypeTokens,
-    SEARCH_TYPE_RESOLUTIONS,
+    VALID_SEARCH_TYPE_SET,
     VALID_SEARCH_TYPE_VALUES
 } from './searchTypes.js';
 
-describe('SEARCH_TYPE_RESOLUTIONS', () => {
+describe('VALID_SEARCH_TYPE_SET', () => {
     it('should be frozen', () => {
-        assert.ok(Object.isFrozen(SEARCH_TYPE_RESOLUTIONS));
+        assert.ok(Object.isFrozen(VALID_SEARCH_TYPE_SET));
     });
 
-    it('should map each supported URL type directly to the same slug', () => {
-        assert.deepStrictEqual(SEARCH_TYPE_RESOLUTIONS, {
-            'hybrid-dates': 'hybrid-dates',
-            'keyword-dates': 'keyword-dates',
-            hybrid: 'hybrid',
-            keyword: 'keyword',
-            semantic: 'semantic'
-        });
+    it('should contain each supported URL type slug', () => {
+        assert.deepStrictEqual(Array.from(VALID_SEARCH_TYPE_SET), [
+            'hybrid-dates',
+            'keyword-dates',
+            'hybrid',
+            'keyword',
+            'semantic'
+        ]);
     });
 });
 
@@ -65,7 +65,7 @@ describe('parseSearchType', () => {
         for (const value of [undefined, null, 42, true, {}]) {
             it(`returns empty result for ${JSON.stringify(value)}`, () => {
                 assert.deepStrictEqual(parseSearchType(value), {
-                    slug: undefined,
+                    searchType: undefined,
                     invalidValue: undefined
                 });
             });
@@ -73,14 +73,14 @@ describe('parseSearchType', () => {
 
         it('returns empty result for an empty string', () => {
             assert.deepStrictEqual(parseSearchType(''), {
-                slug: undefined,
+                searchType: undefined,
                 invalidValue: undefined
             });
         });
 
         it('returns empty result for a whitespace-only string', () => {
             assert.deepStrictEqual(parseSearchType('   '), {
-                slug: undefined,
+                searchType: undefined,
                 invalidValue: undefined
             });
         });
@@ -89,52 +89,52 @@ describe('parseSearchType', () => {
     describe('when value is an array', () => {
         it('uses the last element of the array', () => {
             assert.deepStrictEqual(parseSearchType(['keyword', 'semantic']), {
-                slug: 'semantic',
+                searchType: 'semantic',
                 invalidValue: undefined
             });
         });
 
         it('returns empty result when the last element is not a string', () => {
             assert.deepStrictEqual(parseSearchType(['keyword', undefined]), {
-                slug: undefined,
+                searchType: undefined,
                 invalidValue: undefined
             });
         });
     });
 
-    describe('supported slug inputs', () => {
-        it('resolves supported slugs directly', () => {
+    describe('supported enum values', () => {
+        it('resolves supported values directly', () => {
             assert.deepStrictEqual(parseSearchType('hybrid-dates'), {
-                slug: 'hybrid-dates',
+                searchType: 'hybrid-dates',
                 invalidValue: undefined
             });
             assert.deepStrictEqual(parseSearchType('keyword-dates'), {
-                slug: 'keyword-dates',
+                searchType: 'keyword-dates',
                 invalidValue: undefined
             });
             assert.deepStrictEqual(parseSearchType('hybrid'), {
-                slug: 'hybrid',
+                searchType: 'hybrid',
                 invalidValue: undefined
             });
             assert.deepStrictEqual(parseSearchType('keyword'), {
-                slug: 'keyword',
+                searchType: 'keyword',
                 invalidValue: undefined
             });
             assert.deepStrictEqual(parseSearchType('semantic'), {
-                slug: 'semantic',
+                searchType: 'semantic',
                 invalidValue: undefined
             });
         });
     });
 
     describe('invalid inputs', () => {
-        it('returns the invalid value when the slug is not supported', () => {
+        it('returns the invalid value when the value is not supported', () => {
             assert.deepStrictEqual(parseSearchType('unknown'), {
-                slug: undefined,
+                searchType: undefined,
                 invalidValue: 'unknown'
             });
             assert.deepStrictEqual(parseSearchType('foo,bar'), {
-                slug: undefined,
+                searchType: undefined,
                 invalidValue: 'foo,bar'
             });
         });
@@ -143,18 +143,18 @@ describe('parseSearchType', () => {
     describe('whitespace and case handling', () => {
         it('trims whitespace around values', () => {
             assert.deepStrictEqual(parseSearchType(' hybrid-dates '), {
-                slug: 'hybrid-dates',
+                searchType: 'hybrid-dates',
                 invalidValue: undefined
             });
         });
 
         it('is case-insensitive', () => {
             assert.deepStrictEqual(parseSearchType('KEYWORD-DATES'), {
-                slug: 'keyword-dates',
+                searchType: 'keyword-dates',
                 invalidValue: undefined
             });
             assert.deepStrictEqual(parseSearchType('SEMANTIC'), {
-                slug: 'semantic',
+                searchType: 'semantic',
                 invalidValue: undefined
             });
         });
@@ -164,7 +164,7 @@ describe('parseSearchType', () => {
 describe('parseSearchTypeTokens', () => {
     it('remains an alias of parseSearchType for compatibility', () => {
         assert.deepStrictEqual(parseSearchTypeTokens('HYBRID-DATES'), {
-            slug: 'hybrid-dates',
+            searchType: 'hybrid-dates',
             invalidValue: undefined
         });
     });

--- a/api/search/constants/searchTypes.test.js
+++ b/api/search/constants/searchTypes.test.js
@@ -35,7 +35,7 @@ describe('parseSearchType', () => {
         for (const value of [undefined, null, 42, true, {}]) {
             it(`returns empty result for ${JSON.stringify(value)}`, () => {
                 assert.deepStrictEqual(parseSearchType(value), {
-                    searchType: undefined,
+                    value: undefined,
                     invalidValue: undefined
                 });
             });
@@ -43,14 +43,14 @@ describe('parseSearchType', () => {
 
         it('returns empty result for an empty string', () => {
             assert.deepStrictEqual(parseSearchType(''), {
-                searchType: undefined,
+                value: undefined,
                 invalidValue: undefined
             });
         });
 
         it('returns empty result for a whitespace-only string', () => {
             assert.deepStrictEqual(parseSearchType('   '), {
-                searchType: undefined,
+                value: undefined,
                 invalidValue: undefined
             });
         });
@@ -59,52 +59,52 @@ describe('parseSearchType', () => {
     describe('when value is an array', () => {
         it('uses the last element of the array', () => {
             assert.deepStrictEqual(parseSearchType(['keyword', 'semantic']), {
-                searchType: 'semantic',
+                value: 'semantic',
                 invalidValue: undefined
             });
         });
 
         it('returns empty result when the last element is not a string', () => {
             assert.deepStrictEqual(parseSearchType(['keyword', undefined]), {
-                searchType: undefined,
+                value: undefined,
                 invalidValue: undefined
             });
         });
     });
 
-    describe('supported enum values', () => {
+    describe('supported type values', () => {
         it('resolves supported values directly', () => {
             assert.deepStrictEqual(parseSearchType('hybrid-dates'), {
-                searchType: 'hybrid-dates',
+                value: 'hybrid-dates',
                 invalidValue: undefined
             });
             assert.deepStrictEqual(parseSearchType('keyword-dates'), {
-                searchType: 'keyword-dates',
+                value: 'keyword-dates',
                 invalidValue: undefined
             });
             assert.deepStrictEqual(parseSearchType('hybrid'), {
-                searchType: 'hybrid',
+                value: 'hybrid',
                 invalidValue: undefined
             });
             assert.deepStrictEqual(parseSearchType('keyword'), {
-                searchType: 'keyword',
+                value: 'keyword',
                 invalidValue: undefined
             });
             assert.deepStrictEqual(parseSearchType('semantic'), {
-                searchType: 'semantic',
+                value: 'semantic',
                 invalidValue: undefined
             });
         });
     });
 
     describe('invalid inputs', () => {
-        it('returns the invalid value when the value is not supported', () => {
+        it('returns the invalid value when the type is not recognised', () => {
             assert.deepStrictEqual(parseSearchType('unknown'), {
-                searchType: undefined,
+                value: undefined,
                 invalidValue: 'unknown'
             });
             assert.deepStrictEqual(parseSearchType('foo,bar'), {
-                searchType: undefined,
+                value: undefined,
                 invalidValue: 'foo,bar'
             });
         });
@@ -113,18 +113,18 @@ describe('parseSearchType', () => {
     describe('whitespace and case handling', () => {
         it('trims whitespace around values', () => {
             assert.deepStrictEqual(parseSearchType(' hybrid-dates '), {
-                searchType: 'hybrid-dates',
+                value: 'hybrid-dates',
                 invalidValue: undefined
             });
         });
 
         it('is case-insensitive', () => {
             assert.deepStrictEqual(parseSearchType('KEYWORD-DATES'), {
-                searchType: 'keyword-dates',
+                value: 'keyword-dates',
                 invalidValue: undefined
             });
             assert.deepStrictEqual(parseSearchType('SEMANTIC'), {
-                searchType: 'semantic',
+                value: 'semantic',
                 invalidValue: undefined
             });
         });
@@ -134,7 +134,7 @@ describe('parseSearchType', () => {
 describe('parseSearchTypeTokens', () => {
     it('remains an alias of parseSearchType for compatibility', () => {
         assert.deepStrictEqual(parseSearchTypeTokens('HYBRID-DATES'), {
-            searchType: 'hybrid-dates',
+            value: 'hybrid-dates',
             invalidValue: undefined
         });
     });

--- a/api/search/constants/searchTypes.test.js
+++ b/api/search/constants/searchTypes.test.js
@@ -1,0 +1,247 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import SEARCH_TYPES, {
+    DEFAULT_SEARCH_TYPE,
+    parseSearchTypeTokens,
+    SEARCH_TYPE_RESOLUTIONS,
+    SEARCH_TYPE_TOKENS
+} from './searchTypes.js';
+
+describe('SEARCH_TYPE_TOKENS', () => {
+    it('should be frozen', () => {
+        assert.ok(Object.isFrozen(SEARCH_TYPE_TOKENS));
+    });
+
+    it('should contain the expected token values', () => {
+        assert.deepStrictEqual(SEARCH_TYPE_TOKENS, {
+            KEYWORD: 'keyword',
+            DATES: 'dates',
+            SEMANTIC: 'semantic',
+            HYBRID: 'hybrid'
+        });
+    });
+});
+
+describe('SEARCH_TYPE_RESOLUTIONS', () => {
+    it('should be frozen', () => {
+        assert.ok(Object.isFrozen(SEARCH_TYPE_RESOLUTIONS));
+    });
+
+    it('should list HYBRID_DATES before HYBRID (most-specific first)', () => {
+        const keys = Object.keys(SEARCH_TYPE_RESOLUTIONS);
+        assert.ok(keys.indexOf('HYBRID_DATES') < keys.indexOf('HYBRID'));
+    });
+
+    it('should list KEYWORD_DATES before KEYWORD (most-specific first)', () => {
+        const keys = Object.keys(SEARCH_TYPE_RESOLUTIONS);
+        assert.ok(keys.indexOf('KEYWORD_DATES') < keys.indexOf('KEYWORD'));
+    });
+
+    it('should define correct token arrays for each search mode', () => {
+        assert.deepStrictEqual(SEARCH_TYPE_RESOLUTIONS.HYBRID_DATES, [
+            'keyword',
+            'semantic',
+            'dates'
+        ]);
+        assert.deepStrictEqual(SEARCH_TYPE_RESOLUTIONS.KEYWORD_DATES, ['keyword', 'dates']);
+        assert.deepStrictEqual(SEARCH_TYPE_RESOLUTIONS.HYBRID, ['keyword', 'semantic']);
+        assert.deepStrictEqual(SEARCH_TYPE_RESOLUTIONS.KEYWORD, ['keyword']);
+        assert.deepStrictEqual(SEARCH_TYPE_RESOLUTIONS.SEMANTIC, ['semantic']);
+    });
+});
+
+describe('SEARCH_TYPES (default export)', () => {
+    it('should be frozen', () => {
+        assert.ok(Object.isFrozen(SEARCH_TYPES));
+    });
+
+    it('should map each key to the correct slug', () => {
+        assert.strictEqual(SEARCH_TYPES.HYBRID_DATES, 'hybrid-dates');
+        assert.strictEqual(SEARCH_TYPES.KEYWORD_DATES, 'keyword-dates');
+        assert.strictEqual(SEARCH_TYPES.HYBRID, 'hybrid');
+        assert.strictEqual(SEARCH_TYPES.KEYWORD, 'keyword');
+        assert.strictEqual(SEARCH_TYPES.SEMANTIC, 'semantic');
+    });
+});
+
+describe('DEFAULT_SEARCH_TYPE', () => {
+    it('should equal SEARCH_TYPES.HYBRID_DATES', () => {
+        assert.strictEqual(DEFAULT_SEARCH_TYPE, SEARCH_TYPES.HYBRID_DATES);
+    });
+
+    it('should equal "hybrid-dates"', () => {
+        assert.strictEqual(DEFAULT_SEARCH_TYPE, 'hybrid-dates');
+    });
+});
+
+describe('parseSearchTypeTokens', () => {
+    describe('when value is absent or not a usable string', () => {
+        for (const value of [undefined, null, 42, true, {}]) {
+            it(`returns empty result for ${JSON.stringify(value)}`, () => {
+                assert.deepStrictEqual(parseSearchTypeTokens(value), {
+                    slug: undefined,
+                    unknownTokens: []
+                });
+            });
+        }
+
+        it('returns empty result for an empty string', () => {
+            assert.deepStrictEqual(parseSearchTypeTokens(''), {
+                slug: undefined,
+                unknownTokens: []
+            });
+        });
+
+        it('returns empty result for a whitespace-only string', () => {
+            assert.deepStrictEqual(parseSearchTypeTokens('   '), {
+                slug: undefined,
+                unknownTokens: []
+            });
+        });
+    });
+
+    describe('when value is an array', () => {
+        it('uses the last element of the array', () => {
+            assert.deepStrictEqual(parseSearchTypeTokens(['keyword', 'keyword,semantic']), {
+                slug: 'hybrid',
+                unknownTokens: []
+            });
+        });
+
+        it('returns empty result when the last element is not a string', () => {
+            assert.deepStrictEqual(parseSearchTypeTokens(['keyword', undefined]), {
+                slug: undefined,
+                unknownTokens: []
+            });
+        });
+    });
+
+    describe('single-token inputs', () => {
+        it('does not resolve "hybrid" alone (no single-token resolution for hybrid)', () => {
+            assert.deepStrictEqual(parseSearchTypeTokens('hybrid'), {
+                slug: undefined,
+                unknownTokens: []
+            });
+        });
+
+        it('resolves "keyword" to slug "keyword"', () => {
+            assert.deepStrictEqual(parseSearchTypeTokens('keyword'), {
+                slug: 'keyword',
+                unknownTokens: []
+            });
+        });
+
+        it('resolves "semantic" to slug "semantic"', () => {
+            assert.deepStrictEqual(parseSearchTypeTokens('semantic'), {
+                slug: 'semantic',
+                unknownTokens: []
+            });
+        });
+
+        it('returns slug undefined for "dates" alone (no matching resolution)', () => {
+            assert.deepStrictEqual(parseSearchTypeTokens('dates'), {
+                slug: undefined,
+                unknownTokens: []
+            });
+        });
+
+        it('returns slug undefined for "semantic,dates" (no exact resolution for this combination)', () => {
+            assert.deepStrictEqual(parseSearchTypeTokens('semantic,dates'), {
+                slug: undefined,
+                unknownTokens: []
+            });
+        });
+    });
+
+    describe('multi-token inputs — most-specific match wins', () => {
+        it('resolves "keyword,semantic,dates" to slug "hybrid-dates"', () => {
+            assert.deepStrictEqual(parseSearchTypeTokens('keyword,semantic,dates'), {
+                slug: 'hybrid-dates',
+                unknownTokens: []
+            });
+        });
+
+        it('resolves "dates,semantic,keyword" (any order) to slug "hybrid-dates"', () => {
+            assert.deepStrictEqual(parseSearchTypeTokens('dates,semantic,keyword'), {
+                slug: 'hybrid-dates',
+                unknownTokens: []
+            });
+        });
+
+        it('resolves "keyword,dates" to slug "keyword-dates"', () => {
+            assert.deepStrictEqual(parseSearchTypeTokens('keyword,dates'), {
+                slug: 'keyword-dates',
+                unknownTokens: []
+            });
+        });
+
+        it('resolves "keyword,semantic" to slug "hybrid" (no dates token)', () => {
+            assert.deepStrictEqual(parseSearchTypeTokens('keyword,semantic'), {
+                slug: 'hybrid',
+                unknownTokens: []
+            });
+        });
+    });
+
+    describe('inputs with unknown tokens', () => {
+        it('collects unknown tokens and still resolves the slug when valid tokens are sufficient', () => {
+            assert.deepStrictEqual(parseSearchTypeTokens('keyword,unknown,dates'), {
+                slug: 'keyword-dates',
+                unknownTokens: ['unknown']
+            });
+        });
+
+        it('returns slug undefined when the only token is unknown', () => {
+            assert.deepStrictEqual(parseSearchTypeTokens('unknown'), {
+                slug: undefined,
+                unknownTokens: ['unknown']
+            });
+        });
+
+        it('collects multiple unknown tokens', () => {
+            assert.deepStrictEqual(parseSearchTypeTokens('foo,bar'), {
+                slug: undefined,
+                unknownTokens: ['foo', 'bar']
+            });
+        });
+
+        it('collects unknown tokens even when valid tokens produce no matching resolution', () => {
+            assert.deepStrictEqual(parseSearchTypeTokens('dates,foo'), {
+                slug: undefined,
+                unknownTokens: ['foo']
+            });
+        });
+    });
+
+    describe('whitespace and case handling', () => {
+        it('trims whitespace around tokens', () => {
+            assert.deepStrictEqual(parseSearchTypeTokens(' keyword , semantic , dates '), {
+                slug: 'hybrid-dates',
+                unknownTokens: []
+            });
+        });
+
+        it('is case-insensitive', () => {
+            assert.deepStrictEqual(parseSearchTypeTokens('KEYWORD,SEMANTIC,DATES'), {
+                slug: 'hybrid-dates',
+                unknownTokens: []
+            });
+        });
+
+        it('handles mixed case', () => {
+            assert.deepStrictEqual(parseSearchTypeTokens('Keyword,Dates'), {
+                slug: 'keyword-dates',
+                unknownTokens: []
+            });
+        });
+    });
+
+    describe('duplicate tokens', () => {
+        it('treats duplicate valid tokens as a single token (set deduplication)', () => {
+            assert.deepStrictEqual(parseSearchTypeTokens('keyword,keyword'), {
+                slug: 'keyword',
+                unknownTokens: []
+            });
+        });
+    });
+});

--- a/api/search/constants/searchTypes.test.js
+++ b/api/search/constants/searchTypes.test.js
@@ -75,6 +75,16 @@ describe('resolveSearchType', () => {
                 DEFAULT_SEARCH_TYPE
             );
         });
+
+        it('returns DEFAULT_SEARCH_TYPE when the session feature-flag type is not a recognised value', () => {
+            const session = { featureFlags: { type: 'not-a-real-type' } };
+            assert.strictEqual(resolveSearchType('unknown', session), DEFAULT_SEARCH_TYPE);
+        });
+
+        it('returns DEFAULT_SEARCH_TYPE when the session feature-flag type is a comma-separated invalid value', () => {
+            const session = { featureFlags: { type: 'keyword,semantic' } };
+            assert.strictEqual(resolveSearchType('unknown', session), DEFAULT_SEARCH_TYPE);
+        });
     });
 
     describe('whitespace and case handling', () => {

--- a/api/search/constants/searchTypes.test.js
+++ b/api/search/constants/searchTypes.test.js
@@ -2,51 +2,37 @@ import assert from 'node:assert';
 import { describe, it } from 'node:test';
 import SEARCH_TYPES, {
     DEFAULT_SEARCH_TYPE,
+    parseSearchType,
     parseSearchTypeTokens,
     SEARCH_TYPE_RESOLUTIONS,
-    SEARCH_TYPE_TOKENS
+    VALID_SEARCH_TYPE_VALUES
 } from './searchTypes.js';
-
-describe('SEARCH_TYPE_TOKENS', () => {
-    it('should be frozen', () => {
-        assert.ok(Object.isFrozen(SEARCH_TYPE_TOKENS));
-    });
-
-    it('should contain the expected token values', () => {
-        assert.deepStrictEqual(SEARCH_TYPE_TOKENS, {
-            KEYWORD: 'keyword',
-            DATES: 'dates',
-            SEMANTIC: 'semantic',
-            HYBRID: 'hybrid'
-        });
-    });
-});
 
 describe('SEARCH_TYPE_RESOLUTIONS', () => {
     it('should be frozen', () => {
         assert.ok(Object.isFrozen(SEARCH_TYPE_RESOLUTIONS));
     });
 
-    it('should list HYBRID_DATES before HYBRID (most-specific first)', () => {
-        const keys = Object.keys(SEARCH_TYPE_RESOLUTIONS);
-        assert.ok(keys.indexOf('HYBRID_DATES') < keys.indexOf('HYBRID'));
+    it('should map each supported URL type directly to the same slug', () => {
+        assert.deepStrictEqual(SEARCH_TYPE_RESOLUTIONS, {
+            'hybrid-dates': 'hybrid-dates',
+            'keyword-dates': 'keyword-dates',
+            hybrid: 'hybrid',
+            keyword: 'keyword',
+            semantic: 'semantic'
+        });
     });
+});
 
-    it('should list KEYWORD_DATES before KEYWORD (most-specific first)', () => {
-        const keys = Object.keys(SEARCH_TYPE_RESOLUTIONS);
-        assert.ok(keys.indexOf('KEYWORD_DATES') < keys.indexOf('KEYWORD'));
-    });
-
-    it('should define correct token arrays for each search mode', () => {
-        assert.deepStrictEqual(SEARCH_TYPE_RESOLUTIONS.HYBRID_DATES, [
+describe('VALID_SEARCH_TYPE_VALUES', () => {
+    it('should contain every supported URL type value', () => {
+        assert.deepStrictEqual(VALID_SEARCH_TYPE_VALUES, [
+            'hybrid-dates',
+            'keyword-dates',
+            'hybrid',
             'keyword',
-            'semantic',
-            'dates'
+            'semantic'
         ]);
-        assert.deepStrictEqual(SEARCH_TYPE_RESOLUTIONS.KEYWORD_DATES, ['keyword', 'dates']);
-        assert.deepStrictEqual(SEARCH_TYPE_RESOLUTIONS.HYBRID, ['keyword', 'semantic']);
-        assert.deepStrictEqual(SEARCH_TYPE_RESOLUTIONS.KEYWORD, ['keyword']);
-        assert.deepStrictEqual(SEARCH_TYPE_RESOLUTIONS.SEMANTIC, ['semantic']);
     });
 });
 
@@ -74,174 +60,112 @@ describe('DEFAULT_SEARCH_TYPE', () => {
     });
 });
 
-describe('parseSearchTypeTokens', () => {
+describe('parseSearchType', () => {
     describe('when value is absent or not a usable string', () => {
         for (const value of [undefined, null, 42, true, {}]) {
             it(`returns empty result for ${JSON.stringify(value)}`, () => {
-                assert.deepStrictEqual(parseSearchTypeTokens(value), {
+                assert.deepStrictEqual(parseSearchType(value), {
                     slug: undefined,
-                    unknownTokens: []
+                    invalidValue: undefined
                 });
             });
         }
 
         it('returns empty result for an empty string', () => {
-            assert.deepStrictEqual(parseSearchTypeTokens(''), {
+            assert.deepStrictEqual(parseSearchType(''), {
                 slug: undefined,
-                unknownTokens: []
+                invalidValue: undefined
             });
         });
 
         it('returns empty result for a whitespace-only string', () => {
-            assert.deepStrictEqual(parseSearchTypeTokens('   '), {
+            assert.deepStrictEqual(parseSearchType('   '), {
                 slug: undefined,
-                unknownTokens: []
+                invalidValue: undefined
             });
         });
     });
 
     describe('when value is an array', () => {
         it('uses the last element of the array', () => {
-            assert.deepStrictEqual(parseSearchTypeTokens(['keyword', 'keyword,semantic']), {
-                slug: 'hybrid',
-                unknownTokens: []
+            assert.deepStrictEqual(parseSearchType(['keyword', 'semantic']), {
+                slug: 'semantic',
+                invalidValue: undefined
             });
         });
 
         it('returns empty result when the last element is not a string', () => {
-            assert.deepStrictEqual(parseSearchTypeTokens(['keyword', undefined]), {
+            assert.deepStrictEqual(parseSearchType(['keyword', undefined]), {
                 slug: undefined,
-                unknownTokens: []
+                invalidValue: undefined
             });
         });
     });
 
-    describe('single-token inputs', () => {
-        it('does not resolve "hybrid" alone (no single-token resolution for hybrid)', () => {
-            assert.deepStrictEqual(parseSearchTypeTokens('hybrid'), {
-                slug: undefined,
-                unknownTokens: []
-            });
-        });
-
-        it('resolves "keyword" to slug "keyword"', () => {
-            assert.deepStrictEqual(parseSearchTypeTokens('keyword'), {
-                slug: 'keyword',
-                unknownTokens: []
-            });
-        });
-
-        it('resolves "semantic" to slug "semantic"', () => {
-            assert.deepStrictEqual(parseSearchTypeTokens('semantic'), {
-                slug: 'semantic',
-                unknownTokens: []
-            });
-        });
-
-        it('returns slug undefined for "dates" alone (no matching resolution)', () => {
-            assert.deepStrictEqual(parseSearchTypeTokens('dates'), {
-                slug: undefined,
-                unknownTokens: []
-            });
-        });
-
-        it('returns slug undefined for "semantic,dates" (no exact resolution for this combination)', () => {
-            assert.deepStrictEqual(parseSearchTypeTokens('semantic,dates'), {
-                slug: undefined,
-                unknownTokens: []
-            });
-        });
-    });
-
-    describe('multi-token inputs — most-specific match wins', () => {
-        it('resolves "keyword,semantic,dates" to slug "hybrid-dates"', () => {
-            assert.deepStrictEqual(parseSearchTypeTokens('keyword,semantic,dates'), {
+    describe('supported slug inputs', () => {
+        it('resolves supported slugs directly', () => {
+            assert.deepStrictEqual(parseSearchType('hybrid-dates'), {
                 slug: 'hybrid-dates',
-                unknownTokens: []
+                invalidValue: undefined
             });
-        });
-
-        it('resolves "dates,semantic,keyword" (any order) to slug "hybrid-dates"', () => {
-            assert.deepStrictEqual(parseSearchTypeTokens('dates,semantic,keyword'), {
-                slug: 'hybrid-dates',
-                unknownTokens: []
-            });
-        });
-
-        it('resolves "keyword,dates" to slug "keyword-dates"', () => {
-            assert.deepStrictEqual(parseSearchTypeTokens('keyword,dates'), {
+            assert.deepStrictEqual(parseSearchType('keyword-dates'), {
                 slug: 'keyword-dates',
-                unknownTokens: []
+                invalidValue: undefined
             });
-        });
-
-        it('resolves "keyword,semantic" to slug "hybrid" (no dates token)', () => {
-            assert.deepStrictEqual(parseSearchTypeTokens('keyword,semantic'), {
+            assert.deepStrictEqual(parseSearchType('hybrid'), {
                 slug: 'hybrid',
-                unknownTokens: []
+                invalidValue: undefined
+            });
+            assert.deepStrictEqual(parseSearchType('keyword'), {
+                slug: 'keyword',
+                invalidValue: undefined
+            });
+            assert.deepStrictEqual(parseSearchType('semantic'), {
+                slug: 'semantic',
+                invalidValue: undefined
             });
         });
     });
 
-    describe('inputs with unknown tokens', () => {
-        it('collects unknown tokens and still resolves the slug when valid tokens are sufficient', () => {
-            assert.deepStrictEqual(parseSearchTypeTokens('keyword,unknown,dates'), {
-                slug: 'keyword-dates',
-                unknownTokens: ['unknown']
-            });
-        });
-
-        it('returns slug undefined when the only token is unknown', () => {
-            assert.deepStrictEqual(parseSearchTypeTokens('unknown'), {
+    describe('invalid inputs', () => {
+        it('returns the invalid value when the slug is not supported', () => {
+            assert.deepStrictEqual(parseSearchType('unknown'), {
                 slug: undefined,
-                unknownTokens: ['unknown']
+                invalidValue: 'unknown'
             });
-        });
-
-        it('collects multiple unknown tokens', () => {
-            assert.deepStrictEqual(parseSearchTypeTokens('foo,bar'), {
+            assert.deepStrictEqual(parseSearchType('foo,bar'), {
                 slug: undefined,
-                unknownTokens: ['foo', 'bar']
-            });
-        });
-
-        it('collects unknown tokens even when valid tokens produce no matching resolution', () => {
-            assert.deepStrictEqual(parseSearchTypeTokens('dates,foo'), {
-                slug: undefined,
-                unknownTokens: ['foo']
+                invalidValue: 'foo,bar'
             });
         });
     });
 
     describe('whitespace and case handling', () => {
-        it('trims whitespace around tokens', () => {
-            assert.deepStrictEqual(parseSearchTypeTokens(' keyword , semantic , dates '), {
+        it('trims whitespace around values', () => {
+            assert.deepStrictEqual(parseSearchType(' hybrid-dates '), {
                 slug: 'hybrid-dates',
-                unknownTokens: []
+                invalidValue: undefined
             });
         });
 
         it('is case-insensitive', () => {
-            assert.deepStrictEqual(parseSearchTypeTokens('KEYWORD,SEMANTIC,DATES'), {
-                slug: 'hybrid-dates',
-                unknownTokens: []
-            });
-        });
-
-        it('handles mixed case', () => {
-            assert.deepStrictEqual(parseSearchTypeTokens('Keyword,Dates'), {
+            assert.deepStrictEqual(parseSearchType('KEYWORD-DATES'), {
                 slug: 'keyword-dates',
-                unknownTokens: []
+                invalidValue: undefined
+            });
+            assert.deepStrictEqual(parseSearchType('SEMANTIC'), {
+                slug: 'semantic',
+                invalidValue: undefined
             });
         });
     });
+});
 
-    describe('duplicate tokens', () => {
-        it('treats duplicate valid tokens as a single token (set deduplication)', () => {
-            assert.deepStrictEqual(parseSearchTypeTokens('keyword,keyword'), {
-                slug: 'keyword',
-                unknownTokens: []
-            });
+describe('parseSearchTypeTokens', () => {
+    it('remains an alias of parseSearchType for compatibility', () => {
+        assert.deepStrictEqual(parseSearchTypeTokens('HYBRID-DATES'), {
+            slug: 'hybrid-dates',
+            invalidValue: undefined
         });
     });
 });

--- a/api/search/constants/searchTypes.test.js
+++ b/api/search/constants/searchTypes.test.js
@@ -13,7 +13,7 @@ describe('VALID_SEARCH_TYPE_SET', () => {
         assert.ok(Object.isFrozen(VALID_SEARCH_TYPE_SET));
     });
 
-    it('should contain each supported URL type slug', () => {
+    it('should contain each supported URL type value', () => {
         assert.deepStrictEqual(Array.from(VALID_SEARCH_TYPE_SET), [
             'hybrid-dates',
             'keyword-dates',
@@ -41,7 +41,7 @@ describe('SEARCH_TYPES (default export)', () => {
         assert.ok(Object.isFrozen(SEARCH_TYPES));
     });
 
-    it('should map each key to the correct slug', () => {
+    it('should map each key to the correct value', () => {
         assert.strictEqual(SEARCH_TYPES.HYBRID_DATES, 'hybrid-dates');
         assert.strictEqual(SEARCH_TYPES.KEYWORD_DATES, 'keyword-dates');
         assert.strictEqual(SEARCH_TYPES.HYBRID, 'hybrid');

--- a/api/search/constants/searchTypes.test.js
+++ b/api/search/constants/searchTypes.test.js
@@ -3,38 +3,8 @@ import { describe, it } from 'node:test';
 import SEARCH_TYPES, {
     DEFAULT_SEARCH_TYPE,
     parseSearchType,
-    parseSearchTypeTokens,
-    VALID_SEARCH_TYPE_SET,
-    VALID_SEARCH_TYPE_VALUES
+    parseSearchTypeTokens
 } from './searchTypes.js';
-
-describe('VALID_SEARCH_TYPE_SET', () => {
-    it('should be frozen', () => {
-        assert.ok(Object.isFrozen(VALID_SEARCH_TYPE_SET));
-    });
-
-    it('should contain each supported URL type value', () => {
-        assert.deepStrictEqual(Array.from(VALID_SEARCH_TYPE_SET), [
-            'hybrid-dates',
-            'keyword-dates',
-            'hybrid',
-            'keyword',
-            'semantic'
-        ]);
-    });
-});
-
-describe('VALID_SEARCH_TYPE_VALUES', () => {
-    it('should contain every supported URL type value', () => {
-        assert.deepStrictEqual(VALID_SEARCH_TYPE_VALUES, [
-            'hybrid-dates',
-            'keyword-dates',
-            'hybrid',
-            'keyword',
-            'semantic'
-        ]);
-    });
-});
 
 describe('SEARCH_TYPES (default export)', () => {
     it('should be frozen', () => {

--- a/api/search/constants/searchTypes.test.js
+++ b/api/search/constants/searchTypes.test.js
@@ -1,10 +1,6 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
-import SEARCH_TYPES, {
-    DEFAULT_SEARCH_TYPE,
-    parseSearchType,
-    parseSearchTypeTokens
-} from './searchTypes.js';
+import SEARCH_TYPES, { DEFAULT_SEARCH_TYPE, resolveSearchType } from './searchTypes.js';
 
 describe('SEARCH_TYPES (default export)', () => {
     it('should be frozen', () => {
@@ -30,112 +26,65 @@ describe('DEFAULT_SEARCH_TYPE', () => {
     });
 });
 
-describe('parseSearchType', () => {
+describe('resolveSearchType', () => {
     describe('when value is absent or not a usable string', () => {
         for (const value of [undefined, null, 42, true, {}]) {
-            it(`returns empty result for ${JSON.stringify(value)}`, () => {
-                assert.deepStrictEqual(parseSearchType(value), {
-                    value: undefined,
-                    invalidValue: undefined
-                });
+            it(`returns DEFAULT_SEARCH_TYPE for ${JSON.stringify(value)}`, () => {
+                assert.strictEqual(resolveSearchType(value), DEFAULT_SEARCH_TYPE);
             });
         }
 
-        it('returns empty result for an empty string', () => {
-            assert.deepStrictEqual(parseSearchType(''), {
-                value: undefined,
-                invalidValue: undefined
-            });
+        it('returns DEFAULT_SEARCH_TYPE for an empty string', () => {
+            assert.strictEqual(resolveSearchType(''), DEFAULT_SEARCH_TYPE);
         });
 
-        it('returns empty result for a whitespace-only string', () => {
-            assert.deepStrictEqual(parseSearchType('   '), {
-                value: undefined,
-                invalidValue: undefined
-            });
-        });
-    });
-
-    describe('when value is an array', () => {
-        it('uses the last element of the array', () => {
-            assert.deepStrictEqual(parseSearchType(['keyword', 'semantic']), {
-                value: 'semantic',
-                invalidValue: undefined
-            });
+        it('returns DEFAULT_SEARCH_TYPE for a whitespace-only string', () => {
+            assert.strictEqual(resolveSearchType('   '), DEFAULT_SEARCH_TYPE);
         });
 
-        it('returns empty result when the last element is not a string', () => {
-            assert.deepStrictEqual(parseSearchType(['keyword', undefined]), {
-                value: undefined,
-                invalidValue: undefined
-            });
+        it('returns DEFAULT_SEARCH_TYPE for an array (arrays are not strings)', () => {
+            assert.strictEqual(resolveSearchType(['keyword', 'semantic']), DEFAULT_SEARCH_TYPE);
         });
     });
 
     describe('supported type values', () => {
-        it('resolves supported values directly', () => {
-            assert.deepStrictEqual(parseSearchType('hybrid-dates'), {
-                value: 'hybrid-dates',
-                invalidValue: undefined
-            });
-            assert.deepStrictEqual(parseSearchType('keyword-dates'), {
-                value: 'keyword-dates',
-                invalidValue: undefined
-            });
-            assert.deepStrictEqual(parseSearchType('hybrid'), {
-                value: 'hybrid',
-                invalidValue: undefined
-            });
-            assert.deepStrictEqual(parseSearchType('keyword'), {
-                value: 'keyword',
-                invalidValue: undefined
-            });
-            assert.deepStrictEqual(parseSearchType('semantic'), {
-                value: 'semantic',
-                invalidValue: undefined
-            });
+        it('resolves all supported values directly', () => {
+            assert.strictEqual(resolveSearchType('hybrid-dates'), 'hybrid-dates');
+            assert.strictEqual(resolveSearchType('keyword-dates'), 'keyword-dates');
+            assert.strictEqual(resolveSearchType('hybrid'), 'hybrid');
+            assert.strictEqual(resolveSearchType('keyword'), 'keyword');
+            assert.strictEqual(resolveSearchType('semantic'), 'semantic');
         });
     });
 
-    describe('invalid inputs', () => {
-        it('returns the invalid value when the type is not recognised', () => {
-            assert.deepStrictEqual(parseSearchType('unknown'), {
-                value: undefined,
-                invalidValue: 'unknown'
-            });
-            assert.deepStrictEqual(parseSearchType('foo,bar'), {
-                value: undefined,
-                invalidValue: 'foo,bar'
-            });
+    describe('unrecognised inputs', () => {
+        it('returns DEFAULT_SEARCH_TYPE when the type is not recognised and no session fallback exists', () => {
+            assert.strictEqual(resolveSearchType('unknown'), DEFAULT_SEARCH_TYPE);
+            assert.strictEqual(resolveSearchType('foo,bar'), DEFAULT_SEARCH_TYPE);
+        });
+
+        it('returns the session feature-flag value when the type is not recognised and a session override is set', () => {
+            const session = { featureFlags: { type: 'semantic' } };
+            assert.strictEqual(resolveSearchType('unknown', session), 'semantic');
+        });
+
+        it('returns DEFAULT_SEARCH_TYPE when the session feature-flag value is falsy', () => {
+            assert.strictEqual(resolveSearchType('unknown', {}), DEFAULT_SEARCH_TYPE);
+            assert.strictEqual(
+                resolveSearchType('unknown', { featureFlags: {} }),
+                DEFAULT_SEARCH_TYPE
+            );
         });
     });
 
     describe('whitespace and case handling', () => {
         it('trims whitespace around values', () => {
-            assert.deepStrictEqual(parseSearchType(' hybrid-dates '), {
-                value: 'hybrid-dates',
-                invalidValue: undefined
-            });
+            assert.strictEqual(resolveSearchType(' hybrid-dates '), 'hybrid-dates');
         });
 
         it('is case-insensitive', () => {
-            assert.deepStrictEqual(parseSearchType('KEYWORD-DATES'), {
-                value: 'keyword-dates',
-                invalidValue: undefined
-            });
-            assert.deepStrictEqual(parseSearchType('SEMANTIC'), {
-                value: 'semantic',
-                invalidValue: undefined
-            });
-        });
-    });
-});
-
-describe('parseSearchTypeTokens', () => {
-    it('remains an alias of parseSearchType for compatibility', () => {
-        assert.deepStrictEqual(parseSearchTypeTokens('HYBRID-DATES'), {
-            value: 'hybrid-dates',
-            invalidValue: undefined
+            assert.strictEqual(resolveSearchType('KEYWORD-DATES'), 'keyword-dates');
+            assert.strictEqual(resolveSearchType('SEMANTIC'), 'semantic');
         });
     });
 });

--- a/api/search/routes.js
+++ b/api/search/routes.js
@@ -1,5 +1,9 @@
 import express from 'express';
 import { v4 as uuidv4 } from 'uuid';
+import {
+    FEATURE_FLAG_ENUM_OPTIONS,
+    parseEnumFlagValue
+} from '../../middleware/featureFlags/index.js';
 
 /**
  * @module routes/searchRouter
@@ -56,13 +60,16 @@ export default function searchRouter({ searchService }) {
     router.get('/', async (req, res, next) => {
         try {
             const { query, pageNumber, itemsPerPage } = req.query;
+            const searchType =
+                parseEnumFlagValue(req.query.type, FEATURE_FLAG_ENUM_OPTIONS.type) || 'keyword';
             const searchResults = await searchService.getSearchResultsByKeyword(
                 query,
                 pageNumber,
                 itemsPerPage,
                 {
                     caseReferenceNumber: req.get('On-Behalf-Of'),
-                    logger: req.log
+                    logger: req.log,
+                    searchType
                 }
             );
 

--- a/api/search/routes.js
+++ b/api/search/routes.js
@@ -1,6 +1,5 @@
 import express from 'express';
 import { v4 as uuidv4 } from 'uuid';
-import { parseFeatureFlagValue } from '../../middleware/featureFlags/index.js';
 
 /**
  * @module routes/searchRouter
@@ -56,10 +55,12 @@ export default function searchRouter({ searchService }) {
 
     router.get('/', async (req, res, next) => {
         try {
-            const { query, pageNumber, itemsPerPage } = req.query;
-            const useKeyword = parseFeatureFlagValue(req.query.keyword) ?? true;
-            const useSemantic = parseFeatureFlagValue(req.query.semantic) ?? false;
-            const enableDateExtraction = parseFeatureFlagValue(req.query.dates) ?? true;
+            const {
+                query,
+                pageNumber,
+                itemsPerPage,
+                type: searchType = 'keyword-dates'
+            } = req.query;
             const searchResults = await searchService.getSearchResultsByKeyword(
                 query,
                 pageNumber,
@@ -67,9 +68,7 @@ export default function searchRouter({ searchService }) {
                 {
                     caseReferenceNumber: req.get('On-Behalf-Of'),
                     logger: req.log,
-                    useKeyword,
-                    useSemantic,
-                    enableDateExtraction
+                    searchType
                 }
             );
 

--- a/api/search/routes.js
+++ b/api/search/routes.js
@@ -1,9 +1,6 @@
 import express from 'express';
 import { v4 as uuidv4 } from 'uuid';
-import {
-    FEATURE_FLAG_ENUM_OPTIONS,
-    parseEnumFlagValue
-} from '../../middleware/featureFlags/index.js';
+import { parseFeatureFlagValue } from '../../middleware/featureFlags/index.js';
 
 /**
  * @module routes/searchRouter
@@ -60,8 +57,9 @@ export default function searchRouter({ searchService }) {
     router.get('/', async (req, res, next) => {
         try {
             const { query, pageNumber, itemsPerPage } = req.query;
-            const searchType =
-                parseEnumFlagValue(req.query.type, FEATURE_FLAG_ENUM_OPTIONS.type) || 'keyword';
+            const useKeyword = parseFeatureFlagValue(req.query.keyword) ?? true;
+            const useSemantic = parseFeatureFlagValue(req.query.semantic) ?? false;
+            const enableDateExtraction = parseFeatureFlagValue(req.query.dates) ?? true;
             const searchResults = await searchService.getSearchResultsByKeyword(
                 query,
                 pageNumber,
@@ -69,7 +67,9 @@ export default function searchRouter({ searchService }) {
                 {
                     caseReferenceNumber: req.get('On-Behalf-Of'),
                     logger: req.log,
-                    searchType
+                    useKeyword,
+                    useSemantic,
+                    enableDateExtraction
                 }
             );
 

--- a/api/search/routes.js
+++ b/api/search/routes.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import { v4 as uuidv4 } from 'uuid';
 
-import DEFAULT_SEARCH_TYPE from './constants/searchTypes.js';
+import { resolveSearchType } from './constants/searchTypes.js';
 
 /**
  * @module routes/searchRouter
@@ -57,12 +57,13 @@ export default function searchRouter({ searchService }) {
 
     router.get('/', async (req, res, next) => {
         try {
-            const {
-                query,
-                pageNumber,
-                itemsPerPage,
-                type: searchType = DEFAULT_SEARCH_TYPE
-            } = req.query;
+            const { query, pageNumber, itemsPerPage, type: rawSearchType } = req.query;
+
+            // Resolve and validate the search type, falling back to DEFAULT_SEARCH_TYPE
+            // when absent or invalid. This ensures downstream consumers always receive
+            // a valid type string, not an array or enum object.
+            const searchType = resolveSearchType(rawSearchType);
+
             const searchResults = await searchService.getSearchResultsByKeyword(
                 query,
                 pageNumber,

--- a/api/search/routes.js
+++ b/api/search/routes.js
@@ -1,6 +1,8 @@
 import express from 'express';
 import { v4 as uuidv4 } from 'uuid';
 
+import DEFAULT_SEARCH_TYPE from './constants/searchTypes.js';
+
 /**
  * @module routes/searchRouter
  * @description
@@ -59,7 +61,7 @@ export default function searchRouter({ searchService }) {
                 query,
                 pageNumber,
                 itemsPerPage,
-                type: searchType = 'keyword-dates'
+                type: searchType = DEFAULT_SEARCH_TYPE
             } = req.query;
             const searchResults = await searchService.getSearchResultsByKeyword(
                 query,

--- a/api/search/search-service.js
+++ b/api/search/search-service.js
@@ -26,17 +26,19 @@ function createSearchService({ createDocumentDAL: dalFactory = createDocumentDAL
      * @param {Object} context - The context for the search operation.
      * @param {string} context.caseReferenceNumber - The case reference number.
      * @param {Object} context.logger - The logger instance.
+     * @param {'keyword' | 'semantic' | 'hybrid'} [context.searchType='keyword'] - Which search mode to use.
      * @returns {Promise<Object[]>} A promise that resolves to an array of document results.
      */
     async function getSearchResultsByKeyword(
         keyword,
         pageNumber,
         itemsPerPage,
-        { caseReferenceNumber, logger }
+        { caseReferenceNumber, logger, searchType = 'keyword' }
     ) {
         const db = dalFactory({
             caseReferenceNumber,
-            logger
+            logger,
+            searchType
         });
         return db.getDocumentsChunksByKeyword(keyword, pageNumber, itemsPerPage);
     }

--- a/api/search/search-service.js
+++ b/api/search/search-service.js
@@ -26,19 +26,29 @@ function createSearchService({ createDocumentDAL: dalFactory = createDocumentDAL
      * @param {Object} context - The context for the search operation.
      * @param {string} context.caseReferenceNumber - The case reference number.
      * @param {Object} context.logger - The logger instance.
-     * @param {'keyword' | 'semantic' | 'hybrid'} [context.searchType='keyword'] - Which search mode to use.
+     * @param {boolean} [context.useKeyword=true] - Enable lexical (BM25) keyword matching.
+     * @param {boolean} [context.useSemantic=false] - Enable neural (vector) semantic matching.
+     * @param {boolean} [context.enableDateExtraction=true] - Enable date extraction and variant expansion.
      * @returns {Promise<Object[]>} A promise that resolves to an array of document results.
      */
     async function getSearchResultsByKeyword(
         keyword,
         pageNumber,
         itemsPerPage,
-        { caseReferenceNumber, logger, searchType = 'keyword' }
+        {
+            caseReferenceNumber,
+            logger,
+            useKeyword = true,
+            useSemantic = false,
+            enableDateExtraction = true
+        }
     ) {
         const db = dalFactory({
             caseReferenceNumber,
             logger,
-            searchType
+            useKeyword,
+            useSemantic,
+            enableDateExtraction
         });
         return db.getDocumentsChunksByKeyword(keyword, pageNumber, itemsPerPage);
     }

--- a/api/search/search-service.js
+++ b/api/search/search-service.js
@@ -1,5 +1,5 @@
 import createDocumentDAL from '../DAL/document-dal.js';
-import DEFAULT_SEARCH_TYPE from './constants/searchTypes.js';
+import { DEFAULT_SEARCH_TYPE } from './constants/searchTypes.js';
 
 /**
  * Factory function that creates a Search Service for retrieving documents

--- a/api/search/search-service.js
+++ b/api/search/search-service.js
@@ -26,29 +26,19 @@ function createSearchService({ createDocumentDAL: dalFactory = createDocumentDAL
      * @param {Object} context - The context for the search operation.
      * @param {string} context.caseReferenceNumber - The case reference number.
      * @param {Object} context.logger - The logger instance.
-     * @param {boolean} [context.useKeyword=true] - Enable lexical (BM25) keyword matching.
-     * @param {boolean} [context.useSemantic=false] - Enable neural (vector) semantic matching.
-     * @param {boolean} [context.enableDateExtraction=true] - Enable date extraction and variant expansion.
+     * @param {string} [context.searchType='keyword-dates'] - Search mode. One of SEARCH_TYPES.KEYWORD, SEARCH_TYPES.KEYWORD_DATES, SEARCH_TYPES.SEMANTIC, SEARCH_TYPES.HYBRID, or SEARCH_TYPES.HYBRID_DATES.
      * @returns {Promise<Object[]>} A promise that resolves to an array of document results.
      */
     async function getSearchResultsByKeyword(
         keyword,
         pageNumber,
         itemsPerPage,
-        {
-            caseReferenceNumber,
-            logger,
-            useKeyword = true,
-            useSemantic = false,
-            enableDateExtraction = true
-        }
+        { caseReferenceNumber, logger, searchType = 'keyword-dates' }
     ) {
         const db = dalFactory({
             caseReferenceNumber,
             logger,
-            useKeyword,
-            useSemantic,
-            enableDateExtraction
+            searchType
         });
         return db.getDocumentsChunksByKeyword(keyword, pageNumber, itemsPerPage);
     }

--- a/api/search/search-service.js
+++ b/api/search/search-service.js
@@ -1,4 +1,5 @@
 import createDocumentDAL from '../DAL/document-dal.js';
+import DEFAULT_SEARCH_TYPE from './constants/searchTypes.js';
 
 /**
  * Factory function that creates a Search Service for retrieving documents
@@ -26,14 +27,14 @@ function createSearchService({ createDocumentDAL: dalFactory = createDocumentDAL
      * @param {Object} context - The context for the search operation.
      * @param {string} context.caseReferenceNumber - The case reference number.
      * @param {Object} context.logger - The logger instance.
-     * @param {string} [context.searchType='keyword-dates'] - Search mode. One of SEARCH_TYPES.KEYWORD, SEARCH_TYPES.KEYWORD_DATES, SEARCH_TYPES.SEMANTIC, SEARCH_TYPES.HYBRID, or SEARCH_TYPES.HYBRID_DATES.
+     * @param {string} [context.searchType=DEFAULT_SEARCH_TYPE] - Search mode. One of SEARCH_TYPES.KEYWORD, SEARCH_TYPES.KEYWORD_DATES, SEARCH_TYPES.SEMANTIC, SEARCH_TYPES.HYBRID, or SEARCH_TYPES.HYBRID_DATES.
      * @returns {Promise<Object[]>} A promise that resolves to an array of document results.
      */
     async function getSearchResultsByKeyword(
         keyword,
         pageNumber,
         itemsPerPage,
-        { caseReferenceNumber, logger, searchType = 'keyword-dates' }
+        { caseReferenceNumber, logger, searchType = DEFAULT_SEARCH_TYPE }
     ) {
         const db = dalFactory({
             caseReferenceNumber,

--- a/api/search/search-service.test.js
+++ b/api/search/search-service.test.js
@@ -42,16 +42,19 @@ describe('Search Service', () => {
 
         const caseReferenceNumber = '12-745678';
         const logger = { info: () => {} };
+        const searchType = 'hybrid';
 
         await searchService.getSearchResultsByKeyword('test', 1, 10, {
             caseReferenceNumber,
-            logger
+            logger,
+            searchType
         });
 
         assert.equal(mockDALFactory.mock.callCount(), 1);
         const [dalOptions] = mockDALFactory.mock.calls[0].arguments;
         assert.equal(dalOptions.caseReferenceNumber, caseReferenceNumber);
         assert.deepEqual(dalOptions.logger, logger);
+        assert.equal(dalOptions.searchType, searchType);
     });
 
     it('should call getDocumentsChunksByKeyword with correct parameters', async () => {

--- a/api/search/search-service.test.js
+++ b/api/search/search-service.test.js
@@ -42,19 +42,25 @@ describe('Search Service', () => {
 
         const caseReferenceNumber = '12-745678';
         const logger = { info: () => {} };
-        const searchType = 'hybrid';
+        const useKeyword = false;
+        const useSemantic = true;
+        const enableDateExtraction = false;
 
         await searchService.getSearchResultsByKeyword('test', 1, 10, {
             caseReferenceNumber,
             logger,
-            searchType
+            useKeyword,
+            useSemantic,
+            enableDateExtraction
         });
 
         assert.equal(mockDALFactory.mock.callCount(), 1);
         const [dalOptions] = mockDALFactory.mock.calls[0].arguments;
         assert.equal(dalOptions.caseReferenceNumber, caseReferenceNumber);
         assert.deepEqual(dalOptions.logger, logger);
-        assert.equal(dalOptions.searchType, searchType);
+        assert.equal(dalOptions.useKeyword, useKeyword);
+        assert.equal(dalOptions.useSemantic, useSemantic);
+        assert.equal(dalOptions.enableDateExtraction, enableDateExtraction);
     });
 
     it('should call getDocumentsChunksByKeyword with correct parameters', async () => {

--- a/api/search/search-service.test.js
+++ b/api/search/search-service.test.js
@@ -42,25 +42,19 @@ describe('Search Service', () => {
 
         const caseReferenceNumber = '12-745678';
         const logger = { info: () => {} };
-        const useKeyword = false;
-        const useSemantic = true;
-        const enableDateExtraction = false;
+        const searchType = 'semantic';
 
         await searchService.getSearchResultsByKeyword('test', 1, 10, {
             caseReferenceNumber,
             logger,
-            useKeyword,
-            useSemantic,
-            enableDateExtraction
+            searchType
         });
 
         assert.equal(mockDALFactory.mock.callCount(), 1);
         const [dalOptions] = mockDALFactory.mock.calls[0].arguments;
         assert.equal(dalOptions.caseReferenceNumber, caseReferenceNumber);
         assert.deepEqual(dalOptions.logger, logger);
-        assert.equal(dalOptions.useKeyword, useKeyword);
-        assert.equal(dalOptions.useSemantic, useSemantic);
-        assert.equal(dalOptions.enableDateExtraction, enableDateExtraction);
+        assert.equal(dalOptions.searchType, searchType);
     });
 
     it('should call getDocumentsChunksByKeyword with correct parameters', async () => {

--- a/app.js
+++ b/app.js
@@ -13,6 +13,7 @@ import { caseSelected } from './middleware/caseSelected/index.js';
 import createCsrf from './middleware/csrf/index.js';
 import enforceCrnInQuery from './middleware/enforceCrnInQuery/index.js';
 import enforceFeatureFlagsInQuery from './middleware/enforceFeatureFlagsInQuery/index.js';
+import enforceSearchTypeInQuery from './middleware/enforceSearchTypeInQuery/index.js';
 import {
     checkEnvVars,
     getMandatoryEnvVars,
@@ -201,6 +202,7 @@ async function createApp({ createLogger = defaultCreateLogger } = {}) {
         getCaseReferenceNumberFromQueryString,
         caseSelected,
         featureFlags,
+        enforceSearchTypeInQuery,
         searchRouter({ createTemplateEngineService, createSearchService })
     );
 

--- a/app.js
+++ b/app.js
@@ -58,16 +58,6 @@ async function createApp({ createLogger = defaultCreateLogger } = {}) {
     // Use the middleware for request logging
     app.use(loggerMiddleware);
 
-    app.use((req, res, next) => {
-        res.set({
-            'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
-            Pragma: 'no-cache',
-            Expires: '0',
-            'Surrogate-Control': 'no-store'
-        });
-        next();
-    });
-
     // https://expressjs.com/en/api.html#express.json
     app.use(express.json());
     // https://expressjs.com/en/api.html#express.urlencoded
@@ -153,12 +143,31 @@ async function createApp({ createLogger = defaultCreateLogger } = {}) {
     const templateEngineService = createTemplateEngineService(app);
     templateEngineService.init();
 
-    app.use(express.static(path.join(__dirname, 'public')));
+    app.use(
+        express.static(path.join(__dirname, 'public'), {
+            maxAge: '1h'
+        })
+    );
 
     app.use(
         '/assets',
-        express.static(path.join(__dirname, '/node_modules/govuk-frontend/dist/govuk/assets'))
+        express.static(path.join(__dirname, '/node_modules/govuk-frontend/dist/govuk/assets'), {
+            maxAge: '1y',
+            immutable: true
+        })
     );
+
+    // Prevent caching of dynamic responses while allowing static handlers above
+    // to set long-lived cache headers for fingerprinted assets.
+    app.use((req, res, next) => {
+        res.set({
+            'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
+            Pragma: 'no-cache',
+            Expires: '0',
+            'Surrogate-Control': 'no-store'
+        });
+        next();
+    });
 
     // Apply General Rate Limiter GLOBALLY (Fixes CodeQL)
     // Note: auth login exclusion is handled within the limiter configuration

--- a/app.js
+++ b/app.js
@@ -152,8 +152,8 @@ async function createApp({ createLogger = defaultCreateLogger } = {}) {
 
     app.use(
         '/assets',
-        express.static(path.join(__dirname, '/node_modules/govuk-frontend/dist/govuk/assets'), {
-            maxAge: '1y',
+        express.static(path.join(__dirname, 'node_modules/govuk-frontend/dist/govuk/assets'), {
+            maxAge: 365 * 24 * 60 * 60 * 1000, // 365 days in ms — explicit to avoid ms('1y') = 31557600 (365.25d)
             immutable: true
         })
     );

--- a/app.js
+++ b/app.js
@@ -152,8 +152,8 @@ async function createApp({ createLogger = defaultCreateLogger } = {}) {
 
     app.use(
         '/assets',
-        express.static(path.join(__dirname, 'node_modules/govuk-frontend/dist/govuk/assets'), {
-            maxAge: 365 * 24 * 60 * 60 * 1000, // 365 days in ms — explicit to avoid ms('1y') = 31557600 (365.25d)
+        express.static(path.join(__dirname, '/node_modules/govuk-frontend/dist/govuk/assets'), {
+            maxAge: '1y',
             immutable: true
         })
     );

--- a/app.js
+++ b/app.js
@@ -12,6 +12,7 @@ import indexRouter from './index/routes.js';
 import { caseSelected } from './middleware/caseSelected/index.js';
 import createCsrf from './middleware/csrf/index.js';
 import enforceCrnInQuery from './middleware/enforceCrnInQuery/index.js';
+import enforceFeatureFlagsInQuery from './middleware/enforceFeatureFlagsInQuery/index.js';
 import {
     checkEnvVars,
     getMandatoryEnvVars,
@@ -172,6 +173,9 @@ async function createApp({ createLogger = defaultCreateLogger } = {}) {
     // Security: enforceCrnInQuery uses an explicit allowlist of redirect-eligible paths (see middleware).
     // If you add a new route that should support internal redirects, update the allowlist and its test.
     app.use(enforceCrnInQuery);
+    // Reinstates non-default feature flags into the URL so they persist across navigation
+    // and can be bookmarked. Mirrors the pattern of enforceCrnInQuery.
+    app.use(enforceFeatureFlagsInQuery);
     app.use(
         '/document',
         isAuthenticated,

--- a/app.js
+++ b/app.js
@@ -153,8 +153,7 @@ async function createApp({ createLogger = defaultCreateLogger } = {}) {
     app.use(
         '/assets',
         express.static(path.join(__dirname, '/node_modules/govuk-frontend/dist/govuk/assets'), {
-            maxAge: '1y',
-            immutable: true
+            maxAge: '1h'
         })
     );
 

--- a/app.test.js
+++ b/app.test.js
@@ -110,7 +110,7 @@ describe('App', () => {
             );
         });
 
-        it('should set long-lived immutable cache headers for /assets responses', async () => {
+        it('should set short-lived cache headers for /assets responses', async () => {
             process.env.NODE_ENV = 'development';
             process.env.APP_LOG_LEVEL = 'silent';
 
@@ -118,7 +118,7 @@ describe('App', () => {
             const response = await request(app).get('/assets/images/govuk-crest.svg');
 
             assert.equal(response.status, 200);
-            assert.equal(response.headers['cache-control'], 'public, max-age=31536000, immutable');
+            assert.equal(response.headers['cache-control'], 'public, max-age=3600');
         });
     });
 });

--- a/app.test.js
+++ b/app.test.js
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { afterEach, beforeEach, describe, it } from 'node:test';
+import request from 'supertest';
 import createApp from './app.js';
 
 describe('App', () => {
@@ -107,6 +108,17 @@ describe('App', () => {
                     return true;
                 }
             );
+        });
+
+        it('should set long-lived immutable cache headers for /assets responses', async () => {
+            process.env.NODE_ENV = 'development';
+            process.env.APP_LOG_LEVEL = 'silent';
+
+            const app = await createApp();
+            const response = await request(app).get('/assets/images/govuk-crest.svg');
+
+            assert.equal(response.status, 200);
+            assert.equal(response.headers['cache-control'], 'public, max-age=31536000, immutable');
         });
     });
 });

--- a/document/handlers/page-viewer.js
+++ b/document/handlers/page-viewer.js
@@ -1,4 +1,8 @@
-import { getFeatureFlagValue } from '../../middleware/featureFlags/index.js';
+import {
+    FEATURE_FLAG_ENUM_OPTIONS,
+    getFeatureFlagValue,
+    parseEnumFlagValue
+} from '../../middleware/featureFlags/index.js';
 import createApiJwtToken from '../../service/request/create-api-jwt-token.js';
 import createTemplateEngineService from '../../templateEngine/index.js';
 import { VIEW_MODES } from '../constants/viewModes.js';
@@ -30,6 +34,9 @@ export function createPageViewerHandler(
             // Use pre-validated parameters from middleware
             const { documentId, pageNumber, crn } = req.validatedParams;
             const { searchTerm = '' } = req.query;
+            const searchType =
+                parseEnumFlagValue(req.query.type, FEATURE_FLAG_ENUM_OPTIONS.type) ||
+                getFeatureFlagValue(req.session, 'type');
             const alignFlag = getFeatureFlagValue(req.session, 'align');
             const userName = req.session?.username;
             const apiJwtToken = createApiJwtToken(userName);
@@ -62,7 +69,13 @@ export function createPageViewerHandler(
             const imageUrl = buildImageUrl(documentId, pageNumber, crn);
 
             // Provide a link for sub-navigation to the text view page for this document page
-            const textPageLink = buildTextPageLink(documentId, pageNumber, crn, searchTerm);
+            const textPageLink = buildTextPageLink(
+                documentId,
+                pageNumber,
+                crn,
+                searchTerm,
+                searchType
+            );
 
             const pageTitle = formatPageTitle(pageMetadata.correspondence_type);
 
@@ -74,6 +87,7 @@ export function createPageViewerHandler(
                     pageNumber,
                     crn,
                     searchTerm,
+                    searchType,
                     jwtToken: apiJwtToken,
                     logger: req.log
                 });

--- a/document/handlers/page-viewer.js
+++ b/document/handlers/page-viewer.js
@@ -1,4 +1,4 @@
-import SEARCH_TYPES from '../../api/search/constants/searchTypes.js';
+import { DEFAULT_SEARCH_TYPE } from '../../api/search/constants/searchTypes.js';
 import { getFeatureFlagValue } from '../../middleware/featureFlags/index.js';
 import createApiJwtToken from '../../service/request/create-api-jwt-token.js';
 import createTemplateEngineService from '../../templateEngine/index.js';
@@ -31,8 +31,7 @@ export function createPageViewerHandler(
             // Use pre-validated parameters from middleware
             const { documentId, pageNumber, crn } = req.validatedParams;
             const { searchTerm = '' } = req.query;
-            const searchType =
-                getFeatureFlagValue(req.session, 'type') || SEARCH_TYPES.KEYWORD_DATES;
+            const searchType = getFeatureFlagValue(req.session, 'type') || DEFAULT_SEARCH_TYPE;
             const alignFlag = getFeatureFlagValue(req.session, 'align');
             const userName = req.session?.username;
             const apiJwtToken = createApiJwtToken(userName);

--- a/document/handlers/page-viewer.js
+++ b/document/handlers/page-viewer.js
@@ -58,7 +58,8 @@ export function createPageViewerHandler(
                 pageMetadata,
                 req.query,
                 req.validatedParams,
-                viewMode
+                viewMode,
+                searchType
             );
 
             const imageUrl = buildImageUrl(documentId, pageNumber, crn, searchType, req.session);

--- a/document/handlers/page-viewer.js
+++ b/document/handlers/page-viewer.js
@@ -61,7 +61,7 @@ export function createPageViewerHandler(
                 viewMode
             );
 
-            const imageUrl = buildImageUrl(documentId, pageNumber, crn, searchType);
+            const imageUrl = buildImageUrl(documentId, pageNumber, crn, searchType, req.session);
 
             // Provide a link for sub-navigation to the text view page for this document page
             const textPageLink = buildTextPageLink(
@@ -69,7 +69,8 @@ export function createPageViewerHandler(
                 pageNumber,
                 crn,
                 searchTerm,
-                searchType
+                searchType,
+                req.session
             );
 
             const pageTitle = formatPageTitle(pageMetadata.correspondence_type);

--- a/document/handlers/page-viewer.js
+++ b/document/handlers/page-viewer.js
@@ -1,4 +1,4 @@
-import { DEFAULT_SEARCH_TYPE } from '../../api/search/constants/searchTypes.js';
+import { resolveSearchType } from '../../api/search/constants/searchTypes.js';
 import { getFeatureFlagValue } from '../../middleware/featureFlags/index.js';
 import createApiJwtToken from '../../service/request/create-api-jwt-token.js';
 import createTemplateEngineService from '../../templateEngine/index.js';
@@ -31,7 +31,7 @@ export function createPageViewerHandler(
             // Use pre-validated parameters from middleware
             const { documentId, pageNumber, crn } = req.validatedParams;
             const { searchTerm = '' } = req.query;
-            const searchType = getFeatureFlagValue(req.session, 'type') || DEFAULT_SEARCH_TYPE;
+            const searchType = resolveSearchType(req.session?.featureFlags?.type, req.session);
             const alignFlag = getFeatureFlagValue(req.session, 'align');
             const userName = req.session?.username;
             const apiJwtToken = createApiJwtToken(userName);

--- a/document/handlers/page-viewer.js
+++ b/document/handlers/page-viewer.js
@@ -1,8 +1,4 @@
-import {
-    FEATURE_FLAG_ENUM_OPTIONS,
-    getFeatureFlagValue,
-    parseEnumFlagValue
-} from '../../middleware/featureFlags/index.js';
+import { getFeatureFlagValue } from '../../middleware/featureFlags/index.js';
 import createApiJwtToken from '../../service/request/create-api-jwt-token.js';
 import createTemplateEngineService from '../../templateEngine/index.js';
 import { VIEW_MODES } from '../constants/viewModes.js';
@@ -34,9 +30,9 @@ export function createPageViewerHandler(
             // Use pre-validated parameters from middleware
             const { documentId, pageNumber, crn } = req.validatedParams;
             const { searchTerm = '' } = req.query;
-            const searchType =
-                parseEnumFlagValue(req.query.type, FEATURE_FLAG_ENUM_OPTIONS.type) ||
-                getFeatureFlagValue(req.session, 'type');
+            const useKeyword = getFeatureFlagValue(req.session, 'keyword');
+            const useSemantic = getFeatureFlagValue(req.session, 'semantic');
+            const useDates = getFeatureFlagValue(req.session, 'dates');
             const alignFlag = getFeatureFlagValue(req.session, 'align');
             const userName = req.session?.username;
             const apiJwtToken = createApiJwtToken(userName);
@@ -69,13 +65,7 @@ export function createPageViewerHandler(
             const imageUrl = buildImageUrl(documentId, pageNumber, crn);
 
             // Provide a link for sub-navigation to the text view page for this document page
-            const textPageLink = buildTextPageLink(
-                documentId,
-                pageNumber,
-                crn,
-                searchTerm,
-                searchType
-            );
+            const textPageLink = buildTextPageLink(documentId, pageNumber, crn, searchTerm);
 
             const pageTitle = formatPageTitle(pageMetadata.correspondence_type);
 
@@ -87,7 +77,9 @@ export function createPageViewerHandler(
                     pageNumber,
                     crn,
                     searchTerm,
-                    searchType,
+                    useKeyword,
+                    useSemantic,
+                    useDates,
                     jwtToken: apiJwtToken,
                     logger: req.log
                 });

--- a/document/handlers/page-viewer.js
+++ b/document/handlers/page-viewer.js
@@ -61,10 +61,16 @@ export function createPageViewerHandler(
                 viewMode
             );
 
-            const imageUrl = buildImageUrl(documentId, pageNumber, crn);
+            const imageUrl = buildImageUrl(documentId, pageNumber, crn, searchType);
 
             // Provide a link for sub-navigation to the text view page for this document page
-            const textPageLink = buildTextPageLink(documentId, pageNumber, crn, searchTerm);
+            const textPageLink = buildTextPageLink(
+                documentId,
+                pageNumber,
+                crn,
+                searchTerm,
+                searchType
+            );
 
             const pageTitle = formatPageTitle(pageMetadata.correspondence_type);
 

--- a/document/handlers/page-viewer.js
+++ b/document/handlers/page-viewer.js
@@ -1,3 +1,4 @@
+import SEARCH_TYPES from '../../api/search/constants/searchTypes.js';
 import { getFeatureFlagValue } from '../../middleware/featureFlags/index.js';
 import createApiJwtToken from '../../service/request/create-api-jwt-token.js';
 import createTemplateEngineService from '../../templateEngine/index.js';
@@ -30,9 +31,8 @@ export function createPageViewerHandler(
             // Use pre-validated parameters from middleware
             const { documentId, pageNumber, crn } = req.validatedParams;
             const { searchTerm = '' } = req.query;
-            const useKeyword = getFeatureFlagValue(req.session, 'keyword');
-            const useSemantic = getFeatureFlagValue(req.session, 'semantic');
-            const useDates = getFeatureFlagValue(req.session, 'dates');
+            const searchType =
+                getFeatureFlagValue(req.session, 'type') || SEARCH_TYPES.KEYWORD_DATES;
             const alignFlag = getFeatureFlagValue(req.session, 'align');
             const userName = req.session?.username;
             const apiJwtToken = createApiJwtToken(userName);
@@ -77,9 +77,7 @@ export function createPageViewerHandler(
                     pageNumber,
                     crn,
                     searchTerm,
-                    useKeyword,
-                    useSemantic,
-                    useDates,
+                    searchType,
                     jwtToken: apiJwtToken,
                     logger: req.log
                 });

--- a/document/handlers/text-viewer.js
+++ b/document/handlers/text-viewer.js
@@ -1,3 +1,8 @@
+import {
+    FEATURE_FLAG_ENUM_OPTIONS,
+    getFeatureFlagValue,
+    parseEnumFlagValue
+} from '../../middleware/featureFlags/index.js';
 import createApiJwtToken from '../../service/request/create-api-jwt-token.js';
 import createTemplateEngineService from '../../templateEngine/index.js';
 import { VIEW_MODES } from '../constants/viewModes.js';
@@ -29,6 +34,9 @@ export function createTextViewerHandler(
             // Use pre-validated parameters from middleware
             const { documentId, pageNumber, crn } = req.validatedParams;
             const { searchTerm = '' } = req.query;
+            const searchType =
+                parseEnumFlagValue(req.query.type, FEATURE_FLAG_ENUM_OPTIONS.type) ||
+                getFeatureFlagValue(req.session, 'type');
             const apiJwtToken = createApiJwtToken(req.session?.username);
 
             // Fetch document page metadata from OpenSearch via API
@@ -59,7 +67,13 @@ export function createTextViewerHandler(
             const pageTitle = formatPageTitle(pageMetadata.correspondence_type);
 
             // Provide a link for sub-navigation back to the image page
-            const imagePageLink = buildImagePageLink(documentId, pageNumber, crn, searchTerm);
+            const imagePageLink = buildImagePageLink(
+                documentId,
+                pageNumber,
+                crn,
+                searchTerm,
+                searchType
+            );
 
             const { text } = pageMetadata;
 
@@ -76,6 +90,7 @@ export function createTextViewerHandler(
                         pageNumber,
                         crn,
                         searchTerm: safeSearchTerm,
+                        searchType,
                         jwtToken: apiJwtToken,
                         logger: req.log
                     });

--- a/document/handlers/text-viewer.js
+++ b/document/handlers/text-viewer.js
@@ -1,4 +1,4 @@
-import SEARCH_TYPES from '../../api/search/constants/searchTypes.js';
+import { DEFAULT_SEARCH_TYPE } from '../../api/search/constants/searchTypes.js';
 import { getFeatureFlagValue } from '../../middleware/featureFlags/index.js';
 import createApiJwtToken from '../../service/request/create-api-jwt-token.js';
 import createTemplateEngineService from '../../templateEngine/index.js';
@@ -31,8 +31,7 @@ export function createTextViewerHandler(
             // Use pre-validated parameters from middleware
             const { documentId, pageNumber, crn } = req.validatedParams;
             const { searchTerm = '' } = req.query;
-            const searchType =
-                getFeatureFlagValue(req.session, 'type') || SEARCH_TYPES.KEYWORD_DATES;
+            const searchType = getFeatureFlagValue(req.session, 'type') || DEFAULT_SEARCH_TYPE;
             const apiJwtToken = createApiJwtToken(req.session?.username);
 
             // Fetch document page metadata from OpenSearch via API

--- a/document/handlers/text-viewer.js
+++ b/document/handlers/text-viewer.js
@@ -68,7 +68,8 @@ export function createTextViewerHandler(
                 pageNumber,
                 crn,
                 searchTerm,
-                searchType
+                searchType,
+                req.session
             );
 
             const { text } = pageMetadata;

--- a/document/handlers/text-viewer.js
+++ b/document/handlers/text-viewer.js
@@ -56,7 +56,8 @@ export function createTextViewerHandler(
                 pageMetadata,
                 req.query,
                 req.validatedParams,
-                viewMode
+                viewMode,
+                searchType
             );
 
             const pageTitle = formatPageTitle(pageMetadata.correspondence_type);

--- a/document/handlers/text-viewer.js
+++ b/document/handlers/text-viewer.js
@@ -63,7 +63,13 @@ export function createTextViewerHandler(
             const pageTitle = formatPageTitle(pageMetadata.correspondence_type);
 
             // Provide a link for sub-navigation back to the image page
-            const imagePageLink = buildImagePageLink(documentId, pageNumber, crn, searchTerm);
+            const imagePageLink = buildImagePageLink(
+                documentId,
+                pageNumber,
+                crn,
+                searchTerm,
+                searchType
+            );
 
             const { text } = pageMetadata;
 

--- a/document/handlers/text-viewer.js
+++ b/document/handlers/text-viewer.js
@@ -1,8 +1,4 @@
-import {
-    FEATURE_FLAG_ENUM_OPTIONS,
-    getFeatureFlagValue,
-    parseEnumFlagValue
-} from '../../middleware/featureFlags/index.js';
+import { getFeatureFlagValue } from '../../middleware/featureFlags/index.js';
 import createApiJwtToken from '../../service/request/create-api-jwt-token.js';
 import createTemplateEngineService from '../../templateEngine/index.js';
 import { VIEW_MODES } from '../constants/viewModes.js';
@@ -34,9 +30,9 @@ export function createTextViewerHandler(
             // Use pre-validated parameters from middleware
             const { documentId, pageNumber, crn } = req.validatedParams;
             const { searchTerm = '' } = req.query;
-            const searchType =
-                parseEnumFlagValue(req.query.type, FEATURE_FLAG_ENUM_OPTIONS.type) ||
-                getFeatureFlagValue(req.session, 'type');
+            const useKeyword = getFeatureFlagValue(req.session, 'keyword');
+            const useSemantic = getFeatureFlagValue(req.session, 'semantic');
+            const useDates = getFeatureFlagValue(req.session, 'dates');
             const apiJwtToken = createApiJwtToken(req.session?.username);
 
             // Fetch document page metadata from OpenSearch via API
@@ -67,13 +63,7 @@ export function createTextViewerHandler(
             const pageTitle = formatPageTitle(pageMetadata.correspondence_type);
 
             // Provide a link for sub-navigation back to the image page
-            const imagePageLink = buildImagePageLink(
-                documentId,
-                pageNumber,
-                crn,
-                searchTerm,
-                searchType
-            );
+            const imagePageLink = buildImagePageLink(documentId, pageNumber, crn, searchTerm);
 
             const { text } = pageMetadata;
 
@@ -90,7 +80,9 @@ export function createTextViewerHandler(
                         pageNumber,
                         crn,
                         searchTerm: safeSearchTerm,
-                        searchType,
+                        useKeyword,
+                        useSemantic,
+                        useDates,
                         jwtToken: apiJwtToken,
                         logger: req.log
                     });

--- a/document/handlers/text-viewer.js
+++ b/document/handlers/text-viewer.js
@@ -1,3 +1,4 @@
+import SEARCH_TYPES from '../../api/search/constants/searchTypes.js';
 import { getFeatureFlagValue } from '../../middleware/featureFlags/index.js';
 import createApiJwtToken from '../../service/request/create-api-jwt-token.js';
 import createTemplateEngineService from '../../templateEngine/index.js';
@@ -30,9 +31,8 @@ export function createTextViewerHandler(
             // Use pre-validated parameters from middleware
             const { documentId, pageNumber, crn } = req.validatedParams;
             const { searchTerm = '' } = req.query;
-            const useKeyword = getFeatureFlagValue(req.session, 'keyword');
-            const useSemantic = getFeatureFlagValue(req.session, 'semantic');
-            const useDates = getFeatureFlagValue(req.session, 'dates');
+            const searchType =
+                getFeatureFlagValue(req.session, 'type') || SEARCH_TYPES.KEYWORD_DATES;
             const apiJwtToken = createApiJwtToken(req.session?.username);
 
             // Fetch document page metadata from OpenSearch via API
@@ -52,7 +52,8 @@ export function createTextViewerHandler(
 
             const viewMode = VIEW_MODES.TEXT;
 
-            // work out the pagination data from the metadata and values needed to construct the URLs for the pagination links
+            // work out the pagination data from the metadata and values needed to
+            // construct the URLs for the pagination links.
             const paginationData = paginationDataFromMetadata(
                 pageMetadata,
                 req.query,
@@ -80,9 +81,7 @@ export function createTextViewerHandler(
                         pageNumber,
                         crn,
                         searchTerm: safeSearchTerm,
-                        useKeyword,
-                        useSemantic,
-                        useDates,
+                        searchType,
                         jwtToken: apiJwtToken,
                         logger: req.log
                     });

--- a/document/handlers/text-viewer.js
+++ b/document/handlers/text-viewer.js
@@ -1,5 +1,4 @@
-import { DEFAULT_SEARCH_TYPE } from '../../api/search/constants/searchTypes.js';
-import { getFeatureFlagValue } from '../../middleware/featureFlags/index.js';
+import { resolveSearchType } from '../../api/search/constants/searchTypes.js';
 import createApiJwtToken from '../../service/request/create-api-jwt-token.js';
 import createTemplateEngineService from '../../templateEngine/index.js';
 import { VIEW_MODES } from '../constants/viewModes.js';
@@ -31,7 +30,7 @@ export function createTextViewerHandler(
             // Use pre-validated parameters from middleware
             const { documentId, pageNumber, crn } = req.validatedParams;
             const { searchTerm = '' } = req.query;
-            const searchType = getFeatureFlagValue(req.session, 'type') || DEFAULT_SEARCH_TYPE;
+            const searchType = resolveSearchType(req.session?.featureFlags?.type, req.session);
             const apiJwtToken = createApiJwtToken(req.session?.username);
 
             // Fetch document page metadata from OpenSearch via API

--- a/document/handlers/text-viewer.test.js
+++ b/document/handlers/text-viewer.test.js
@@ -285,6 +285,7 @@ describe('Text Viewer Handler', () => {
                 pageNumber: 1,
                 crn: '26-745678',
                 searchTerm: '12/12/1995',
+                searchType: 'keyword',
                 jwtToken: undefined,
                 logger: req.log
             }

--- a/document/handlers/text-viewer.test.js
+++ b/document/handlers/text-viewer.test.js
@@ -285,9 +285,7 @@ describe('Text Viewer Handler', () => {
                 pageNumber: 1,
                 crn: '26-745678',
                 searchTerm: '12/12/1995',
-                useKeyword: true,
-                useSemantic: false,
-                useDates: true,
+                searchType: 'keyword-dates',
                 jwtToken: undefined,
                 logger: req.log
             }

--- a/document/handlers/text-viewer.test.js
+++ b/document/handlers/text-viewer.test.js
@@ -78,15 +78,15 @@ describe('Text Viewer Handler', () => {
         assert.equal(renderParams.paginationData?.results?.count, 3);
         assert.equal(
             renderParams.paginationData?.items?.[0]?.href,
-            '/document/123e4567-e89b-12d3-a456-426614174000/view/text/page/1?crn=26-745678'
+            '/document/123e4567-e89b-12d3-a456-426614174000/view/text/page/1?crn=26-745678&type=hybrid-dates'
         );
         assert.equal(
             renderParams.paginationData?.previous?.href,
-            '/document/123e4567-e89b-12d3-a456-426614174000/view/text/page/1?crn=26-745678'
+            '/document/123e4567-e89b-12d3-a456-426614174000/view/text/page/1?crn=26-745678&type=hybrid-dates'
         );
         assert.equal(
             renderParams.paginationData?.next?.href,
-            '/document/123e4567-e89b-12d3-a456-426614174000/view/text/page/3?crn=26-745678'
+            '/document/123e4567-e89b-12d3-a456-426614174000/view/text/page/3?crn=26-745678&type=hybrid-dates'
         );
         assert.equal(result, sendResult);
     });

--- a/document/handlers/text-viewer.test.js
+++ b/document/handlers/text-viewer.test.js
@@ -285,7 +285,7 @@ describe('Text Viewer Handler', () => {
                 pageNumber: 1,
                 crn: '26-745678',
                 searchTerm: '12/12/1995',
-                searchType: 'keyword-dates',
+                searchType: 'hybrid-dates',
                 jwtToken: undefined,
                 logger: req.log
             }

--- a/document/handlers/text-viewer.test.js
+++ b/document/handlers/text-viewer.test.js
@@ -285,7 +285,9 @@ describe('Text Viewer Handler', () => {
                 pageNumber: 1,
                 crn: '26-745678',
                 searchTerm: '12/12/1995',
-                searchType: 'keyword',
+                useKeyword: true,
+                useSemantic: false,
+                useDates: true,
                 jwtToken: undefined,
                 logger: req.log
             }

--- a/document/services/document-chunks-service.js
+++ b/document/services/document-chunks-service.js
@@ -9,6 +9,7 @@ import createRequestServiceDefault from '../../service/request/index.js';
  * @param {number|string} options.pageNumber - The page number to fetch chunks for.
  * @param {string} options.crn - The case reference number.
  * @param {string} [options.searchTerm] - Search term to filter chunks by content.
+ * @param {'keyword'|'semantic'|'hybrid'} [options.searchType='keyword'] - Search mode for chunk matching.
  * @param {string} [options.jwtToken] - Optional JWT token for authentication.
  * @param {Object} options.logger - Logger instance for logging actions.
  * @param {Function} [options.createRequestService=createRequestServiceDefault] - Factory function to create a request service.
@@ -19,6 +20,7 @@ function createPageChunksService({
     pageNumber,
     crn,
     searchTerm,
+    searchType = 'keyword',
     jwtToken,
     logger,
     createRequestService = createRequestServiceDefault
@@ -36,15 +38,16 @@ function createPageChunksService({
     async function getPageChunks() {
         if (logger && typeof logger.info === 'function') {
             logger.info(
-                { documentId, pageNumber, crn, searchTerm },
+                { documentId, pageNumber, crn, searchTerm, searchType },
                 'Fetching document page chunks with bounding boxes'
             );
         }
 
         // there's an issue with URLSearchParams encoding spaces to '+' which is breaking the api call. When encoded as %20 it works fine.
+        const baseUrl = `${process.env.APP_API_URL}/document/${documentId}/page/${pageNumber}/chunks?crn=${encodeURIComponent(crn)}&type=${encodeURIComponent(searchType)}`;
         const url = searchTerm
-            ? `${process.env.APP_API_URL}/document/${documentId}/page/${pageNumber}/chunks?crn=${encodeURIComponent(crn)}&searchTerm=${encodeURIComponent(searchTerm)}`
-            : `${process.env.APP_API_URL}/document/${documentId}/page/${pageNumber}/chunks?crn=${encodeURIComponent(crn)}`;
+            ? `${baseUrl}&searchTerm=${encodeURIComponent(searchTerm)}`
+            : baseUrl;
 
         const opts = {
             url

--- a/document/services/document-chunks-service.js
+++ b/document/services/document-chunks-service.js
@@ -9,9 +9,7 @@ import createRequestServiceDefault from '../../service/request/index.js';
  * @param {number|string} options.pageNumber - The page number to fetch chunks for.
  * @param {string} options.crn - The case reference number.
  * @param {string} [options.searchTerm] - Search term to filter chunks by content.
- * @param {boolean} [options.useKeyword=true] - Enable lexical (BM25) keyword matching.
- * @param {boolean} [options.useSemantic=false] - Enable neural (vector) semantic matching.
- * @param {boolean} [options.useDates=true] - Enable date extraction and variant expansion.
+ * @param {string} [options.searchType='keyword-dates'] - Search mode (one of SEARCH_TYPES: keyword, keyword-dates, semantic, hybrid, hybrid-dates).
  * @param {string} [options.jwtToken] - Optional JWT token for authentication.
  * @param {Object} options.logger - Logger instance for logging actions.
  * @param {Function} [options.createRequestService=createRequestServiceDefault] - Factory function to create a request service.
@@ -22,9 +20,7 @@ function createPageChunksService({
     pageNumber,
     crn,
     searchTerm,
-    useKeyword = true,
-    useSemantic = false,
-    useDates = true,
+    searchType = 'keyword-dates',
     jwtToken,
     logger,
     createRequestService = createRequestServiceDefault
@@ -42,14 +38,13 @@ function createPageChunksService({
     async function getPageChunks() {
         if (logger && typeof logger.info === 'function') {
             logger.info(
-                { documentId, pageNumber, crn, searchTerm, useKeyword, useSemantic, useDates },
+                { documentId, pageNumber, crn, searchTerm, searchType },
                 'Fetching document page chunks with bounding boxes'
             );
         }
 
         // there's an issue with URLSearchParams encoding spaces to '+' which is breaking the api call. When encoded as %20 it works fine.
-        const flag = (val) => (val ? 'on' : 'off');
-        const baseUrl = `${process.env.APP_API_URL}/document/${documentId}/page/${pageNumber}/chunks?crn=${encodeURIComponent(crn)}&keyword=${flag(useKeyword)}&semantic=${flag(useSemantic)}&dates=${flag(useDates)}`;
+        const baseUrl = `${process.env.APP_API_URL}/document/${documentId}/page/${pageNumber}/chunks?crn=${encodeURIComponent(crn)}&type=${searchType}`;
         const url = searchTerm
             ? `${baseUrl}&searchTerm=${encodeURIComponent(searchTerm)}`
             : baseUrl;

--- a/document/services/document-chunks-service.js
+++ b/document/services/document-chunks-service.js
@@ -9,7 +9,9 @@ import createRequestServiceDefault from '../../service/request/index.js';
  * @param {number|string} options.pageNumber - The page number to fetch chunks for.
  * @param {string} options.crn - The case reference number.
  * @param {string} [options.searchTerm] - Search term to filter chunks by content.
- * @param {'keyword'|'semantic'|'hybrid'} [options.searchType='keyword'] - Search mode for chunk matching.
+ * @param {boolean} [options.useKeyword=true] - Enable lexical (BM25) keyword matching.
+ * @param {boolean} [options.useSemantic=false] - Enable neural (vector) semantic matching.
+ * @param {boolean} [options.useDates=true] - Enable date extraction and variant expansion.
  * @param {string} [options.jwtToken] - Optional JWT token for authentication.
  * @param {Object} options.logger - Logger instance for logging actions.
  * @param {Function} [options.createRequestService=createRequestServiceDefault] - Factory function to create a request service.
@@ -20,7 +22,9 @@ function createPageChunksService({
     pageNumber,
     crn,
     searchTerm,
-    searchType = 'keyword',
+    useKeyword = true,
+    useSemantic = false,
+    useDates = true,
     jwtToken,
     logger,
     createRequestService = createRequestServiceDefault
@@ -38,13 +42,13 @@ function createPageChunksService({
     async function getPageChunks() {
         if (logger && typeof logger.info === 'function') {
             logger.info(
-                { documentId, pageNumber, crn, searchTerm, searchType },
+                { documentId, pageNumber, crn, searchTerm, useKeyword, useSemantic, useDates },
                 'Fetching document page chunks with bounding boxes'
             );
         }
 
         // there's an issue with URLSearchParams encoding spaces to '+' which is breaking the api call. When encoded as %20 it works fine.
-        const baseUrl = `${process.env.APP_API_URL}/document/${documentId}/page/${pageNumber}/chunks?crn=${encodeURIComponent(crn)}&type=${encodeURIComponent(searchType)}`;
+        const baseUrl = `${process.env.APP_API_URL}/document/${documentId}/page/${pageNumber}/chunks?crn=${encodeURIComponent(crn)}&keyword=${useKeyword}&semantic=${useSemantic}&dates=${useDates}`;
         const url = searchTerm
             ? `${baseUrl}&searchTerm=${encodeURIComponent(searchTerm)}`
             : baseUrl;

--- a/document/services/document-chunks-service.js
+++ b/document/services/document-chunks-service.js
@@ -1,4 +1,5 @@
 import createRequestServiceDefault from '../../service/request/index.js';
+import { DEFAULT_SEARCH_TYPE } from '../../api/search/constants/searchTypes.js';
 
 /**
  * Creates a document chunks service for fetching bounding box data for document pages.
@@ -9,7 +10,7 @@ import createRequestServiceDefault from '../../service/request/index.js';
  * @param {number|string} options.pageNumber - The page number to fetch chunks for.
  * @param {string} options.crn - The case reference number.
  * @param {string} [options.searchTerm] - Search term to filter chunks by content.
- * @param {string} [options.searchType='keyword-dates'] - Search mode (one of SEARCH_TYPES: keyword, keyword-dates, semantic, hybrid, hybrid-dates).
+ * @param {string} [options.searchType=DEFAULT_SEARCH_TYPE] - Search mode (one of SEARCH_TYPES: keyword, keyword-dates, semantic, hybrid, hybrid-dates).
  * @param {string} [options.jwtToken] - Optional JWT token for authentication.
  * @param {Object} options.logger - Logger instance for logging actions.
  * @param {Function} [options.createRequestService=createRequestServiceDefault] - Factory function to create a request service.
@@ -20,7 +21,7 @@ function createPageChunksService({
     pageNumber,
     crn,
     searchTerm,
-    searchType = 'keyword-dates',
+    searchType = DEFAULT_SEARCH_TYPE,
     jwtToken,
     logger,
     createRequestService = createRequestServiceDefault

--- a/document/services/document-chunks-service.js
+++ b/document/services/document-chunks-service.js
@@ -1,5 +1,5 @@
-import createRequestServiceDefault from '../../service/request/index.js';
 import { DEFAULT_SEARCH_TYPE } from '../../api/search/constants/searchTypes.js';
+import createRequestServiceDefault from '../../service/request/index.js';
 
 /**
  * Creates a document chunks service for fetching bounding box data for document pages.

--- a/document/services/document-chunks-service.js
+++ b/document/services/document-chunks-service.js
@@ -48,7 +48,8 @@ function createPageChunksService({
         }
 
         // there's an issue with URLSearchParams encoding spaces to '+' which is breaking the api call. When encoded as %20 it works fine.
-        const baseUrl = `${process.env.APP_API_URL}/document/${documentId}/page/${pageNumber}/chunks?crn=${encodeURIComponent(crn)}&keyword=${useKeyword}&semantic=${useSemantic}&dates=${useDates}`;
+        const flag = (val) => (val ? 'on' : 'off');
+        const baseUrl = `${process.env.APP_API_URL}/document/${documentId}/page/${pageNumber}/chunks?crn=${encodeURIComponent(crn)}&keyword=${flag(useKeyword)}&semantic=${flag(useSemantic)}&dates=${flag(useDates)}`;
         const url = searchTerm
             ? `${baseUrl}&searchTerm=${encodeURIComponent(searchTerm)}`
             : baseUrl;

--- a/document/services/document-chunks-service.test.js
+++ b/document/services/document-chunks-service.test.js
@@ -97,6 +97,7 @@ describe('createPageChunksService', () => {
                 pageNumber: mockPageNumber,
                 crn: mockCrn,
                 searchTerm: mockSearchTerm,
+                searchType: 'semantic',
                 jwtToken: mockJwtToken,
                 logger: mockLogger,
                 createRequestService: mockCreateRequestService
@@ -108,7 +109,7 @@ describe('createPageChunksService', () => {
             assert.strictEqual(mockGet.calls.length, 1);
             assert.strictEqual(
                 mockGet.calls[0].url,
-                `http://localhost:3000/api/document/${mockDocumentId}/page/${mockPageNumber}/chunks?crn=${mockCrn}&searchTerm=${encodeURIComponent(mockSearchTerm)}`
+                `http://localhost:3000/api/document/${mockDocumentId}/page/${mockPageNumber}/chunks?crn=${mockCrn}&type=semantic&searchTerm=${encodeURIComponent(mockSearchTerm)}`
             );
             assert.deepStrictEqual(mockGet.calls[0].headers, {
                 Authorization: `Bearer ${mockJwtToken}`
@@ -159,6 +160,7 @@ describe('createPageChunksService', () => {
                 pageNumber: mockPageNumber,
                 crn: mockCrn,
                 searchTerm: mockSearchTerm,
+                searchType: 'hybrid',
                 jwtToken: mockJwtToken,
                 logger: mockLogger,
                 createRequestService: mockCreateRequestService
@@ -168,6 +170,7 @@ describe('createPageChunksService', () => {
 
             assert.strictEqual(mockGet.calls.length, 1);
             assert.strictEqual(mockGet.calls[0].url.includes(`crn=${mockCrn}`), true);
+            assert.strictEqual(mockGet.calls[0].url.includes('type=hybrid'), true);
             assert.strictEqual(
                 mockGet.calls[0].url.includes(`searchTerm=${encodeURIComponent(mockSearchTerm)}`),
                 true

--- a/document/services/document-chunks-service.test.js
+++ b/document/services/document-chunks-service.test.js
@@ -97,9 +97,7 @@ describe('createPageChunksService', () => {
                 pageNumber: mockPageNumber,
                 crn: mockCrn,
                 searchTerm: mockSearchTerm,
-                useKeyword: false,
-                useSemantic: true,
-                useDates: false,
+                searchType: 'semantic',
                 jwtToken: mockJwtToken,
                 logger: mockLogger,
                 createRequestService: mockCreateRequestService
@@ -111,7 +109,7 @@ describe('createPageChunksService', () => {
             assert.strictEqual(mockGet.calls.length, 1);
             assert.strictEqual(
                 mockGet.calls[0].url,
-                `http://localhost:3000/api/document/${mockDocumentId}/page/${mockPageNumber}/chunks?crn=${mockCrn}&keyword=off&semantic=on&dates=off&searchTerm=${encodeURIComponent(mockSearchTerm)}`
+                `http://localhost:3000/api/document/${mockDocumentId}/page/${mockPageNumber}/chunks?crn=${mockCrn}&type=semantic&searchTerm=${encodeURIComponent(mockSearchTerm)}`
             );
             assert.deepStrictEqual(mockGet.calls[0].headers, {
                 Authorization: `Bearer ${mockJwtToken}`
@@ -162,21 +160,16 @@ describe('createPageChunksService', () => {
                 pageNumber: mockPageNumber,
                 crn: mockCrn,
                 searchTerm: mockSearchTerm,
-                useKeyword: true,
-                useSemantic: true,
-                useDates: true,
+                searchType: 'hybrid',
                 jwtToken: mockJwtToken,
                 logger: mockLogger,
                 createRequestService: mockCreateRequestService
             });
 
             await service.getPageChunks();
-
             assert.strictEqual(mockGet.calls.length, 1);
             assert.strictEqual(mockGet.calls[0].url.includes(`crn=${mockCrn}`), true);
-            assert.strictEqual(mockGet.calls[0].url.includes('keyword=on'), true);
-            assert.strictEqual(mockGet.calls[0].url.includes('semantic=on'), true);
-            assert.strictEqual(mockGet.calls[0].url.includes('dates=on'), true);
+            assert.strictEqual(mockGet.calls[0].url.includes('type=hybrid'), true);
             assert.strictEqual(
                 mockGet.calls[0].url.includes(`searchTerm=${encodeURIComponent(mockSearchTerm)}`),
                 true

--- a/document/services/document-chunks-service.test.js
+++ b/document/services/document-chunks-service.test.js
@@ -111,7 +111,7 @@ describe('createPageChunksService', () => {
             assert.strictEqual(mockGet.calls.length, 1);
             assert.strictEqual(
                 mockGet.calls[0].url,
-                `http://localhost:3000/api/document/${mockDocumentId}/page/${mockPageNumber}/chunks?crn=${mockCrn}&keyword=false&semantic=true&dates=false&searchTerm=${encodeURIComponent(mockSearchTerm)}`
+                `http://localhost:3000/api/document/${mockDocumentId}/page/${mockPageNumber}/chunks?crn=${mockCrn}&keyword=off&semantic=on&dates=off&searchTerm=${encodeURIComponent(mockSearchTerm)}`
             );
             assert.deepStrictEqual(mockGet.calls[0].headers, {
                 Authorization: `Bearer ${mockJwtToken}`
@@ -174,9 +174,9 @@ describe('createPageChunksService', () => {
 
             assert.strictEqual(mockGet.calls.length, 1);
             assert.strictEqual(mockGet.calls[0].url.includes(`crn=${mockCrn}`), true);
-            assert.strictEqual(mockGet.calls[0].url.includes('keyword=true'), true);
-            assert.strictEqual(mockGet.calls[0].url.includes('semantic=true'), true);
-            assert.strictEqual(mockGet.calls[0].url.includes('dates=true'), true);
+            assert.strictEqual(mockGet.calls[0].url.includes('keyword=on'), true);
+            assert.strictEqual(mockGet.calls[0].url.includes('semantic=on'), true);
+            assert.strictEqual(mockGet.calls[0].url.includes('dates=on'), true);
             assert.strictEqual(
                 mockGet.calls[0].url.includes(`searchTerm=${encodeURIComponent(mockSearchTerm)}`),
                 true

--- a/document/services/document-chunks-service.test.js
+++ b/document/services/document-chunks-service.test.js
@@ -97,7 +97,9 @@ describe('createPageChunksService', () => {
                 pageNumber: mockPageNumber,
                 crn: mockCrn,
                 searchTerm: mockSearchTerm,
-                searchType: 'semantic',
+                useKeyword: false,
+                useSemantic: true,
+                useDates: false,
                 jwtToken: mockJwtToken,
                 logger: mockLogger,
                 createRequestService: mockCreateRequestService
@@ -109,7 +111,7 @@ describe('createPageChunksService', () => {
             assert.strictEqual(mockGet.calls.length, 1);
             assert.strictEqual(
                 mockGet.calls[0].url,
-                `http://localhost:3000/api/document/${mockDocumentId}/page/${mockPageNumber}/chunks?crn=${mockCrn}&type=semantic&searchTerm=${encodeURIComponent(mockSearchTerm)}`
+                `http://localhost:3000/api/document/${mockDocumentId}/page/${mockPageNumber}/chunks?crn=${mockCrn}&keyword=false&semantic=true&dates=false&searchTerm=${encodeURIComponent(mockSearchTerm)}`
             );
             assert.deepStrictEqual(mockGet.calls[0].headers, {
                 Authorization: `Bearer ${mockJwtToken}`
@@ -160,7 +162,9 @@ describe('createPageChunksService', () => {
                 pageNumber: mockPageNumber,
                 crn: mockCrn,
                 searchTerm: mockSearchTerm,
-                searchType: 'hybrid',
+                useKeyword: true,
+                useSemantic: true,
+                useDates: true,
                 jwtToken: mockJwtToken,
                 logger: mockLogger,
                 createRequestService: mockCreateRequestService
@@ -170,7 +174,9 @@ describe('createPageChunksService', () => {
 
             assert.strictEqual(mockGet.calls.length, 1);
             assert.strictEqual(mockGet.calls[0].url.includes(`crn=${mockCrn}`), true);
-            assert.strictEqual(mockGet.calls[0].url.includes('type=hybrid'), true);
+            assert.strictEqual(mockGet.calls[0].url.includes('keyword=true'), true);
+            assert.strictEqual(mockGet.calls[0].url.includes('semantic=true'), true);
+            assert.strictEqual(mockGet.calls[0].url.includes('dates=true'), true);
             assert.strictEqual(
                 mockGet.calls[0].url.includes(`searchTerm=${encodeURIComponent(mockSearchTerm)}`),
                 true

--- a/document/utils/link-builders/index.js
+++ b/document/utils/link-builders/index.js
@@ -21,10 +21,17 @@ export function buildImageUrl(documentId, pageNumber, crn) {
  * @param {number} pageNumber - The page number
  * @param {string} crn - The case reference number
  * @param {string} [searchTerm=''] - The search term
+ * @param {'keyword'|'semantic'|'hybrid'} [searchType='keyword'] - Search type mode
  * @returns {string} The text view URL
  */
-export function buildTextPageLink(documentId, pageNumber, crn, searchTerm = '') {
-    return `/document/${documentId}/view/text/page/${pageNumber}?crn=${encodeURIComponent(crn)}&searchTerm=${encodeURIComponent(searchTerm)}`;
+export function buildTextPageLink(
+    documentId,
+    pageNumber,
+    crn,
+    searchTerm = '',
+    searchType = 'keyword'
+) {
+    return `/document/${documentId}/view/text/page/${pageNumber}?crn=${encodeURIComponent(crn)}&searchTerm=${encodeURIComponent(searchTerm)}&type=${encodeURIComponent(searchType)}`;
 }
 
 /**
@@ -34,8 +41,15 @@ export function buildTextPageLink(documentId, pageNumber, crn, searchTerm = '') 
  * @param {number} pageNumber - The page number
  * @param {string} crn - The case reference number
  * @param {string} [searchTerm=''] - The search term
+ * @param {'keyword'|'semantic'|'hybrid'} [searchType='keyword'] - Search type mode
  * @returns {string} The image view URL
  */
-export function buildImagePageLink(documentId, pageNumber, crn, searchTerm = '') {
-    return `/document/${documentId}/view/page/${pageNumber}?crn=${encodeURIComponent(crn)}&searchTerm=${encodeURIComponent(searchTerm)}`;
+export function buildImagePageLink(
+    documentId,
+    pageNumber,
+    crn,
+    searchTerm = '',
+    searchType = 'keyword'
+) {
+    return `/document/${documentId}/view/page/${pageNumber}?crn=${encodeURIComponent(crn)}&searchTerm=${encodeURIComponent(searchTerm)}&type=${encodeURIComponent(searchType)}`;
 }

--- a/document/utils/link-builders/index.js
+++ b/document/utils/link-builders/index.js
@@ -2,18 +2,22 @@
  * Utility functions for building navigation and document URLs.
  */
 
+import {
+    DEFAULT_SEARCH_TYPE,
+    resolveSearchType
+} from '../../../api/search/constants/searchTypes.js';
+
 /**
  * Builds the image streaming URL for a document page.
  *
  * @param {string} documentId - The document UUID
  * @param {number} pageNumber - The page number
  * @param {string} crn - The case reference number
- * @param {string} [searchType=''] - Optional active search type feature flag value; when omitted, no `type` query parameter is added
- * @returns {string} The image URL path
+ * @param {string} [searchType=DEFAULT_SEARCH_TYPE] - The active search type value
  */
-export function buildImageUrl(documentId, pageNumber, crn, searchType = '') {
+export function buildImageUrl(documentId, pageNumber, crn, searchType = DEFAULT_SEARCH_TYPE) {
     const base = `/document/${documentId}/page/${pageNumber}?crn=${crn}`;
-    return searchType ? `${base}&type=${encodeURIComponent(searchType)}` : base;
+    return `${base}&type=${encodeURIComponent(resolveSearchType(searchType))}`;
 }
 
 /**
@@ -23,12 +27,18 @@ export function buildImageUrl(documentId, pageNumber, crn, searchType = '') {
  * @param {number} pageNumber - The page number
  * @param {string} crn - The case reference number
  * @param {string} [searchTerm=''] - The search term
- * @param {string} [searchType=''] - Optional active search type feature flag value; when omitted, no `type` query parameter is added
+ * @param {string} [searchType=DEFAULT_SEARCH_TYPE] - The active search type value
  * @returns {string} The text view URL
  */
-export function buildTextPageLink(documentId, pageNumber, crn, searchTerm = '', searchType = '') {
+export function buildTextPageLink(
+    documentId,
+    pageNumber,
+    crn,
+    searchTerm = '',
+    searchType = DEFAULT_SEARCH_TYPE
+) {
     const base = `/document/${documentId}/view/text/page/${pageNumber}?crn=${encodeURIComponent(crn)}&searchTerm=${encodeURIComponent(searchTerm)}`;
-    return searchType ? `${base}&type=${encodeURIComponent(searchType)}` : base;
+    return `${base}&type=${encodeURIComponent(resolveSearchType(searchType))}`;
 }
 
 /**
@@ -38,10 +48,16 @@ export function buildTextPageLink(documentId, pageNumber, crn, searchTerm = '', 
  * @param {number} pageNumber - The page number
  * @param {string} crn - The case reference number
  * @param {string} [searchTerm=''] - The search term
- * @param {string} [searchType=''] - Optional active search type feature flag value; when omitted, no `type` query parameter is added
+ * @param {string} [searchType=DEFAULT_SEARCH_TYPE] - The active search type value
  * @returns {string} The image view URL
  */
-export function buildImagePageLink(documentId, pageNumber, crn, searchTerm = '', searchType = '') {
+export function buildImagePageLink(
+    documentId,
+    pageNumber,
+    crn,
+    searchTerm = '',
+    searchType = DEFAULT_SEARCH_TYPE
+) {
     const base = `/document/${documentId}/view/page/${pageNumber}?crn=${encodeURIComponent(crn)}&searchTerm=${encodeURIComponent(searchTerm)}`;
-    return searchType ? `${base}&type=${encodeURIComponent(searchType)}` : base;
+    return `${base}&type=${encodeURIComponent(resolveSearchType(searchType))}`;
 }

--- a/document/utils/link-builders/index.js
+++ b/document/utils/link-builders/index.js
@@ -8,7 +8,7 @@
  * @param {string} documentId - The document UUID
  * @param {number} pageNumber - The page number
  * @param {string} crn - The case reference number
- * @param {string} [searchType=''] - The active search type value
+ * @param {string} [searchType=''] - Optional active search type feature flag value; when omitted, no `type` query parameter is added
  * @returns {string} The image URL path
  */
 export function buildImageUrl(documentId, pageNumber, crn, searchType = '') {
@@ -23,7 +23,7 @@ export function buildImageUrl(documentId, pageNumber, crn, searchType = '') {
  * @param {number} pageNumber - The page number
  * @param {string} crn - The case reference number
  * @param {string} [searchTerm=''] - The search term
- * @param {string} [searchType=''] - The active search type value
+ * @param {string} [searchType=''] - Optional active search type feature flag value; when omitted, no `type` query parameter is added
  * @returns {string} The text view URL
  */
 export function buildTextPageLink(documentId, pageNumber, crn, searchTerm = '', searchType = '') {
@@ -38,7 +38,7 @@ export function buildTextPageLink(documentId, pageNumber, crn, searchTerm = '', 
  * @param {number} pageNumber - The page number
  * @param {string} crn - The case reference number
  * @param {string} [searchTerm=''] - The search term
- * @param {string} [searchType=''] - The active search type value
+ * @param {string} [searchType=''] - Optional active search type feature flag value; when omitted, no `type` query parameter is added
  * @returns {string} The image view URL
  */
 export function buildImagePageLink(documentId, pageNumber, crn, searchTerm = '', searchType = '') {

--- a/document/utils/link-builders/index.js
+++ b/document/utils/link-builders/index.js
@@ -15,6 +15,7 @@ import {
  * @param {string} crn - The case reference number
  * @param {string} [searchType=DEFAULT_SEARCH_TYPE] - The active search type value
  * @param {Object} [session={}] - The session object
+ * @returns {string} The image streaming URL
  */
 export function buildImageUrl(
     documentId,

--- a/document/utils/link-builders/index.js
+++ b/document/utils/link-builders/index.js
@@ -14,10 +14,17 @@ import {
  * @param {number} pageNumber - The page number
  * @param {string} crn - The case reference number
  * @param {string} [searchType=DEFAULT_SEARCH_TYPE] - The active search type value
+ * @param {Object} [session={}] - The session object
  */
-export function buildImageUrl(documentId, pageNumber, crn, searchType = DEFAULT_SEARCH_TYPE) {
+export function buildImageUrl(
+    documentId,
+    pageNumber,
+    crn,
+    searchType = DEFAULT_SEARCH_TYPE,
+    session = {}
+) {
     const base = `/document/${documentId}/page/${pageNumber}?crn=${crn}`;
-    return `${base}&type=${encodeURIComponent(resolveSearchType(searchType))}`;
+    return `${base}&type=${encodeURIComponent(resolveSearchType(searchType, session))}`;
 }
 
 /**
@@ -28,6 +35,7 @@ export function buildImageUrl(documentId, pageNumber, crn, searchType = DEFAULT_
  * @param {string} crn - The case reference number
  * @param {string} [searchTerm=''] - The search term
  * @param {string} [searchType=DEFAULT_SEARCH_TYPE] - The active search type value
+ * @param {Object} [session={}] - The session object
  * @returns {string} The text view URL
  */
 export function buildTextPageLink(
@@ -35,10 +43,11 @@ export function buildTextPageLink(
     pageNumber,
     crn,
     searchTerm = '',
-    searchType = DEFAULT_SEARCH_TYPE
+    searchType = DEFAULT_SEARCH_TYPE,
+    session = {}
 ) {
     const base = `/document/${documentId}/view/text/page/${pageNumber}?crn=${encodeURIComponent(crn)}&searchTerm=${encodeURIComponent(searchTerm)}`;
-    return `${base}&type=${encodeURIComponent(resolveSearchType(searchType))}`;
+    return `${base}&type=${encodeURIComponent(resolveSearchType(searchType, session))}`;
 }
 
 /**
@@ -49,6 +58,7 @@ export function buildTextPageLink(
  * @param {string} crn - The case reference number
  * @param {string} [searchTerm=''] - The search term
  * @param {string} [searchType=DEFAULT_SEARCH_TYPE] - The active search type value
+ * @param {Object} [session={}] - The session object
  * @returns {string} The image view URL
  */
 export function buildImagePageLink(
@@ -56,8 +66,9 @@ export function buildImagePageLink(
     pageNumber,
     crn,
     searchTerm = '',
-    searchType = DEFAULT_SEARCH_TYPE
+    searchType = DEFAULT_SEARCH_TYPE,
+    session = {}
 ) {
     const base = `/document/${documentId}/view/page/${pageNumber}?crn=${encodeURIComponent(crn)}&searchTerm=${encodeURIComponent(searchTerm)}`;
-    return `${base}&type=${encodeURIComponent(resolveSearchType(searchType))}`;
+    return `${base}&type=${encodeURIComponent(resolveSearchType(searchType, session))}`;
 }

--- a/document/utils/link-builders/index.js
+++ b/document/utils/link-builders/index.js
@@ -8,7 +8,7 @@
  * @param {string} documentId - The document UUID
  * @param {number} pageNumber - The page number
  * @param {string} crn - The case reference number
- * @param {string} [searchType=''] - The active search type slug
+ * @param {string} [searchType=''] - The active search type value
  * @returns {string} The image URL path
  */
 export function buildImageUrl(documentId, pageNumber, crn, searchType = '') {
@@ -23,7 +23,7 @@ export function buildImageUrl(documentId, pageNumber, crn, searchType = '') {
  * @param {number} pageNumber - The page number
  * @param {string} crn - The case reference number
  * @param {string} [searchTerm=''] - The search term
- * @param {string} [searchType=''] - The active search type slug
+ * @param {string} [searchType=''] - The active search type value
  * @returns {string} The text view URL
  */
 export function buildTextPageLink(documentId, pageNumber, crn, searchTerm = '', searchType = '') {
@@ -38,7 +38,7 @@ export function buildTextPageLink(documentId, pageNumber, crn, searchTerm = '', 
  * @param {number} pageNumber - The page number
  * @param {string} crn - The case reference number
  * @param {string} [searchTerm=''] - The search term
- * @param {string} [searchType=''] - The active search type slug
+ * @param {string} [searchType=''] - The active search type value
  * @returns {string} The image view URL
  */
 export function buildImagePageLink(documentId, pageNumber, crn, searchTerm = '', searchType = '') {

--- a/document/utils/link-builders/index.js
+++ b/document/utils/link-builders/index.js
@@ -21,17 +21,10 @@ export function buildImageUrl(documentId, pageNumber, crn) {
  * @param {number} pageNumber - The page number
  * @param {string} crn - The case reference number
  * @param {string} [searchTerm=''] - The search term
- * @param {'keyword'|'semantic'|'hybrid'} [searchType='keyword'] - Search type mode
  * @returns {string} The text view URL
  */
-export function buildTextPageLink(
-    documentId,
-    pageNumber,
-    crn,
-    searchTerm = '',
-    searchType = 'keyword'
-) {
-    return `/document/${documentId}/view/text/page/${pageNumber}?crn=${encodeURIComponent(crn)}&searchTerm=${encodeURIComponent(searchTerm)}&type=${encodeURIComponent(searchType)}`;
+export function buildTextPageLink(documentId, pageNumber, crn, searchTerm = '') {
+    return `/document/${documentId}/view/text/page/${pageNumber}?crn=${encodeURIComponent(crn)}&searchTerm=${encodeURIComponent(searchTerm)}`;
 }
 
 /**
@@ -41,15 +34,8 @@ export function buildTextPageLink(
  * @param {number} pageNumber - The page number
  * @param {string} crn - The case reference number
  * @param {string} [searchTerm=''] - The search term
- * @param {'keyword'|'semantic'|'hybrid'} [searchType='keyword'] - Search type mode
  * @returns {string} The image view URL
  */
-export function buildImagePageLink(
-    documentId,
-    pageNumber,
-    crn,
-    searchTerm = '',
-    searchType = 'keyword'
-) {
-    return `/document/${documentId}/view/page/${pageNumber}?crn=${encodeURIComponent(crn)}&searchTerm=${encodeURIComponent(searchTerm)}&type=${encodeURIComponent(searchType)}`;
+export function buildImagePageLink(documentId, pageNumber, crn, searchTerm = '') {
+    return `/document/${documentId}/view/page/${pageNumber}?crn=${encodeURIComponent(crn)}&searchTerm=${encodeURIComponent(searchTerm)}`;
 }

--- a/document/utils/link-builders/index.js
+++ b/document/utils/link-builders/index.js
@@ -8,10 +8,12 @@
  * @param {string} documentId - The document UUID
  * @param {number} pageNumber - The page number
  * @param {string} crn - The case reference number
+ * @param {string} [searchType=''] - The active search type slug
  * @returns {string} The image URL path
  */
-export function buildImageUrl(documentId, pageNumber, crn) {
-    return `/document/${documentId}/page/${pageNumber}?crn=${crn}`;
+export function buildImageUrl(documentId, pageNumber, crn, searchType = '') {
+    const base = `/document/${documentId}/page/${pageNumber}?crn=${crn}`;
+    return searchType ? `${base}&type=${encodeURIComponent(searchType)}` : base;
 }
 
 /**
@@ -21,10 +23,12 @@ export function buildImageUrl(documentId, pageNumber, crn) {
  * @param {number} pageNumber - The page number
  * @param {string} crn - The case reference number
  * @param {string} [searchTerm=''] - The search term
+ * @param {string} [searchType=''] - The active search type slug
  * @returns {string} The text view URL
  */
-export function buildTextPageLink(documentId, pageNumber, crn, searchTerm = '') {
-    return `/document/${documentId}/view/text/page/${pageNumber}?crn=${encodeURIComponent(crn)}&searchTerm=${encodeURIComponent(searchTerm)}`;
+export function buildTextPageLink(documentId, pageNumber, crn, searchTerm = '', searchType = '') {
+    const base = `/document/${documentId}/view/text/page/${pageNumber}?crn=${encodeURIComponent(crn)}&searchTerm=${encodeURIComponent(searchTerm)}`;
+    return searchType ? `${base}&type=${encodeURIComponent(searchType)}` : base;
 }
 
 /**
@@ -34,8 +38,10 @@ export function buildTextPageLink(documentId, pageNumber, crn, searchTerm = '') 
  * @param {number} pageNumber - The page number
  * @param {string} crn - The case reference number
  * @param {string} [searchTerm=''] - The search term
+ * @param {string} [searchType=''] - The active search type slug
  * @returns {string} The image view URL
  */
-export function buildImagePageLink(documentId, pageNumber, crn, searchTerm = '') {
-    return `/document/${documentId}/view/page/${pageNumber}?crn=${encodeURIComponent(crn)}&searchTerm=${encodeURIComponent(searchTerm)}`;
+export function buildImagePageLink(documentId, pageNumber, crn, searchTerm = '', searchType = '') {
+    const base = `/document/${documentId}/view/page/${pageNumber}?crn=${encodeURIComponent(crn)}&searchTerm=${encodeURIComponent(searchTerm)}`;
+    return searchType ? `${base}&type=${encodeURIComponent(searchType)}` : base;
 }

--- a/document/utils/link-builders/index.test.js
+++ b/document/utils/link-builders/index.test.js
@@ -16,6 +16,16 @@ describe('Link Builders', () => {
             const result = buildImageUrl(docId, 42, crn);
             assert.strictEqual(result, `/document/${docId}/page/42?crn=${crn}`);
         });
+
+        it('appends type when searchType is provided', () => {
+            const result = buildImageUrl(docId, 1, crn, 'keyword');
+            assert.strictEqual(result, `/document/${docId}/page/1?crn=${crn}&type=keyword`);
+        });
+
+        it('omits type when searchType is empty', () => {
+            const result = buildImageUrl(docId, 1, crn, '');
+            assert.strictEqual(result, `/document/${docId}/page/1?crn=${crn}`);
+        });
     });
 
     describe('buildTextPageLink', () => {
@@ -36,6 +46,16 @@ describe('Link Builders', () => {
             const result = buildTextPageLink(docId, 1, crn, 'test & special');
             assert.ok(result.includes(encodeURIComponent('test & special')));
         });
+
+        it('appends type when searchType is provided', () => {
+            const result = buildTextPageLink(docId, 1, crn, 'foo', 'hybrid-dates');
+            assert.ok(result.includes('&type=hybrid-dates'));
+        });
+
+        it('omits type when searchType is empty', () => {
+            const result = buildTextPageLink(docId, 1, crn, 'foo');
+            assert.ok(!result.includes('type='));
+        });
     });
 
     describe('buildImagePageLink', () => {
@@ -50,6 +70,16 @@ describe('Link Builders', () => {
             const result = buildImagePageLink(docId, 1, crn);
             assert.ok(result.includes(`/document/${docId}/view/page/1`));
             assert.ok(result.includes('searchTerm='));
+        });
+
+        it('appends type when searchType is provided', () => {
+            const result = buildImagePageLink(docId, 1, crn, 'foo', 'hybrid-dates');
+            assert.ok(result.includes('&type=hybrid-dates'));
+        });
+
+        it('omits type when searchType is empty', () => {
+            const result = buildImagePageLink(docId, 1, crn, 'foo');
+            assert.ok(!result.includes('type='));
         });
     });
 });

--- a/document/utils/link-builders/index.test.js
+++ b/document/utils/link-builders/index.test.js
@@ -57,6 +57,17 @@ describe('Link Builders', () => {
                 `/document/${docId}/page/1?crn=${crn}&type=${DEFAULT_SEARCH_TYPE}`
             );
         });
+
+        it('uses session feature-flag type when searchType is invalid and session override is set', () => {
+            const session = { featureFlags: { type: 'semantic' } };
+            const result = buildImageUrl(docId, 1, crn, 'invalid-type', session);
+            assert.ok(result.includes('&type=semantic'));
+        });
+
+        it('falls back to DEFAULT_SEARCH_TYPE when searchType is invalid and session has no type flag', () => {
+            const result = buildImageUrl(docId, 1, crn, 'invalid-type', {});
+            assert.ok(result.includes(`&type=${DEFAULT_SEARCH_TYPE}`));
+        });
     });
 
     describe('buildTextPageLink', () => {
@@ -100,6 +111,17 @@ describe('Link Builders', () => {
             assert.ok(result.includes(`/document/${docId}/view/text/page/1`));
             assert.ok(result.includes(`&type=${DEFAULT_SEARCH_TYPE}`));
         });
+
+        it('uses session feature-flag type when searchType is invalid and session override is set', () => {
+            const session = { featureFlags: { type: 'semantic' } };
+            const result = buildTextPageLink(docId, 1, crn, '', 'invalid-type', session);
+            assert.ok(result.includes('&type=semantic'));
+        });
+
+        it('falls back to DEFAULT_SEARCH_TYPE when searchType is invalid and session has no type flag', () => {
+            const result = buildTextPageLink(docId, 1, crn, '', 'invalid-type', {});
+            assert.ok(result.includes(`&type=${DEFAULT_SEARCH_TYPE}`));
+        });
     });
 
     describe('buildImagePageLink', () => {
@@ -136,6 +158,17 @@ describe('Link Builders', () => {
         it('defaults to DEFAULT_SEARCH_TYPE when searchType is empty string', () => {
             const result = buildImagePageLink(docId, 1, crn, '', '');
             assert.ok(result.includes(`/document/${docId}/view/page/1`));
+            assert.ok(result.includes(`&type=${DEFAULT_SEARCH_TYPE}`));
+        });
+
+        it('uses session feature-flag type when searchType is invalid and session override is set', () => {
+            const session = { featureFlags: { type: 'semantic' } };
+            const result = buildImagePageLink(docId, 1, crn, '', 'invalid-type', session);
+            assert.ok(result.includes('&type=semantic'));
+        });
+
+        it('falls back to DEFAULT_SEARCH_TYPE when searchType is invalid and session has no type flag', () => {
+            const result = buildImagePageLink(docId, 1, crn, '', 'invalid-type', {});
             assert.ok(result.includes(`&type=${DEFAULT_SEARCH_TYPE}`));
         });
     });

--- a/document/utils/link-builders/index.test.js
+++ b/document/utils/link-builders/index.test.js
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { DEFAULT_SEARCH_TYPE } from '../../../api/search/constants/searchTypes.js';
 import { buildImagePageLink, buildImageUrl, buildTextPageLink } from './index.js';
 
 describe('Link Builders', () => {
@@ -9,12 +10,18 @@ describe('Link Builders', () => {
     describe('buildImageUrl', () => {
         it('builds image URL correctly', () => {
             const result = buildImageUrl(docId, 1, crn);
-            assert.strictEqual(result, `/document/${docId}/page/1?crn=${crn}`);
+            assert.strictEqual(
+                result,
+                `/document/${docId}/page/1?crn=${crn}&type=${DEFAULT_SEARCH_TYPE}`
+            );
         });
 
         it('handles different page numbers', () => {
             const result = buildImageUrl(docId, 42, crn);
-            assert.strictEqual(result, `/document/${docId}/page/42?crn=${crn}`);
+            assert.strictEqual(
+                result,
+                `/document/${docId}/page/42?crn=${crn}&type=${DEFAULT_SEARCH_TYPE}`
+            );
         });
 
         it('appends type when searchType is provided', () => {
@@ -22,9 +29,33 @@ describe('Link Builders', () => {
             assert.strictEqual(result, `/document/${docId}/page/1?crn=${crn}&type=keyword`);
         });
 
-        it('omits type when searchType is empty', () => {
+        it('defaults to DEFAULT_SEARCH_TYPE when searchType is not provided', () => {
+            const result = buildImageUrl(docId, 1, crn);
+            assert.ok(result.includes(`&type=${DEFAULT_SEARCH_TYPE}`));
+        });
+
+        it('defaults to DEFAULT_SEARCH_TYPE when searchType is undefined', () => {
+            const result = buildImageUrl(docId, 1, crn, undefined);
+            assert.strictEqual(
+                result,
+                `/document/${docId}/page/1?crn=${crn}&type=${DEFAULT_SEARCH_TYPE}`
+            );
+        });
+
+        it('defaults to DEFAULT_SEARCH_TYPE when searchType is invalid', () => {
+            const result = buildImageUrl(docId, 1, crn, 'invalid-type');
+            assert.strictEqual(
+                result,
+                `/document/${docId}/page/1?crn=${crn}&type=${DEFAULT_SEARCH_TYPE}`
+            );
+        });
+
+        it('defaults to DEFAULT_SEARCH_TYPE when searchType is empty string', () => {
             const result = buildImageUrl(docId, 1, crn, '');
-            assert.strictEqual(result, `/document/${docId}/page/1?crn=${crn}`);
+            assert.strictEqual(
+                result,
+                `/document/${docId}/page/1?crn=${crn}&type=${DEFAULT_SEARCH_TYPE}`
+            );
         });
     });
 
@@ -47,14 +78,27 @@ describe('Link Builders', () => {
             assert.ok(result.includes(encodeURIComponent('test & special')));
         });
 
-        it('appends type when searchType is provided', () => {
-            const result = buildTextPageLink(docId, 1, crn, 'foo', 'hybrid-dates');
-            assert.ok(result.includes('&type=hybrid-dates'));
+        it('defaults to DEFAULT_SEARCH_TYPE when searchType is not provided', () => {
+            const result = buildTextPageLink(docId, 1, crn);
+            assert.ok(result.includes(`&type=${DEFAULT_SEARCH_TYPE}`));
         });
 
-        it('omits type when searchType is empty', () => {
-            const result = buildTextPageLink(docId, 1, crn, 'foo');
-            assert.ok(!result.includes('type='));
+        it('defaults to DEFAULT_SEARCH_TYPE when searchType is undefined', () => {
+            const result = buildTextPageLink(docId, 1, crn, '', undefined);
+            assert.ok(result.includes(`/document/${docId}/view/text/page/1`));
+            assert.ok(result.includes(`&type=${DEFAULT_SEARCH_TYPE}`));
+        });
+
+        it('defaults to DEFAULT_SEARCH_TYPE when searchType is invalid', () => {
+            const result = buildTextPageLink(docId, 1, crn, '', 'invalid-type');
+            assert.ok(result.includes(`/document/${docId}/view/text/page/1`));
+            assert.ok(result.includes(`&type=${DEFAULT_SEARCH_TYPE}`));
+        });
+
+        it('defaults to DEFAULT_SEARCH_TYPE when searchType is empty string', () => {
+            const result = buildTextPageLink(docId, 1, crn, '', '');
+            assert.ok(result.includes(`/document/${docId}/view/text/page/1`));
+            assert.ok(result.includes(`&type=${DEFAULT_SEARCH_TYPE}`));
         });
     });
 
@@ -72,14 +116,27 @@ describe('Link Builders', () => {
             assert.ok(result.includes('searchTerm='));
         });
 
-        it('appends type when searchType is provided', () => {
-            const result = buildImagePageLink(docId, 1, crn, 'foo', 'hybrid-dates');
-            assert.ok(result.includes('&type=hybrid-dates'));
+        it('defaults to DEFAULT_SEARCH_TYPE when searchType is not provided', () => {
+            const result = buildImagePageLink(docId, 1, crn);
+            assert.ok(result.includes(`&type=${DEFAULT_SEARCH_TYPE}`));
         });
 
-        it('omits type when searchType is empty', () => {
-            const result = buildImagePageLink(docId, 1, crn, 'foo');
-            assert.ok(!result.includes('type='));
+        it('defaults to DEFAULT_SEARCH_TYPE when searchType is undefined', () => {
+            const result = buildImagePageLink(docId, 1, crn, '', undefined);
+            assert.ok(result.includes(`/document/${docId}/view/page/1`));
+            assert.ok(result.includes(`&type=${DEFAULT_SEARCH_TYPE}`));
+        });
+
+        it('defaults to DEFAULT_SEARCH_TYPE when searchType is invalid', () => {
+            const result = buildImagePageLink(docId, 1, crn, '', 'invalid-type');
+            assert.ok(result.includes(`/document/${docId}/view/page/1`));
+            assert.ok(result.includes(`&type=${DEFAULT_SEARCH_TYPE}`));
+        });
+
+        it('defaults to DEFAULT_SEARCH_TYPE when searchType is empty string', () => {
+            const result = buildImagePageLink(docId, 1, crn, '', '');
+            assert.ok(result.includes(`/document/${docId}/view/page/1`));
+            assert.ok(result.includes(`&type=${DEFAULT_SEARCH_TYPE}`));
         });
     });
 });

--- a/document/utils/pagination/index.js
+++ b/document/utils/pagination/index.js
@@ -89,17 +89,19 @@ const buildPaginationItems = ({ visiblePages, currentPageIndex, buildPageUrl }) 
  * @param {object} options - Query options.
  * @param {object} [options.query] - Optional request query object.
  * @param {string} [options.query.searchTerm] - Search term to preserve in links.
+ * @param {string} [options.query.type] - Search type to preserve in links.
  * @param {object} [options.params] - Optional route params object.
  * @param {string} [options.params.crn] - Case reference number.
  * @returns {string} Encoded query string.
  */
 const buildQueryString = ({ query, params }) => {
-    const { searchTerm = '' } = query || {};
+    const { searchTerm = '', type = '' } = query || {};
     const { crn } = params || {};
     const queryParams = new URLSearchParams();
 
     if (crn) queryParams.append('crn', crn);
     if (searchTerm) queryParams.append('searchTerm', searchTerm);
+    if (type) queryParams.append('type', type);
 
     return queryParams.toString();
 };

--- a/document/utils/pagination/index.js
+++ b/document/utils/pagination/index.js
@@ -89,19 +89,21 @@ const buildPaginationItems = ({ visiblePages, currentPageIndex, buildPageUrl }) 
  * @param {object} options - Query options.
  * @param {object} [options.query] - Optional request query object.
  * @param {string} [options.query.searchTerm] - Search term to preserve in links.
- * @param {string} [options.query.type] - Search type to preserve in links.
  * @param {object} [options.params] - Optional route params object.
  * @param {string} [options.params.crn] - Case reference number.
+ * @param {string} [options.resolvedSearchType] - The canonical resolved search type (from session/default). Used instead of raw query.type to ensure pagination links are always canonical.
  * @returns {string} Encoded query string.
  */
-const buildQueryString = ({ query, params }) => {
-    const { searchTerm = '', type = '' } = query || {};
+const buildQueryString = ({ query, params, resolvedSearchType }) => {
+    const { searchTerm = '' } = query || {};
     const { crn } = params || {};
     const queryParams = new URLSearchParams();
 
     if (crn) queryParams.append('crn', crn);
     if (searchTerm) queryParams.append('searchTerm', searchTerm);
-    if (type) queryParams.append('type', type);
+    if (resolvedSearchType) {
+        queryParams.append('type', resolvedSearchType);
+    }
 
     return queryParams.toString();
 };
@@ -178,15 +180,17 @@ export const createPaginationData = ({
  * @param {object} [query] - Optional request query object.
  * @param {object} [params] - Optional route params object.
  * @param {'image'|'text'} [viewMode='image'] - Viewer mode used to build page URLs.
+ * @param {string} [resolvedSearchType] - The canonical resolved search type. When provided, pagination links use this instead of the raw query.type to ensure they reflect the active search mode.
  * @returns {{items:Array,results:{pages:{current:number,count:number},count:number,text:string},previous:{text:string,href:string}|null,next:{text:string,href:string}|null}} Pagination data object.
  */
 export const paginationDataFromMetadata = (
     pageMetadata,
     query,
     params,
-    viewMode = VIEW_MODES.IMAGE
+    viewMode = VIEW_MODES.IMAGE,
+    resolvedSearchType
 ) => {
-    const queryString = buildQueryString({ query, params });
+    const queryString = buildQueryString({ query, params, resolvedSearchType });
     const { documentId } = params || {};
     const viewPath = viewMode === VIEW_MODES.TEXT ? '/view/text/page/' : '/view/page/';
     const buildDocumentPageUrl = (pageNum) =>

--- a/middleware/enforceCrnInQuery/allowList.test.js
+++ b/middleware/enforceCrnInQuery/allowList.test.js
@@ -13,6 +13,8 @@ assert.deepStrictEqual(
 const validPaths = [
     '/document/123e4567-e89b-12d3-a456-426614174000/view/page/1',
     '/document/abcdefab-1234-5678-abcd-abcdefabcdef/view/page/42',
+    '/document/123e4567-e89b-12d3-a456-426614174000/view/text/page/1',
+    '/document/abcdefab-1234-5678-abcd-abcdefabcdef/view/text/page/42',
     '/document/123e4567-e89b-12d3-a456-426614174000/page/1',
     '/document/55b2ea3c-3eae-54f7-b81d-292db7c84be7/page/6'
 ];
@@ -21,6 +23,10 @@ const invalidPaths = [
     '/document/123e4567-e89b-12d3-a456-426614174000/view/page/notanumber',
     '/document/123e4567-e89b-12d3-a456-426614174000/view/page/',
     '/document/123e4567-e89b-12d3-a456-426614174000/view/page/1/extra',
+    '/document/not-a-uuid/view/text/page/1',
+    '/document/123e4567-e89b-12d3-a456-426614174000/view/text/page/notanumber',
+    '/document/123e4567-e89b-12d3-a456-426614174000/view/text/page/',
+    '/document/123e4567-e89b-12d3-a456-426614174000/view/text/page/1/extra',
     '/document/not-a-uuid/page/1',
     '/document/123e4567-e89b-12d3-a456-426614174000/page/notanumber'
 ];

--- a/middleware/enforceCrnInQuery/index.js
+++ b/middleware/enforceCrnInQuery/index.js
@@ -19,6 +19,7 @@ const ALLOWED_PATHS = ['/search'];
  */
 const ALLOWED_PATH_PATTERNS = [
     /^\/document\/[0-9a-fA-F-]{36}\/view\/page\/\d+$/,
+    /^\/document\/[0-9a-fA-F-]{36}\/view\/text\/page\/\d+$/, // Text viewer endpoint
     /^\/document\/[0-9a-fA-F-]{36}\/page\/\d+$/ // Image streaming endpoint
 ];
 

--- a/middleware/enforceFeatureFlagsInQuery/allowList.test.js
+++ b/middleware/enforceFeatureFlagsInQuery/allowList.test.js
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { ALLOWED_PATH_PATTERNS, ALLOWED_PATHS } from './index.js';
+
+// --- Static allowlist test ---
+const EXPECTED_ALLOWED_PATHS = ['/search'];
+assert.deepStrictEqual(
+    ALLOWED_PATHS.sort(),
+    EXPECTED_ALLOWED_PATHS.sort(),
+    'ALLOWED_PATHS does not match the expected set of redirect-eligible routes. Update the allowlist if you add new routes.'
+);
+
+// --- Pattern-based allowlist test ---
+const validPaths = [
+    '/document/123e4567-e89b-12d3-a456-426614174000/view/page/1',
+    '/document/abcdefab-1234-5678-abcd-abcdefabcdef/view/page/42',
+    '/document/123e4567-e89b-12d3-a456-426614174000/page/1',
+    '/document/55b2ea3c-3eae-54f7-b81d-292db7c84be7/page/6'
+];
+const invalidPaths = [
+    '/document/not-a-uuid/view/page/1',
+    '/document/123e4567-e89b-12d3-a456-426614174000/view/page/notanumber',
+    '/document/123e4567-e89b-12d3-a456-426614174000/view/page/',
+    '/document/123e4567-e89b-12d3-a456-426614174000/view/page/1/extra',
+    '/document/not-a-uuid/page/1',
+    '/document/123e4567-e89b-12d3-a456-426614174000/page/notanumber'
+];
+
+for (const path of validPaths) {
+    assert(
+        ALLOWED_PATH_PATTERNS.some((pattern) => pattern.test(path)),
+        `Expected pattern to match: ${path}`
+    );
+}
+for (const path of invalidPaths) {
+    assert(
+        !ALLOWED_PATH_PATTERNS.some((pattern) => pattern.test(path)),
+        `Expected pattern NOT to match: ${path}`
+    );
+}

--- a/middleware/enforceFeatureFlagsInQuery/allowList.test.js
+++ b/middleware/enforceFeatureFlagsInQuery/allowList.test.js
@@ -13,6 +13,8 @@ assert.deepStrictEqual(
 const validPaths = [
     '/document/123e4567-e89b-12d3-a456-426614174000/view/page/1',
     '/document/abcdefab-1234-5678-abcd-abcdefabcdef/view/page/42',
+    '/document/123e4567-e89b-12d3-a456-426614174000/view/text/page/1',
+    '/document/abcdefab-1234-5678-abcd-abcdefabcdef/view/text/page/42',
     '/document/123e4567-e89b-12d3-a456-426614174000/page/1',
     '/document/55b2ea3c-3eae-54f7-b81d-292db7c84be7/page/6'
 ];

--- a/middleware/enforceFeatureFlagsInQuery/index.js
+++ b/middleware/enforceFeatureFlagsInQuery/index.js
@@ -1,0 +1,123 @@
+import { FEATURE_FLAG_DEFAULTS } from '../featureFlags/index.js';
+
+/**
+ * An array of allowed URL paths for which feature-flag enforcement applies.
+ * @type {string[]}
+ * @constant
+ */
+const ALLOWED_PATHS = ['/search'];
+
+/**
+ * An array of allowed URL patterns for which feature-flag enforcement applies.
+ * @type {RegExp[]}
+ * @constant
+ */
+const ALLOWED_PATH_PATTERNS = [
+    /^\/document\/[0-9a-fA-F-]{36}\/view\/page\/\d+$/,
+    /^\/document\/[0-9a-fA-F-]{36}\/page\/\d+$/ // Image streaming endpoint
+];
+
+/**
+ * Paths that should be excluded from feature-flag enforcement (static assets, etc.)
+ * @type {RegExp[]}
+ * @constant
+ */
+const EXCLUDED_PATHS = [
+    /^\/favicon\.ico$/,
+    /^\/public\//,
+    /^\/js\//,
+    /^\/stylesheets\//,
+    /^\/assets\//,
+    /^\/\.well-known\//
+];
+
+/**
+ * Serialises a feature-flag session value to its query-string representation.
+ *
+ * Boolean flags are encoded as `on` / `off`; string flags are passed through as-is.
+ *
+ * @param {boolean | string} value - The session flag value.
+ * @returns {string} The query-string representation.
+ */
+function serializeFlagValue(value) {
+    if (typeof value === 'boolean') return value ? 'on' : 'off';
+    return String(value);
+}
+
+/**
+ * Middleware to ensure that non-default feature flags are present as query parameters
+ * on GET requests. If a session flag differs from its default value and is absent from
+ * the current query string, the request is redirected with the missing flags appended.
+ *
+ * This mirrors the behaviour of `enforceCrnInQuery` and allows non-default feature-flag
+ * state to be visible in (and bookmarkable from) the URL.
+ *
+ * @param {import('express').Request} req - Express request object.
+ * @param {import('express').Response} res - Express response object.
+ * @param {import('express').NextFunction} next - Express next middleware function.
+ */
+const enforceFeatureFlagsInQuery = (req, res, next) => {
+    // Skip enforcement for excluded paths (static assets, favicon, etc.)
+    if (EXCLUDED_PATHS.some((pattern) => pattern.test(req.path))) {
+        return next();
+    }
+
+    // Only enforce on GET requests that already have session flags set
+    if (req.method !== 'GET' || !req.session?.featureFlags) {
+        return next();
+    }
+
+    const sessionFlags = req.session.featureFlags;
+
+    // Find non-default flags that are absent from the current query string
+    const flagsToAdd = Object.entries(sessionFlags).filter(
+        ([key, val]) => val !== FEATURE_FLAG_DEFAULTS[key] && req.query[key] === undefined
+    );
+
+    if (flagsToAdd.length === 0) return next();
+
+    // Harden: reject unsafe paths before attempting a redirect
+    if (
+        typeof req.path !== 'string' ||
+        req.path.includes('//') ||
+        req.path.includes('\\') ||
+        req.path.includes('..') ||
+        req.path.startsWith('http://') ||
+        req.path.startsWith('https://')
+    ) {
+        const err = new Error('Invalid redirect path');
+        err.status = 400;
+        return next(err);
+    }
+
+    const normalizedPath = req.path.replace(/\/+$/, '');
+
+    let safePath;
+    if (ALLOWED_PATHS.includes(normalizedPath)) {
+        safePath = normalizedPath;
+    } else {
+        for (const pattern of ALLOWED_PATH_PATTERNS) {
+            if (pattern.test(normalizedPath)) {
+                safePath = normalizedPath;
+                break;
+            }
+        }
+    }
+
+    if (!safePath) {
+        const err = new Error('Redirect not allowed for this path');
+        err.status = 400;
+        return next(err);
+    }
+
+    const newQuery = { ...req.query };
+    for (const [key, val] of flagsToAdd) {
+        newQuery[key] = serializeFlagValue(val);
+    }
+
+    const queryString = new URLSearchParams(newQuery).toString();
+    return res.redirect(`${safePath}?${queryString}`);
+};
+
+export { ALLOWED_PATH_PATTERNS, ALLOWED_PATHS, EXCLUDED_PATHS };
+export default enforceFeatureFlagsInQuery;

--- a/middleware/enforceFeatureFlagsInQuery/index.js
+++ b/middleware/enforceFeatureFlagsInQuery/index.js
@@ -1,5 +1,5 @@
-import { FEATURE_FLAG_DEFAULTS, getFeatureFlagValue } from '../featureFlags/index.js';
 import { resolveSearchType } from '../../api/search/constants/searchTypes.js';
+import { FEATURE_FLAG_DEFAULTS, getFeatureFlagValue } from '../featureFlags/index.js';
 
 /**
  * An array of allowed URL paths for which feature-flag enforcement applies.

--- a/middleware/enforceFeatureFlagsInQuery/index.js
+++ b/middleware/enforceFeatureFlagsInQuery/index.js
@@ -14,6 +14,7 @@ const ALLOWED_PATHS = ['/search'];
  */
 const ALLOWED_PATH_PATTERNS = [
     /^\/document\/[0-9a-fA-F-]{36}\/view\/page\/\d+$/,
+    /^\/document\/[0-9a-fA-F-]{36}\/view\/text\/page\/\d+$/,
     /^\/document\/[0-9a-fA-F-]{36}\/page\/\d+$/ // Image streaming endpoint
 ];
 

--- a/middleware/enforceFeatureFlagsInQuery/index.js
+++ b/middleware/enforceFeatureFlagsInQuery/index.js
@@ -41,7 +41,10 @@ const EXCLUDED_PATHS = [
  * @returns {string} The query-string representation.
  */
 function serializeFlagValue(value) {
-    if (typeof value === 'boolean') return value ? 'on' : 'off';
+    if (typeof value === 'boolean') {
+        return value ? 'on' : 'off';
+    }
+
     return String(value);
 }
 
@@ -70,12 +73,20 @@ const enforceFeatureFlagsInQuery = (req, res, next) => {
 
     const sessionFlags = req.session.featureFlags;
 
-    // Find non-default flags that are absent from the current query string
-    const flagsToAdd = Object.entries(sessionFlags).filter(
-        ([key, val]) => val !== FEATURE_FLAG_DEFAULTS[key] && req.query[key] === undefined
-    );
+    // Find non-default supported flags that are absent from the current query string.
+    // Unknown/stale session keys are ignored so only bookmarkable flags are reflected.
+    const flagsToAdd = Object.keys(FEATURE_FLAG_DEFAULTS)
+        .map((flagName) => [flagName, sessionFlags[flagName]])
+        .filter(([, sessionFlagValue]) => sessionFlagValue !== undefined)
+        .filter(
+            ([flagName, sessionFlagValue]) =>
+                sessionFlagValue !== FEATURE_FLAG_DEFAULTS[flagName] &&
+                req.query[flagName] === undefined
+        );
 
-    if (flagsToAdd.length === 0) return next();
+    if (flagsToAdd.length === 0) {
+        return next();
+    }
 
     // Harden: reject unsafe paths before attempting a redirect
     if (

--- a/middleware/enforceFeatureFlagsInQuery/index.js
+++ b/middleware/enforceFeatureFlagsInQuery/index.js
@@ -32,6 +32,12 @@ const EXCLUDED_PATHS = [
     /^\/\.well-known\//
 ];
 
+const DOCUMENT_VIEW_PAGE_PATH_PATTERN =
+    /^\/document\/([0-9a-fA-F-]{36})\/view\/page\/(\d+)$/;
+const DOCUMENT_VIEW_TEXT_PAGE_PATH_PATTERN =
+    /^\/document\/([0-9a-fA-F-]{36})\/view\/text\/page\/(\d+)$/;
+const DOCUMENT_IMAGE_PAGE_PATH_PATTERN = /^\/document\/([0-9a-fA-F-]{36})\/page\/(\d+)$/;
+
 /**
  * Serialises a feature-flag session value to its query-string representation.
  *
@@ -46,6 +52,43 @@ function serializeFlagValue(value) {
     }
 
     return String(value);
+}
+
+/**
+ * Returns a canonical redirect path for supported routes.
+ *
+ * The returned path is rebuilt from regex-captured segments so redirects never
+ * depend on raw, unsanitized request path input.
+ *
+ * @param {string} path - Request path to validate.
+ * @returns {string | undefined} Canonical safe path when allowed.
+ */
+function resolveSafeRedirectPath(path) {
+    const normalizedPath = path.replace(/\/+$/, '');
+
+    if (ALLOWED_PATHS.includes(normalizedPath)) {
+        return normalizedPath;
+    }
+
+    const viewPageMatch = normalizedPath.match(DOCUMENT_VIEW_PAGE_PATH_PATTERN);
+    if (viewPageMatch) {
+        const [, documentId, pageNumber] = viewPageMatch;
+        return `/document/${documentId}/view/page/${pageNumber}`;
+    }
+
+    const viewTextPageMatch = normalizedPath.match(DOCUMENT_VIEW_TEXT_PAGE_PATH_PATTERN);
+    if (viewTextPageMatch) {
+        const [, documentId, pageNumber] = viewTextPageMatch;
+        return `/document/${documentId}/view/text/page/${pageNumber}`;
+    }
+
+    const imagePageMatch = normalizedPath.match(DOCUMENT_IMAGE_PAGE_PATH_PATTERN);
+    if (imagePageMatch) {
+        const [, documentId, pageNumber] = imagePageMatch;
+        return `/document/${documentId}/page/${pageNumber}`;
+    }
+
+    return undefined;
 }
 
 /**
@@ -102,19 +145,7 @@ const enforceFeatureFlagsInQuery = (req, res, next) => {
         return next(err);
     }
 
-    const normalizedPath = req.path.replace(/\/+$/, '');
-
-    let safePath;
-    if (ALLOWED_PATHS.includes(normalizedPath)) {
-        safePath = normalizedPath;
-    } else {
-        for (const pattern of ALLOWED_PATH_PATTERNS) {
-            if (pattern.test(normalizedPath)) {
-                safePath = normalizedPath;
-                break;
-            }
-        }
-    }
+    const safePath = resolveSafeRedirectPath(req.path);
 
     if (!safePath) {
         const err = new Error('Redirect not allowed for this path');
@@ -123,8 +154,8 @@ const enforceFeatureFlagsInQuery = (req, res, next) => {
     }
 
     const newQuery = { ...req.query };
-    for (const [key, val] of flagsToAdd) {
-        newQuery[key] = serializeFlagValue(val);
+    for (const [flagName, sessionFlagValue] of flagsToAdd) {
+        newQuery[flagName] = serializeFlagValue(sessionFlagValue);
     }
 
     const queryString = new URLSearchParams(newQuery).toString();

--- a/middleware/enforceFeatureFlagsInQuery/index.js
+++ b/middleware/enforceFeatureFlagsInQuery/index.js
@@ -1,4 +1,5 @@
-import { FEATURE_FLAG_DEFAULTS } from '../featureFlags/index.js';
+import { FEATURE_FLAG_DEFAULTS, getFeatureFlagValue } from '../featureFlags/index.js';
+import { resolveSearchType } from '../../api/search/constants/searchTypes.js';
 
 /**
  * An array of allowed URL paths for which feature-flag enforcement applies.
@@ -32,8 +33,7 @@ const EXCLUDED_PATHS = [
     /^\/\.well-known\//
 ];
 
-const DOCUMENT_VIEW_PAGE_PATH_PATTERN =
-    /^\/document\/([0-9a-fA-F-]{36})\/view\/page\/(\d+)$/;
+const DOCUMENT_VIEW_PAGE_PATH_PATTERN = /^\/document\/([0-9a-fA-F-]{36})\/view\/page\/(\d+)$/;
 const DOCUMENT_VIEW_TEXT_PAGE_PATH_PATTERN =
     /^\/document\/([0-9a-fA-F-]{36})\/view\/text\/page\/(\d+)$/;
 const DOCUMENT_IMAGE_PAGE_PATH_PATTERN = /^\/document\/([0-9a-fA-F-]{36})\/page\/(\d+)$/;
@@ -92,6 +92,24 @@ function resolveSafeRedirectPath(path) {
 }
 
 /**
+ * Resolves a supported feature flag from the session to a validated value.
+ *
+ * `type` values are canonicalized via `resolveSearchType`; boolean flags are
+ * type-checked and fall back to defaults when stale/corrupt.
+ *
+ * @param {import('express-session').Session | undefined} session - Request session object.
+ * @param {'align' | 'type'} flagName - Supported feature flag name.
+ * @returns {boolean | string} Validated feature flag value.
+ */
+function resolveSessionFeatureFlagValue(session, flagName) {
+    if (flagName === 'type') {
+        return resolveSearchType(session?.featureFlags?.type, session);
+    }
+
+    return getFeatureFlagValue(session, flagName);
+}
+
+/**
  * Middleware to ensure that non-default feature flags are present as query parameters
  * on GET requests. If a session flag differs from its default value and is absent from
  * the current query string, the request is redirected with the missing flags appended.
@@ -114,13 +132,10 @@ const enforceFeatureFlagsInQuery = (req, res, next) => {
         return next();
     }
 
-    const sessionFlags = req.session.featureFlags;
-
     // Find non-default supported flags that are absent from the current query string.
     // Unknown/stale session keys are ignored so only bookmarkable flags are reflected.
     const flagsToAdd = Object.keys(FEATURE_FLAG_DEFAULTS)
-        .map((flagName) => [flagName, sessionFlags[flagName]])
-        .filter(([, sessionFlagValue]) => sessionFlagValue !== undefined)
+        .map((flagName) => [flagName, resolveSessionFeatureFlagValue(req.session, flagName)])
         .filter(
             ([flagName, sessionFlagValue]) =>
                 sessionFlagValue !== FEATURE_FLAG_DEFAULTS[flagName] &&

--- a/middleware/enforceFeatureFlagsInQuery/index.test.js
+++ b/middleware/enforceFeatureFlagsInQuery/index.test.js
@@ -78,6 +78,24 @@ test('redirects with multiple non-default flags appended', () => {
     assert.ok(res.redirectedUrl?.startsWith('/search?'), 'should start with /search?');
 });
 
+test('ignores unsupported session feature flags when building redirect query', () => {
+    const req = createMockReq({
+        session: {
+            featureFlags: {
+                align: false,
+                type: DEFAULT_SEARCH_TYPE,
+                staleFlag: 'unexpected'
+            }
+        }
+    });
+    const res = createMockRes();
+
+    enforceFeatureFlagsInQuery(req, res, () => {});
+
+    assert.strictEqual(res.redirectedUrl, '/search?align=off');
+    assert.ok(!res.redirectedUrl?.includes('staleFlag='));
+});
+
 test('preserves existing query parameters when redirecting', () => {
     const req = createMockReq({
         query: { crn: '12-745678', page: '2' },

--- a/middleware/enforceFeatureFlagsInQuery/index.test.js
+++ b/middleware/enforceFeatureFlagsInQuery/index.test.js
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
+import { DEFAULT_SEARCH_TYPE } from '../../api/search/constants/searchTypes.js';
 import enforceFeatureFlagsInQuery from './index.js';
 
 /**
@@ -39,7 +40,7 @@ function createMockRes() {
 
 test('redirects to URL with non-default boolean flag when missing from query', () => {
     const req = createMockReq({
-        session: { featureFlags: { align: false, type: 'keyword-dates' } }
+        session: { featureFlags: { align: false, type: DEFAULT_SEARCH_TYPE } }
     });
     const res = createMockRes();
     let nextCalled = false;
@@ -113,7 +114,7 @@ test('does not redirect when all non-default flags are already in the query', ()
 
 test('does not redirect when all flags are at their defaults', () => {
     const req = createMockReq({
-        session: { featureFlags: { align: true, type: 'keyword-dates' } }
+        session: { featureFlags: { align: true, type: DEFAULT_SEARCH_TYPE } }
     });
     const res = createMockRes();
     let nextCalled = false;
@@ -162,7 +163,7 @@ test('does not redirect for non-GET requests', () => {
 test('redirects for document view page path', () => {
     const req = createMockReq({
         path: '/document/123e4567-e89b-12d3-a456-426614174000/view/page/1',
-        session: { featureFlags: { align: false, type: 'keyword-dates' } }
+        session: { featureFlags: { align: false, type: DEFAULT_SEARCH_TYPE } }
     });
     const res = createMockRes();
 
@@ -193,7 +194,7 @@ test('normalises trailing slash before checking allowed path', () => {
     const req = createMockReq({
         path: '/search/',
         query: { crn: '12-745678' },
-        session: { featureFlags: { align: false, type: 'keyword-dates' } }
+        session: { featureFlags: { align: false, type: DEFAULT_SEARCH_TYPE } }
     });
     const res = createMockRes();
 
@@ -209,7 +210,7 @@ test('normalises trailing slash before checking allowed path', () => {
 test('blocks redirect for path not in allowed list or patterns', () => {
     const req = createMockReq({
         path: '/admin/secret',
-        session: { featureFlags: { align: false, type: 'keyword-dates' } }
+        session: { featureFlags: { align: false, type: DEFAULT_SEARCH_TYPE } }
     });
     let nextArg;
 
@@ -225,7 +226,7 @@ test('blocks redirect for path not in allowed list or patterns', () => {
 test('blocks redirect for absolute http:// path', () => {
     const req = createMockReq({
         path: 'http://malicious.com/search',
-        session: { featureFlags: { align: false, type: 'keyword-dates' } }
+        session: { featureFlags: { align: false, type: DEFAULT_SEARCH_TYPE } }
     });
     let nextArg;
 
@@ -241,7 +242,7 @@ test('blocks redirect for absolute http:// path', () => {
 test('blocks redirect for absolute https:// path', () => {
     const req = createMockReq({
         path: 'https://evil.com/search',
-        session: { featureFlags: { align: false, type: 'keyword-dates' } }
+        session: { featureFlags: { align: false, type: DEFAULT_SEARCH_TYPE } }
     });
     let nextArg;
 
@@ -257,7 +258,7 @@ test('blocks redirect for absolute https:// path', () => {
 test('blocks redirect for path containing double slashes', () => {
     const req = createMockReq({
         path: '/search//evil',
-        session: { featureFlags: { align: false, type: 'keyword-dates' } }
+        session: { featureFlags: { align: false, type: DEFAULT_SEARCH_TYPE } }
     });
     let nextArg;
 
@@ -273,7 +274,7 @@ test('blocks redirect for path containing double slashes', () => {
 test('blocks redirect for path containing backslash', () => {
     const req = createMockReq({
         path: '/search\\evil',
-        session: { featureFlags: { align: false, type: 'keyword-dates' } }
+        session: { featureFlags: { align: false, type: DEFAULT_SEARCH_TYPE } }
     });
     let nextArg;
 
@@ -289,7 +290,7 @@ test('blocks redirect for path containing backslash', () => {
 test('blocks redirect for path containing double dots', () => {
     const req = createMockReq({
         path: '/search/../admin',
-        session: { featureFlags: { align: false, type: 'keyword-dates' } }
+        session: { featureFlags: { align: false, type: DEFAULT_SEARCH_TYPE } }
     });
     let nextArg;
 

--- a/middleware/enforceFeatureFlagsInQuery/index.test.js
+++ b/middleware/enforceFeatureFlagsInQuery/index.test.js
@@ -96,6 +96,46 @@ test('ignores unsupported session feature flags when building redirect query', (
     assert.ok(!res.redirectedUrl?.includes('staleFlag='));
 });
 
+test('does not append stale invalid session type values', () => {
+    const req = createMockReq({
+        session: {
+            featureFlags: {
+                align: true,
+                type: 'old-invalid-type'
+            }
+        }
+    });
+    const res = createMockRes();
+    let nextCalled = false;
+
+    enforceFeatureFlagsInQuery(req, res, () => {
+        nextCalled = true;
+    });
+
+    assert.strictEqual(res.redirectedUrl, null);
+    assert.strictEqual(nextCalled, true);
+});
+
+test('does not append non-boolean stale session align values', () => {
+    const req = createMockReq({
+        session: {
+            featureFlags: {
+                align: 'off',
+                type: DEFAULT_SEARCH_TYPE
+            }
+        }
+    });
+    const res = createMockRes();
+    let nextCalled = false;
+
+    enforceFeatureFlagsInQuery(req, res, () => {
+        nextCalled = true;
+    });
+
+    assert.strictEqual(res.redirectedUrl, null);
+    assert.strictEqual(nextCalled, true);
+});
+
 test('preserves existing query parameters when redirecting', () => {
     const req = createMockReq({
         query: { crn: '12-745678', page: '2' },

--- a/middleware/enforceFeatureFlagsInQuery/index.test.js
+++ b/middleware/enforceFeatureFlagsInQuery/index.test.js
@@ -1,0 +1,355 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import enforceFeatureFlagsInQuery from './index.js';
+
+/**
+ * Creates a mock Express request object for testing purposes.
+ *
+ * @param {Object} [options] - Options to customise the mock request.
+ * @param {string} [options.method='GET'] - The HTTP method of the request.
+ * @param {string} [options.path='/search'] - The request path.
+ * @param {Object} [options.query={}] - The query parameters of the request.
+ * @param {Object} [options.session={}] - The session object of the request.
+ * @returns {Object} Mock request object.
+ */
+function createMockReq({ method = 'GET', path = '/search', query = {}, session = {} } = {}) {
+    return { method, path, query, session };
+}
+
+/**
+ * Creates a mock response object that captures any URL passed to `redirect`.
+ *
+ * @returns {{ redirect: function(string): void, redirectedUrl: string|null }}
+ */
+function createMockRes() {
+    let redirectedUrl = null;
+    return {
+        redirect: (url) => {
+            redirectedUrl = url;
+        },
+        get redirectedUrl() {
+            return redirectedUrl;
+        }
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Core redirect behaviour
+// ---------------------------------------------------------------------------
+
+test('redirects to URL with non-default boolean flag when missing from query', () => {
+    const req = createMockReq({
+        session: { featureFlags: { align: false, type: 'keyword-dates' } }
+    });
+    const res = createMockRes();
+    let nextCalled = false;
+
+    enforceFeatureFlagsInQuery(req, res, () => {
+        nextCalled = true;
+    });
+
+    assert.strictEqual(res.redirectedUrl, '/search?align=off');
+    assert.strictEqual(nextCalled, false);
+});
+
+test('redirects to URL with non-default string flag when missing from query', () => {
+    const req = createMockReq({
+        session: { featureFlags: { align: true, type: 'hybrid' } }
+    });
+    const res = createMockRes();
+
+    enforceFeatureFlagsInQuery(req, res, () => {});
+
+    assert.strictEqual(res.redirectedUrl, '/search?type=hybrid');
+});
+
+test('redirects with multiple non-default flags appended', () => {
+    const req = createMockReq({
+        session: { featureFlags: { align: false, type: 'hybrid' } }
+    });
+    const res = createMockRes();
+
+    enforceFeatureFlagsInQuery(req, res, () => {});
+
+    // Both non-default flags must be present (order may vary via URLSearchParams)
+    assert.ok(res.redirectedUrl?.includes('align=off'), 'should include align=off');
+    assert.ok(res.redirectedUrl?.includes('type=hybrid'), 'should include type=hybrid');
+    assert.ok(res.redirectedUrl?.startsWith('/search?'), 'should start with /search?');
+});
+
+test('preserves existing query parameters when redirecting', () => {
+    const req = createMockReq({
+        query: { crn: '12-745678', page: '2' },
+        session: { featureFlags: { align: true, type: 'hybrid' } }
+    });
+    const res = createMockRes();
+
+    enforceFeatureFlagsInQuery(req, res, () => {});
+
+    assert.ok(res.redirectedUrl?.includes('crn=12-745678'));
+    assert.ok(res.redirectedUrl?.includes('page=2'));
+    assert.ok(res.redirectedUrl?.includes('type=hybrid'));
+});
+
+// ---------------------------------------------------------------------------
+// No-redirect conditions
+// ---------------------------------------------------------------------------
+
+test('does not redirect when all non-default flags are already in the query', () => {
+    const req = createMockReq({
+        query: { type: 'hybrid' },
+        session: { featureFlags: { align: true, type: 'hybrid' } }
+    });
+    const res = createMockRes();
+    let nextCalled = false;
+
+    enforceFeatureFlagsInQuery(req, res, () => {
+        nextCalled = true;
+    });
+
+    assert.strictEqual(res.redirectedUrl, null);
+    assert.strictEqual(nextCalled, true);
+});
+
+test('does not redirect when all flags are at their defaults', () => {
+    const req = createMockReq({
+        session: { featureFlags: { align: true, type: 'keyword-dates' } }
+    });
+    const res = createMockRes();
+    let nextCalled = false;
+
+    enforceFeatureFlagsInQuery(req, res, () => {
+        nextCalled = true;
+    });
+
+    assert.strictEqual(res.redirectedUrl, null);
+    assert.strictEqual(nextCalled, true);
+});
+
+test('does not redirect when session has no featureFlags', () => {
+    const req = createMockReq({ session: {} });
+    const res = createMockRes();
+    let nextCalled = false;
+
+    enforceFeatureFlagsInQuery(req, res, () => {
+        nextCalled = true;
+    });
+
+    assert.strictEqual(res.redirectedUrl, null);
+    assert.strictEqual(nextCalled, true);
+});
+
+test('does not redirect for non-GET requests', () => {
+    const req = createMockReq({
+        method: 'POST',
+        session: { featureFlags: { align: false, type: 'hybrid' } }
+    });
+    const res = createMockRes();
+    let nextCalled = false;
+
+    enforceFeatureFlagsInQuery(req, res, () => {
+        nextCalled = true;
+    });
+
+    assert.strictEqual(res.redirectedUrl, null);
+    assert.strictEqual(nextCalled, true);
+});
+
+// ---------------------------------------------------------------------------
+// Allowed path patterns
+// ---------------------------------------------------------------------------
+
+test('redirects for document view page path', () => {
+    const req = createMockReq({
+        path: '/document/123e4567-e89b-12d3-a456-426614174000/view/page/1',
+        session: { featureFlags: { align: false, type: 'keyword-dates' } }
+    });
+    const res = createMockRes();
+
+    enforceFeatureFlagsInQuery(req, res, () => {});
+
+    assert.strictEqual(
+        res.redirectedUrl,
+        '/document/123e4567-e89b-12d3-a456-426614174000/view/page/1?align=off'
+    );
+});
+
+test('redirects for document image streaming endpoint', () => {
+    const req = createMockReq({
+        path: '/document/123e4567-e89b-12d3-a456-426614174000/page/5',
+        session: { featureFlags: { align: true, type: 'hybrid' } }
+    });
+    const res = createMockRes();
+
+    enforceFeatureFlagsInQuery(req, res, () => {});
+
+    assert.strictEqual(
+        res.redirectedUrl,
+        '/document/123e4567-e89b-12d3-a456-426614174000/page/5?type=hybrid'
+    );
+});
+
+test('normalises trailing slash before checking allowed path', () => {
+    const req = createMockReq({
+        path: '/search/',
+        query: { crn: '12-745678' },
+        session: { featureFlags: { align: false, type: 'keyword-dates' } }
+    });
+    const res = createMockRes();
+
+    enforceFeatureFlagsInQuery(req, res, () => {});
+
+    assert.strictEqual(res.redirectedUrl, '/search?crn=12-745678&align=off');
+});
+
+// ---------------------------------------------------------------------------
+// Path security guards
+// ---------------------------------------------------------------------------
+
+test('blocks redirect for path not in allowed list or patterns', () => {
+    const req = createMockReq({
+        path: '/admin/secret',
+        session: { featureFlags: { align: false, type: 'keyword-dates' } }
+    });
+    let nextArg;
+
+    enforceFeatureFlagsInQuery(req, {}, (err) => {
+        nextArg = err;
+    });
+
+    assert(nextArg instanceof Error);
+    assert.strictEqual(nextArg.message, 'Redirect not allowed for this path');
+    assert.strictEqual(nextArg.status, 400);
+});
+
+test('blocks redirect for absolute http:// path', () => {
+    const req = createMockReq({
+        path: 'http://malicious.com/search',
+        session: { featureFlags: { align: false, type: 'keyword-dates' } }
+    });
+    let nextArg;
+
+    enforceFeatureFlagsInQuery(req, {}, (err) => {
+        nextArg = err;
+    });
+
+    assert(nextArg instanceof Error);
+    assert.strictEqual(nextArg.message, 'Invalid redirect path');
+    assert.strictEqual(nextArg.status, 400);
+});
+
+test('blocks redirect for absolute https:// path', () => {
+    const req = createMockReq({
+        path: 'https://evil.com/search',
+        session: { featureFlags: { align: false, type: 'keyword-dates' } }
+    });
+    let nextArg;
+
+    enforceFeatureFlagsInQuery(req, {}, (err) => {
+        nextArg = err;
+    });
+
+    assert(nextArg instanceof Error);
+    assert.strictEqual(nextArg.message, 'Invalid redirect path');
+    assert.strictEqual(nextArg.status, 400);
+});
+
+test('blocks redirect for path containing double slashes', () => {
+    const req = createMockReq({
+        path: '/search//evil',
+        session: { featureFlags: { align: false, type: 'keyword-dates' } }
+    });
+    let nextArg;
+
+    enforceFeatureFlagsInQuery(req, {}, (err) => {
+        nextArg = err;
+    });
+
+    assert(nextArg instanceof Error);
+    assert.strictEqual(nextArg.message, 'Invalid redirect path');
+    assert.strictEqual(nextArg.status, 400);
+});
+
+test('blocks redirect for path containing backslash', () => {
+    const req = createMockReq({
+        path: '/search\\evil',
+        session: { featureFlags: { align: false, type: 'keyword-dates' } }
+    });
+    let nextArg;
+
+    enforceFeatureFlagsInQuery(req, {}, (err) => {
+        nextArg = err;
+    });
+
+    assert(nextArg instanceof Error);
+    assert.strictEqual(nextArg.message, 'Invalid redirect path');
+    assert.strictEqual(nextArg.status, 400);
+});
+
+test('blocks redirect for path containing double dots', () => {
+    const req = createMockReq({
+        path: '/search/../admin',
+        session: { featureFlags: { align: false, type: 'keyword-dates' } }
+    });
+    let nextArg;
+
+    enforceFeatureFlagsInQuery(req, {}, (err) => {
+        nextArg = err;
+    });
+
+    assert(nextArg instanceof Error);
+    assert.strictEqual(nextArg.message, 'Invalid redirect path');
+    assert.strictEqual(nextArg.status, 400);
+});
+
+// ---------------------------------------------------------------------------
+// Excluded paths (static assets)
+// ---------------------------------------------------------------------------
+
+test('skips enforcement for favicon', () => {
+    const req = createMockReq({
+        path: '/favicon.ico',
+        session: { featureFlags: { align: false, type: 'hybrid' } }
+    });
+    const res = createMockRes();
+    let nextCalled = false;
+
+    enforceFeatureFlagsInQuery(req, res, () => {
+        nextCalled = true;
+    });
+
+    assert.strictEqual(res.redirectedUrl, null);
+    assert.strictEqual(nextCalled, true);
+});
+
+test('skips enforcement for public assets', () => {
+    const req = createMockReq({
+        path: '/public/style.css',
+        session: { featureFlags: { align: false, type: 'hybrid' } }
+    });
+    const res = createMockRes();
+    let nextCalled = false;
+
+    enforceFeatureFlagsInQuery(req, res, () => {
+        nextCalled = true;
+    });
+
+    assert.strictEqual(res.redirectedUrl, null);
+    assert.strictEqual(nextCalled, true);
+});
+
+test('skips enforcement for js bundle files', () => {
+    const req = createMockReq({
+        path: '/js/bundle.js',
+        session: { featureFlags: { align: false, type: 'hybrid' } }
+    });
+    const res = createMockRes();
+    let nextCalled = false;
+
+    enforceFeatureFlagsInQuery(req, res, () => {
+        nextCalled = true;
+    });
+
+    assert.strictEqual(res.redirectedUrl, null);
+    assert.strictEqual(nextCalled, true);
+});

--- a/middleware/enforceSearchTypeInQuery/index.js
+++ b/middleware/enforceSearchTypeInQuery/index.js
@@ -1,4 +1,4 @@
-import { DEFAULT_SEARCH_TYPE, parseSearchType } from '../../api/search/constants/searchTypes.js';
+import { DEFAULT_SEARCH_TYPE, resolveSearchType } from '../../api/search/constants/searchTypes.js';
 import { getFeatureFlagValue } from '../featureFlags/index.js';
 
 /**
@@ -22,8 +22,13 @@ export default function enforceSearchTypeInQuery(req, res, next) {
     }
 
     if (req.query.type !== undefined) {
-        const { value } = parseSearchType(req.query.type);
-        if (typeof value === 'string') {
+        const normalisedQueryType =
+            typeof req.query.type === 'string' ? req.query.type.trim().toLowerCase() : '';
+        const resolved = resolveSearchType(req.query.type, req.session);
+        // Only skip the redirect when the type in the URL was itself a recognised
+        // value. If it was unrecognised, resolveSearchType falls back to the session
+        // or default, and we still need to redirect to canonicalise the URL.
+        if (normalisedQueryType && resolved === normalisedQueryType) {
             return next();
         }
     }

--- a/middleware/enforceSearchTypeInQuery/index.js
+++ b/middleware/enforceSearchTypeInQuery/index.js
@@ -54,6 +54,12 @@ export default function enforceSearchTypeInQuery(req, res, next) {
     }
 
     redirectQuery.set('type', searchType);
-    const currentPath = req.originalUrl.split('?')[0];
-    return res.redirect(`${currentPath}?${redirectQuery.toString()}`);
+
+    // Reconstruct the redirect path from Express-parsed routing values rather than
+    // forwarding req.originalUrl directly, which is raw user-controlled input.
+    // req.baseUrl is set by Express based on the matched mount point; req.path is
+    // the sub-path after that mount point. Combining them avoids taint from the
+    // raw URL string while correctly preserving the effective request path.
+    const safePath = req.baseUrl + req.path.replace(/\/$/, '');
+    return res.redirect(`${safePath}?${redirectQuery.toString()}`);
 }

--- a/middleware/enforceSearchTypeInQuery/index.js
+++ b/middleware/enforceSearchTypeInQuery/index.js
@@ -21,7 +21,15 @@ export default function enforceSearchTypeInQuery(req, res, next) {
     }
 
     if (req.query.type !== undefined) {
-        const rawQueryType = typeof req.query.type === 'string' ? req.query.type : '';
+           // Express parses repeated query params (e.g. ?type=a&type=b) as an array.
+           // Use the last element in that case, consistent with parseFeatureFlagValue /
+           // parseEnumFlagValue, so a valid trailing value is not silently discarded and
+           // the user's intent is preserved in any subsequent redirect.
+        const rawQueryType = Array.isArray(req.query.type)
+            ? (req.query.type.at(-1) ?? '')
+            : typeof req.query.type === 'string'
+              ? req.query.type
+              : '';
         const canonicalQueryType = rawQueryType.trim().toLowerCase();
         const resolved = resolveSearchType(req.query.type, req.session);
         // Only skip the redirect when the type in the URL is already in its

--- a/middleware/enforceSearchTypeInQuery/index.js
+++ b/middleware/enforceSearchTypeInQuery/index.js
@@ -20,27 +20,31 @@ export default function enforceSearchTypeInQuery(req, res, next) {
         return next();
     }
 
-    // Express parses repeated query params (e.g. ?type=a&type=b) as an array.
-    // Use the last element in that case, consistent with parseFeatureFlagValue /
-    // parseEnumFlagValue, so a valid trailing value is not silently discarded.
-    const queryType = Array.isArray(req.query.type) ? req.query.type.at(-1) : req.query.type;
+    const rawQueryType = req.query.type;
 
-    const resolved = resolveSearchType(queryType, req.session);
+    // Express parses repeated query params (e.g. ?type=a&type=b) as an array.
+    // Normalize to the last entry first, consistent with parseFeatureFlagValue /
+    // parseEnumFlagValue.
+    const queryType = Array.isArray(rawQueryType) ? rawQueryType.at(-1) : rawQueryType;
+
+    const resolvedType = resolveSearchType(queryType, req.session);
 
     // Only skip the redirect when the query value is already the exact canonical
     // form. Anything absent, invalid, or messy (wrong case, whitespace) is
     // redirected to the resolved value from the session or app default.
-    if (queryType === resolved) {
+    if (!Array.isArray(rawQueryType) && queryType === resolvedType) {
         return next();
     }
 
-    // For the redirect, resolve from the session value directly so that a valid
-    // session type is used as the fallback rather than always defaulting to the
-    // app default. resolveSearchType(undefined, session) skips the session lookup
-    // and returns DEFAULT_SEARCH_TYPE immediately, so we pass the session value
-    // explicitly here.
-    const searchType = resolveSearchType(req.session?.featureFlags?.type, req.session);
     const redirectQuery = new URLSearchParams(req.query);
+
+    // Keep historical behaviour for single values (fallback from session/default),
+    // but canonicalize repeated params to one resolved value so downstream
+    // middleware sees a string type rather than an array.
+    const searchType = Array.isArray(rawQueryType)
+        ? resolvedType
+        : resolveSearchType(req.session?.featureFlags?.type, req.session);
+
     redirectQuery.set('type', searchType);
     const currentPath = req.originalUrl.split('?')[0];
     return res.redirect(`${currentPath}?${redirectQuery.toString()}`);

--- a/middleware/enforceSearchTypeInQuery/index.js
+++ b/middleware/enforceSearchTypeInQuery/index.js
@@ -22,14 +22,27 @@ export default function enforceSearchTypeInQuery(req, res, next) {
     }
 
     if (req.query.type !== undefined) {
-        const normalisedQueryType =
-            typeof req.query.type === 'string' ? req.query.type.trim().toLowerCase() : '';
+        const rawQueryType = typeof req.query.type === 'string' ? req.query.type : '';
+        const canonicalQueryType = rawQueryType.trim().toLowerCase();
         const resolved = resolveSearchType(req.query.type, req.session);
-        // Only skip the redirect when the type in the URL was itself a recognised
-        // value. If it was unrecognised, resolveSearchType falls back to the session
-        // or default, and we still need to redirect to canonicalise the URL.
-        if (normalisedQueryType && resolved === normalisedQueryType) {
+        // Only skip the redirect when the type in the URL is already in its
+        // canonical form and is itself a recognised value. Non-canonical casing
+        // or whitespace should still be redirected so the URL is canonicalised.
+        if (
+            rawQueryType &&
+            rawQueryType === canonicalQueryType &&
+            resolved === canonicalQueryType
+        ) {
             return next();
+        }
+        // If the type is recognisable but not canonical (e.g. wrong case or
+        // surrounding whitespace), redirect to the canonical form of the input
+        // rather than falling back to the session/default.
+        if (canonicalQueryType && resolved === canonicalQueryType) {
+            const redirectQuery = new URLSearchParams(req.query);
+            redirectQuery.set('type', canonicalQueryType);
+            const currentPath = req.originalUrl.split('?')[0];
+            return res.redirect(`${currentPath}?${redirectQuery.toString()}`);
         }
     }
 

--- a/middleware/enforceSearchTypeInQuery/index.js
+++ b/middleware/enforceSearchTypeInQuery/index.js
@@ -6,8 +6,9 @@ import { getFeatureFlagValue } from '../featureFlags/index.js';
  *
  * When `type` is absent from the query string the resolved search type (from the session,
  * falling back to the application default) is appended and the browser is redirected.
- * This keeps the URL canonical and bookmarkable without the route handler needing to
- * duplicate the logic.
+ * This keeps the URL canonical and bookmarkable without route handlers needing to
+ * duplicate the logic. The redirect preserves the current request path so it can be
+ * mounted at a route or app layer.
  *
  * Applies only to GET requests; POST requests are passed through unchanged.
  *
@@ -27,5 +28,6 @@ export default function enforceSearchTypeInQuery(req, res, next) {
     const searchType = getFeatureFlagValue(req.session, 'type') || DEFAULT_SEARCH_TYPE;
     const redirectQuery = new URLSearchParams(req.query);
     redirectQuery.set('type', searchType);
-    return res.redirect(`/search?${redirectQuery.toString()}`);
+    const currentPath = req.originalUrl.split('?')[0];
+    return res.redirect(`${currentPath}?${redirectQuery.toString()}`);
 }

--- a/middleware/enforceSearchTypeInQuery/index.js
+++ b/middleware/enforceSearchTypeInQuery/index.js
@@ -38,12 +38,20 @@ export default function enforceSearchTypeInQuery(req, res, next) {
 
     const redirectQuery = new URLSearchParams(req.query);
 
-    // Keep historical behaviour for single values (fallback from session/default),
-    // but canonicalize repeated params to one resolved value so downstream
-    // middleware sees a string type rather than an array.
-    const searchType = Array.isArray(rawQueryType)
-        ? resolvedType
-        : resolveSearchType(req.session?.featureFlags?.type, req.session);
+    // Use the resolved canonical value when the query param is provided (even if
+    // non-canonical like "HYBRID" or " keyword-dates "). Fall back to session/default
+    // only when the query value is genuinely absent or empty.
+    let searchType;
+    if (Array.isArray(rawQueryType)) {
+        // Canonicalize repeated params to resolved value
+        searchType = resolvedType;
+    } else if (typeof queryType === 'string' && queryType.trim().length > 0) {
+        // Query value was provided (not absent/empty) - use the resolved canonical form
+        searchType = resolvedType;
+    } else {
+        // Query value was absent or empty - fall back to session/default
+        searchType = resolveSearchType(req.session?.featureFlags?.type, req.session);
+    }
 
     redirectQuery.set('type', searchType);
     const currentPath = req.originalUrl.split('?')[0];

--- a/middleware/enforceSearchTypeInQuery/index.js
+++ b/middleware/enforceSearchTypeInQuery/index.js
@@ -22,8 +22,8 @@ export default function enforceSearchTypeInQuery(req, res, next) {
     }
 
     if (req.query.type !== undefined) {
-        const { searchType } = parseSearchType(req.query.type);
-        if (typeof searchType === 'string') {
+        const { value } = parseSearchType(req.query.type);
+        if (typeof value === 'string') {
             return next();
         }
     }

--- a/middleware/enforceSearchTypeInQuery/index.js
+++ b/middleware/enforceSearchTypeInQuery/index.js
@@ -1,5 +1,4 @@
-import { DEFAULT_SEARCH_TYPE, resolveSearchType } from '../../api/search/constants/searchTypes.js';
-import { getFeatureFlagValue } from '../featureFlags/index.js';
+import { resolveSearchType } from '../../api/search/constants/searchTypes.js';
 
 /**
  * Middleware that ensures a `type` query parameter is always present on GET /search requests.
@@ -46,7 +45,7 @@ export default function enforceSearchTypeInQuery(req, res, next) {
         }
     }
 
-    const searchType = getFeatureFlagValue(req.session, 'type') || DEFAULT_SEARCH_TYPE;
+    const searchType = resolveSearchType(req.session?.featureFlags?.type, req.session);
     const redirectQuery = new URLSearchParams(req.query);
     redirectQuery.set('type', searchType);
     const currentPath = req.originalUrl.split('?')[0];

--- a/middleware/enforceSearchTypeInQuery/index.js
+++ b/middleware/enforceSearchTypeInQuery/index.js
@@ -1,0 +1,31 @@
+import { DEFAULT_SEARCH_TYPE } from '../../api/search/constants/searchTypes.js';
+import { getFeatureFlagValue } from '../featureFlags/index.js';
+
+/**
+ * Middleware that ensures a `type` query parameter is always present on GET /search requests.
+ *
+ * When `type` is absent from the query string the resolved search type (from the session,
+ * falling back to the application default) is appended and the browser is redirected.
+ * This keeps the URL canonical and bookmarkable without the route handler needing to
+ * duplicate the logic.
+ *
+ * Applies only to GET requests; POST requests are passed through unchanged.
+ *
+ * @param {import('express').Request} req - Express request object.
+ * @param {import('express').Response} res - Express response object.
+ * @param {import('express').NextFunction} next - Express next middleware function.
+ */
+export default function enforceSearchTypeInQuery(req, res, next) {
+    if (req.method !== 'GET') {
+        return next();
+    }
+
+    if (req.query.type !== undefined) {
+        return next();
+    }
+
+    const searchType = getFeatureFlagValue(req.session, 'type') || DEFAULT_SEARCH_TYPE;
+    const redirectQuery = new URLSearchParams(req.query);
+    redirectQuery.set('type', searchType);
+    return res.redirect(`/search?${redirectQuery.toString()}`);
+}

--- a/middleware/enforceSearchTypeInQuery/index.js
+++ b/middleware/enforceSearchTypeInQuery/index.js
@@ -20,39 +20,25 @@ export default function enforceSearchTypeInQuery(req, res, next) {
         return next();
     }
 
-    if (req.query.type !== undefined) {
-           // Express parses repeated query params (e.g. ?type=a&type=b) as an array.
-           // Use the last element in that case, consistent with parseFeatureFlagValue /
-           // parseEnumFlagValue, so a valid trailing value is not silently discarded and
-           // the user's intent is preserved in any subsequent redirect.
-        const rawQueryType = Array.isArray(req.query.type)
-            ? (req.query.type.at(-1) ?? '')
-            : typeof req.query.type === 'string'
-              ? req.query.type
-              : '';
-        const canonicalQueryType = rawQueryType.trim().toLowerCase();
-        const resolved = resolveSearchType(req.query.type, req.session);
-        // Only skip the redirect when the type in the URL is already in its
-        // canonical form and is itself a recognised value. Non-canonical casing
-        // or whitespace should still be redirected so the URL is canonicalised.
-        if (
-            rawQueryType &&
-            rawQueryType === canonicalQueryType &&
-            resolved === canonicalQueryType
-        ) {
-            return next();
-        }
-        // If the type is recognisable but not canonical (e.g. wrong case or
-        // surrounding whitespace), redirect to the canonical form of the input
-        // rather than falling back to the session/default.
-        if (canonicalQueryType && resolved === canonicalQueryType) {
-            const redirectQuery = new URLSearchParams(req.query);
-            redirectQuery.set('type', canonicalQueryType);
-            const currentPath = req.originalUrl.split('?')[0];
-            return res.redirect(`${currentPath}?${redirectQuery.toString()}`);
-        }
+    // Express parses repeated query params (e.g. ?type=a&type=b) as an array.
+    // Use the last element in that case, consistent with parseFeatureFlagValue /
+    // parseEnumFlagValue, so a valid trailing value is not silently discarded.
+    const queryType = Array.isArray(req.query.type) ? req.query.type.at(-1) : req.query.type;
+
+    const resolved = resolveSearchType(queryType, req.session);
+
+    // Only skip the redirect when the query value is already the exact canonical
+    // form. Anything absent, invalid, or messy (wrong case, whitespace) is
+    // redirected to the resolved value from the session or app default.
+    if (queryType === resolved) {
+        return next();
     }
 
+    // For the redirect, resolve from the session value directly so that a valid
+    // session type is used as the fallback rather than always defaulting to the
+    // app default. resolveSearchType(undefined, session) skips the session lookup
+    // and returns DEFAULT_SEARCH_TYPE immediately, so we pass the session value
+    // explicitly here.
     const searchType = resolveSearchType(req.session?.featureFlags?.type, req.session);
     const redirectQuery = new URLSearchParams(req.query);
     redirectQuery.set('type', searchType);

--- a/middleware/enforceSearchTypeInQuery/index.js
+++ b/middleware/enforceSearchTypeInQuery/index.js
@@ -1,11 +1,11 @@
-import { DEFAULT_SEARCH_TYPE } from '../../api/search/constants/searchTypes.js';
+import { DEFAULT_SEARCH_TYPE, parseSearchType } from '../../api/search/constants/searchTypes.js';
 import { getFeatureFlagValue } from '../featureFlags/index.js';
 
 /**
  * Middleware that ensures a `type` query parameter is always present on GET /search requests.
  *
- * When `type` is absent from the query string the resolved search type (from the session,
- * falling back to the application default) is appended and the browser is redirected.
+ * When `type` is absent or invalid in the query string the resolved search type (from the
+ * session, falling back to the application default) is appended and the browser is redirected.
  * This keeps the URL canonical and bookmarkable without route handlers needing to
  * duplicate the logic. The redirect preserves the current request path so it can be
  * mounted at a route or app layer.
@@ -22,7 +22,10 @@ export default function enforceSearchTypeInQuery(req, res, next) {
     }
 
     if (req.query.type !== undefined) {
-        return next();
+        const { searchType } = parseSearchType(req.query.type);
+        if (typeof searchType === 'string') {
+            return next();
+        }
     }
 
     const searchType = getFeatureFlagValue(req.session, 'type') || DEFAULT_SEARCH_TYPE;

--- a/middleware/enforceSearchTypeInQuery/index.test.js
+++ b/middleware/enforceSearchTypeInQuery/index.test.js
@@ -63,7 +63,7 @@ describe('enforceSearchTypeInQuery', () => {
         assert.strictEqual(nextCalled, false);
     });
 
-    it('calls next without redirecting when type is present in query', () => {
+    it('calls next without redirecting when type is present and valid in query', () => {
         const req = createMockReq({ query: { query: 'acute', type: 'hybrid' } });
         const res = createMockRes();
         let nextCalled = false;
@@ -74,6 +74,22 @@ describe('enforceSearchTypeInQuery', () => {
 
         assert.strictEqual(res.redirectedUrl, null);
         assert.strictEqual(nextCalled, true);
+    });
+
+    it('redirects with session/default type when type is present but invalid', () => {
+        const req = createMockReq({
+            query: { query: 'acute', type: 'keyword,semantic' },
+            session: { featureFlags: { type: 'keyword' } }
+        });
+        const res = createMockRes();
+        let nextCalled = false;
+
+        enforceSearchTypeInQuery(req, res, () => {
+            nextCalled = true;
+        });
+
+        assert.strictEqual(res.redirectedUrl, '/search?query=acute&type=keyword');
+        assert.strictEqual(nextCalled, false);
     });
 
     it('calls next without redirecting for non-GET requests', () => {

--- a/middleware/enforceSearchTypeInQuery/index.test.js
+++ b/middleware/enforceSearchTypeInQuery/index.test.js
@@ -6,11 +6,11 @@ import enforceSearchTypeInQuery from './index.js';
 /**
  * Creates a mock Express request object.
  *
- * @param {{ method?: string, query?: object, session?: object, originalUrl?: string }} [opts] - Optional request properties to override.
+ * @param {{ method?: string, query?: object, session?: object, originalUrl?: string, baseUrl?: string, path?: string }} [opts] - Optional request properties to override.
  * @returns {object}
  */
-function createMockReq({ method = 'GET', query = {}, session = {}, originalUrl = '/search' } = {}) {
-    return { method, query, session, originalUrl };
+function createMockReq({ method = 'GET', query = {}, session = {}, originalUrl = '/search', baseUrl = '/search', path = '/' } = {}) {
+    return { method, query, session, originalUrl, baseUrl, path };
 }
 
 /**
@@ -226,7 +226,9 @@ describe('enforceSearchTypeInQuery', () => {
     it('preserves the current request path in the redirect', () => {
         const req = createMockReq({
             query: { query: 'acute' },
-            originalUrl: '/search/advanced?query=acute'
+            originalUrl: '/search/advanced?query=acute',
+            baseUrl: '/search',
+            path: '/advanced'
         });
         const res = createMockRes();
 
@@ -236,5 +238,23 @@ describe('enforceSearchTypeInQuery', () => {
             res.redirectedUrl,
             `/search/advanced?query=acute&type=${DEFAULT_SEARCH_TYPE}`
         );
+    });
+
+    it('does not forward raw originalUrl into the redirect destination', () => {
+        const req = createMockReq({
+            query: { query: 'acute' },
+            originalUrl: 'https://evil.example.com/search?query=acute',
+            baseUrl: '/search',
+            path: '/'
+        });
+        const res = createMockRes();
+
+        enforceSearchTypeInQuery(req, res, () => {});
+
+        assert.ok(
+            !res.redirectedUrl?.startsWith('https://'),
+            'redirect must not use raw originalUrl'
+        );
+        assert.ok(res.redirectedUrl?.startsWith('/search?'));
     });
 });

--- a/middleware/enforceSearchTypeInQuery/index.test.js
+++ b/middleware/enforceSearchTypeInQuery/index.test.js
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { DEFAULT_SEARCH_TYPE } from '../../api/search/constants/searchTypes.js';
+import enforceSearchTypeInQuery from './index.js';
+
+/**
+ * Creates a mock Express request object.
+ *
+ * @param {{ method?: string, query?: object, session?: object }} [opts] - Optional request properties to override.
+ * @returns {object}
+ */
+function createMockReq({ method = 'GET', query = {}, session = {} } = {}) {
+    return { method, query, session };
+}
+
+/**
+ * Creates a mock Express response object with redirect tracking.
+ *
+ * @returns {object}
+ */
+function createMockRes() {
+    let redirectedUrl = null;
+    return {
+        redirect(url) {
+            redirectedUrl = url;
+        },
+        get redirectedUrl() {
+            return redirectedUrl;
+        }
+    };
+}
+
+describe('enforceSearchTypeInQuery', () => {
+    it('redirects with default type when type is absent from query', () => {
+        const req = createMockReq({ query: { query: 'acute', crn: '26-711111' } });
+        const res = createMockRes();
+        let nextCalled = false;
+
+        enforceSearchTypeInQuery(req, res, () => {
+            nextCalled = true;
+        });
+
+        assert.strictEqual(
+            res.redirectedUrl,
+            `/search?query=acute&crn=26-711111&type=${DEFAULT_SEARCH_TYPE}`
+        );
+        assert.strictEqual(nextCalled, false);
+    });
+
+    it('redirects with session type when set and type absent from query', () => {
+        const req = createMockReq({
+            query: { query: 'acute' },
+            session: { featureFlags: { type: 'keyword' } }
+        });
+        const res = createMockRes();
+        let nextCalled = false;
+
+        enforceSearchTypeInQuery(req, res, () => {
+            nextCalled = true;
+        });
+
+        assert.strictEqual(res.redirectedUrl, '/search?query=acute&type=keyword');
+        assert.strictEqual(nextCalled, false);
+    });
+
+    it('calls next without redirecting when type is present in query', () => {
+        const req = createMockReq({ query: { query: 'acute', type: 'hybrid' } });
+        const res = createMockRes();
+        let nextCalled = false;
+
+        enforceSearchTypeInQuery(req, res, () => {
+            nextCalled = true;
+        });
+
+        assert.strictEqual(res.redirectedUrl, null);
+        assert.strictEqual(nextCalled, true);
+    });
+
+    it('calls next without redirecting for non-GET requests', () => {
+        const req = createMockReq({ method: 'POST', query: {} });
+        const res = createMockRes();
+        let nextCalled = false;
+
+        enforceSearchTypeInQuery(req, res, () => {
+            nextCalled = true;
+        });
+
+        assert.strictEqual(res.redirectedUrl, null);
+        assert.strictEqual(nextCalled, true);
+    });
+
+    it('preserves all existing query params in the redirect', () => {
+        const req = createMockReq({
+            query: { query: 'brain injury', pageNumber: '2', crn: '26-711111' }
+        });
+        const res = createMockRes();
+
+        enforceSearchTypeInQuery(req, res, () => {});
+
+        const redirected = new URL(res.redirectedUrl, 'http://localhost');
+        assert.strictEqual(redirected.searchParams.get('query'), 'brain injury');
+        assert.strictEqual(redirected.searchParams.get('pageNumber'), '2');
+        assert.strictEqual(redirected.searchParams.get('crn'), '26-711111');
+        assert.strictEqual(redirected.searchParams.get('type'), DEFAULT_SEARCH_TYPE);
+    });
+});

--- a/middleware/enforceSearchTypeInQuery/index.test.js
+++ b/middleware/enforceSearchTypeInQuery/index.test.js
@@ -92,7 +92,7 @@ describe('enforceSearchTypeInQuery', () => {
         assert.strictEqual(nextCalled, true);
     });
 
-    it('redirects to canonical form when type is valid but has non-canonical casing', () => {
+    it('redirects with session/default type when type has non-canonical casing', () => {
         const req = createMockReq({ query: { query: 'acute', type: 'HYBRID' } });
         const res = createMockRes();
         let nextCalled = false;
@@ -104,10 +104,10 @@ describe('enforceSearchTypeInQuery', () => {
         assert.ok(res.redirectedUrl !== null, 'should redirect');
         assert.strictEqual(nextCalled, false);
         const redirected = new URL(res.redirectedUrl, 'http://localhost');
-        assert.strictEqual(redirected.searchParams.get('type'), 'hybrid');
+        assert.strictEqual(redirected.searchParams.get('type'), DEFAULT_SEARCH_TYPE);
     });
 
-    it('redirects to canonical form when type is valid but has surrounding whitespace', () => {
+    it('redirects with session/default type when type has surrounding whitespace', () => {
         const req = createMockReq({ query: { query: 'acute', type: ' keyword-dates ' } });
         const res = createMockRes();
         let nextCalled = false;
@@ -119,7 +119,7 @@ describe('enforceSearchTypeInQuery', () => {
         assert.ok(res.redirectedUrl !== null, 'should redirect');
         assert.strictEqual(nextCalled, false);
         const redirected = new URL(res.redirectedUrl, 'http://localhost');
-        assert.strictEqual(redirected.searchParams.get('type'), 'keyword-dates');
+        assert.strictEqual(redirected.searchParams.get('type'), DEFAULT_SEARCH_TYPE);
     });
 
     it('uses the last value when type is supplied as an array with a valid final element', () => {

--- a/middleware/enforceSearchTypeInQuery/index.test.js
+++ b/middleware/enforceSearchTypeInQuery/index.test.js
@@ -92,7 +92,7 @@ describe('enforceSearchTypeInQuery', () => {
         assert.strictEqual(nextCalled, true);
     });
 
-    it('redirects with session/default type when type has non-canonical casing', () => {
+    it('redirects to canonical form when type has non-canonical casing', () => {
         const req = createMockReq({ query: { query: 'acute', type: 'HYBRID' } });
         const res = createMockRes();
         let nextCalled = false;
@@ -104,10 +104,11 @@ describe('enforceSearchTypeInQuery', () => {
         assert.ok(res.redirectedUrl !== null, 'should redirect');
         assert.strictEqual(nextCalled, false);
         const redirected = new URL(res.redirectedUrl, 'http://localhost');
-        assert.strictEqual(redirected.searchParams.get('type'), DEFAULT_SEARCH_TYPE);
+        // Non-canonical input 'HYBRID' should resolve and redirect to canonical 'hybrid'
+        assert.strictEqual(redirected.searchParams.get('type'), 'hybrid');
     });
 
-    it('redirects with session/default type when type has surrounding whitespace', () => {
+    it('redirects to canonical form when type has surrounding whitespace', () => {
         const req = createMockReq({ query: { query: 'acute', type: ' keyword-dates ' } });
         const res = createMockRes();
         let nextCalled = false;
@@ -119,7 +120,34 @@ describe('enforceSearchTypeInQuery', () => {
         assert.ok(res.redirectedUrl !== null, 'should redirect');
         assert.strictEqual(nextCalled, false);
         const redirected = new URL(res.redirectedUrl, 'http://localhost');
-        assert.strictEqual(redirected.searchParams.get('type'), DEFAULT_SEARCH_TYPE);
+        // Non-canonical input with whitespace should resolve and redirect to canonical form
+        assert.strictEqual(redirected.searchParams.get('type'), 'keyword-dates');
+    });
+
+    it('uses resolved query value over session value for non-canonical single params', () => {
+        const req = createMockReq({
+            query: { query: 'acute', type: ' KEYWORD ' },
+            session: { featureFlags: { type: 'semantic' } }
+        });
+        const res = createMockRes();
+
+        enforceSearchTypeInQuery(req, res, () => {});
+
+        // Non-canonical query param should be canonicalized to 'keyword', not fallback to session 'semantic'
+        assert.strictEqual(res.redirectedUrl, '/search?query=acute&type=keyword');
+    });
+
+    it('falls back to session value when type is empty or whitespace-only', () => {
+        const req = createMockReq({
+            query: { query: 'acute', type: '   ' },
+            session: { featureFlags: { type: 'semantic' } }
+        });
+        const res = createMockRes();
+
+        enforceSearchTypeInQuery(req, res, () => {});
+
+        // Empty/whitespace query param should fall back to session value
+        assert.strictEqual(res.redirectedUrl, '/search?query=acute&type=semantic');
     });
 
     it('redirects to the last value when type is supplied as an array with a valid final element', () => {

--- a/middleware/enforceSearchTypeInQuery/index.test.js
+++ b/middleware/enforceSearchTypeInQuery/index.test.js
@@ -76,6 +76,36 @@ describe('enforceSearchTypeInQuery', () => {
         assert.strictEqual(nextCalled, true);
     });
 
+    it('redirects to canonical form when type is valid but has non-canonical casing', () => {
+        const req = createMockReq({ query: { query: 'acute', type: 'HYBRID' } });
+        const res = createMockRes();
+        let nextCalled = false;
+
+        enforceSearchTypeInQuery(req, res, () => {
+            nextCalled = true;
+        });
+
+        assert.ok(res.redirectedUrl !== null, 'should redirect');
+        assert.strictEqual(nextCalled, false);
+        const redirected = new URL(res.redirectedUrl, 'http://localhost');
+        assert.strictEqual(redirected.searchParams.get('type'), 'hybrid');
+    });
+
+    it('redirects to canonical form when type is valid but has surrounding whitespace', () => {
+        const req = createMockReq({ query: { query: 'acute', type: ' keyword-dates ' } });
+        const res = createMockRes();
+        let nextCalled = false;
+
+        enforceSearchTypeInQuery(req, res, () => {
+            nextCalled = true;
+        });
+
+        assert.ok(res.redirectedUrl !== null, 'should redirect');
+        assert.strictEqual(nextCalled, false);
+        const redirected = new URL(res.redirectedUrl, 'http://localhost');
+        assert.strictEqual(redirected.searchParams.get('type'), 'keyword-dates');
+    });
+
     it('redirects with session/default type when type is present but invalid', () => {
         const req = createMockReq({
             query: { query: 'acute', type: 'keyword,semantic' },

--- a/middleware/enforceSearchTypeInQuery/index.test.js
+++ b/middleware/enforceSearchTypeInQuery/index.test.js
@@ -63,6 +63,22 @@ describe('enforceSearchTypeInQuery', () => {
         assert.strictEqual(nextCalled, false);
     });
 
+    it('redirects with default type when session type is invalid and type absent from query', () => {
+        const req = createMockReq({
+            query: { query: 'acute' },
+            session: { featureFlags: { type: 'old-value' } }
+        });
+        const res = createMockRes();
+        let nextCalled = false;
+
+        enforceSearchTypeInQuery(req, res, () => {
+            nextCalled = true;
+        });
+
+        assert.strictEqual(res.redirectedUrl, `/search?query=acute&type=${DEFAULT_SEARCH_TYPE}`);
+        assert.strictEqual(nextCalled, false);
+    });
+
     it('calls next without redirecting when type is present and valid in query', () => {
         const req = createMockReq({ query: { query: 'acute', type: 'hybrid' } });
         const res = createMockRes();

--- a/middleware/enforceSearchTypeInQuery/index.test.js
+++ b/middleware/enforceSearchTypeInQuery/index.test.js
@@ -122,7 +122,7 @@ describe('enforceSearchTypeInQuery', () => {
         assert.strictEqual(redirected.searchParams.get('type'), DEFAULT_SEARCH_TYPE);
     });
 
-    it('uses the last value when type is supplied as an array with a valid final element', () => {
+    it('redirects to the last value when type is supplied as an array with a valid final element', () => {
         const req = createMockReq({ query: { query: 'acute', type: ['invalid', 'keyword'] } });
         const res = createMockRes();
         let nextCalled = false;
@@ -131,8 +131,8 @@ describe('enforceSearchTypeInQuery', () => {
             nextCalled = true;
         });
 
-        assert.strictEqual(res.redirectedUrl, null);
-        assert.strictEqual(nextCalled, true);
+        assert.strictEqual(res.redirectedUrl, '/search?query=acute&type=keyword');
+        assert.strictEqual(nextCalled, false);
     });
 
     it('redirects to session/default when type is an array whose last element is invalid', () => {

--- a/middleware/enforceSearchTypeInQuery/index.test.js
+++ b/middleware/enforceSearchTypeInQuery/index.test.js
@@ -6,11 +6,11 @@ import enforceSearchTypeInQuery from './index.js';
 /**
  * Creates a mock Express request object.
  *
- * @param {{ method?: string, query?: object, session?: object }} [opts] - Optional request properties to override.
+ * @param {{ method?: string, query?: object, session?: object, originalUrl?: string }} [opts] - Optional request properties to override.
  * @returns {object}
  */
-function createMockReq({ method = 'GET', query = {}, session = {} } = {}) {
-    return { method, query, session };
+function createMockReq({ method = 'GET', query = {}, session = {}, originalUrl = '/search' } = {}) {
+    return { method, query, session, originalUrl };
 }
 
 /**
@@ -102,5 +102,20 @@ describe('enforceSearchTypeInQuery', () => {
         assert.strictEqual(redirected.searchParams.get('pageNumber'), '2');
         assert.strictEqual(redirected.searchParams.get('crn'), '26-711111');
         assert.strictEqual(redirected.searchParams.get('type'), DEFAULT_SEARCH_TYPE);
+    });
+
+    it('preserves the current request path in the redirect', () => {
+        const req = createMockReq({
+            query: { query: 'acute' },
+            originalUrl: '/search/advanced?query=acute'
+        });
+        const res = createMockRes();
+
+        enforceSearchTypeInQuery(req, res, () => {});
+
+        assert.strictEqual(
+            res.redirectedUrl,
+            `/search/advanced?query=acute&type=${DEFAULT_SEARCH_TYPE}`
+        );
     });
 });

--- a/middleware/enforceSearchTypeInQuery/index.test.js
+++ b/middleware/enforceSearchTypeInQuery/index.test.js
@@ -9,7 +9,14 @@ import enforceSearchTypeInQuery from './index.js';
  * @param {{ method?: string, query?: object, session?: object, originalUrl?: string, baseUrl?: string, path?: string }} [opts] - Optional request properties to override.
  * @returns {object}
  */
-function createMockReq({ method = 'GET', query = {}, session = {}, originalUrl = '/search', baseUrl = '/search', path = '/' } = {}) {
+function createMockReq({
+    method = 'GET',
+    query = {},
+    session = {},
+    originalUrl = '/search',
+    baseUrl = '/search',
+    path = '/'
+} = {}) {
     return { method, query, session, originalUrl, baseUrl, path };
 }
 

--- a/middleware/enforceSearchTypeInQuery/index.test.js
+++ b/middleware/enforceSearchTypeInQuery/index.test.js
@@ -122,6 +122,35 @@ describe('enforceSearchTypeInQuery', () => {
         assert.strictEqual(redirected.searchParams.get('type'), 'keyword-dates');
     });
 
+    it('uses the last value when type is supplied as an array with a valid final element', () => {
+        const req = createMockReq({ query: { query: 'acute', type: ['invalid', 'keyword'] } });
+        const res = createMockRes();
+        let nextCalled = false;
+
+        enforceSearchTypeInQuery(req, res, () => {
+            nextCalled = true;
+        });
+
+        assert.strictEqual(res.redirectedUrl, null);
+        assert.strictEqual(nextCalled, true);
+    });
+
+    it('redirects to session/default when type is an array whose last element is invalid', () => {
+        const req = createMockReq({
+            query: { query: 'acute', type: ['keyword', 'not-a-type'] },
+            session: { featureFlags: { type: 'semantic' } }
+        });
+        const res = createMockRes();
+        let nextCalled = false;
+
+        enforceSearchTypeInQuery(req, res, () => {
+            nextCalled = true;
+        });
+
+        assert.strictEqual(res.redirectedUrl, '/search?query=acute&type=semantic');
+        assert.strictEqual(nextCalled, false);
+    });
+
     it('redirects with session/default type when type is present but invalid', () => {
         const req = createMockReq({
             query: { query: 'acute', type: 'keyword,semantic' },

--- a/middleware/featureFlags/README.md
+++ b/middleware/featureFlags/README.md
@@ -6,40 +6,42 @@ Runtime feature flags are stored in the Express session (`req.session.featureFla
 
 | Flag | Type | Default | Purpose |
 |---|---|---|---|
-| `keyword` | `boolean` | `true` | Enable lexical (BM25) keyword search matching |
-| `semantic` | `boolean` | `false` | Enable neural (vector) semantic search matching |
-| `dates` | `boolean` | `true` | Enable date extraction and format-variant expansion in lexical matching |
 | `align` | `boolean` | `true` | Enable alignment of image highlight bounding boxes to prevent overlaps |
+| `type` | `string` | `hybrid,dates` | Search mode - controls which OpenSearch query strategy is used |
 
 ## Toggling flags via URL
 
-Any flag can be toggled by including it as a query parameter with `on` or `off`:
+Boolean flags (`align`) are toggled with `on` / `off`.
+
+The `type` flag accepts a comma-delimited string of capability tokens (`keyword`, `dates`, `semantic`, `hybrid`). The tokens are resolved order-independently to a search mode slug:
 
 ```
-/search?keyword=on&semantic=on        → enable hybrid search (keyword + neural)
-/search?keyword=on&semantic=off       → keyword only
-/search?keyword=off&semantic=on       → semantic only
-/search?dates=off                     → disable date extraction
-/search?keyword=on&semantic=on&dates=on → hybrid + date expansion (all capabilities)
-/search?align=off                     → disable bounding-box alignment
+/search?type=hybrid,dates          → hybrid-dates  (default)
+/search?type=hybrid                → hybrid
+/search?type=keyword,dates         → keyword-dates
+/search?type=keyword               → keyword
+/search?type=semantic              → semantic
+/search?align=off                  → disable bounding-box alignment
+/search?type=hybrid,dates&align=off → hybrid-dates + alignment off
 ```
 
-The middleware persists the value to the session, so subsequent requests within the same session retain the setting without repeating the query parameter.
+The middleware persists the resolved slug to the session, so subsequent requests within the same session retain the setting without repeating the query parameter.
 
-## Search mode combinations
+## Search mode slugs
 
-| `keyword` | `semantic` | `dates` | Effective mode |
-|:---:|:---:|:---:|---|
-| on | off | off | Keyword only |
-| on | off | on | Keyword + date expansion |
-| off | on | off | Semantic only |
-| off | on | on | Semantic + date phrases |
-| on | on | off | Hybrid |
-| on | on | on | Hybrid + date expansion |
+| `type` slug | Tokens required | OpenSearch strategy |
+|---|---|---|
+| `hybrid-dates` _(default)_ | `hybrid` + `dates` | BM25 + neural + date phrase expansion |
+| `hybrid` | `hybrid` | BM25 + neural, no date extraction |
+| `keyword-dates` | `keyword` + `dates` | BM25 + date phrase expansion |
+| `keyword` | `keyword` | BM25 only |
+| `semantic` | `semantic` | Neural vector only |
 
 ## Implementation
 
-- `FEATURE_FLAG_DEFAULTS` — the baseline value for each flag when not set in session.
+- `DEFAULT_SEARCH_TYPE` — exported from `api/search/constants/searchTypes.js`; the single source of truth for the default (`hybrid-dates`).
+- `FEATURE_FLAG_DEFAULTS` — the baseline value for each flag when not set in session. Its `type` field is set to `DEFAULT_SEARCH_TYPE`.
 - `parseFeatureFlagValue(value)` — parses `'on'`→`true`, `'off'`→`false`, anything else→`undefined`.
+- `parseEnumFlagValue(value, allowedValues?)` — parses a string flag, with optional allowlist.
 - `getFeatureFlagValue(session, flagName)` — resolves a flag from session with fallback to defaults.
 - `featureFlags` (default export) — Express middleware that reads query params, updates session, and sets `res.locals.featureFlags`.

--- a/middleware/featureFlags/README.md
+++ b/middleware/featureFlags/README.md
@@ -13,7 +13,7 @@ Runtime feature flags are stored in the Express session (`req.session.featureFla
 
 Boolean flags (`align`) are toggled with `on` / `off`.
 
-The `type` flag accepts a direct search mode slug:
+The `type` flag accepts a direct search mode value:
 
 ```
 /search?type=hybrid-dates          → hybrid-dates  (default)
@@ -25,13 +25,13 @@ The `type` flag accepts a direct search mode slug:
 /search?type=hybrid-dates&align=off → hybrid-dates + alignment off
 ```
 
-The middleware persists the resolved slug to the session, so subsequent requests within the same session retain the setting without repeating the query parameter.
+The middleware persists the resolved search type to the session, so subsequent requests within the same session retain the setting without repeating the query parameter.
 
-> **Note:** The token set must match a known resolution **exactly** — extra tokens are not ignored. An unresolvable combination (e.g. `semantic,dates`) returns a 400 error rather than falling back to the previous session value.
+> **Note:** The value must match a supported search mode **exactly**. An invalid value (for example `semantic,dates`) is ignored and the system falls back to the existing session value, or the default when no session value exists.
 
-## Search mode slugs
+## Search mode values
 
-| `type` slug | Tokens required | OpenSearch strategy |
+| `type` value | Tokens required | OpenSearch strategy |
 |---|---|---|
 | `hybrid-dates` _(default)_ | `keyword` + `semantic` + `dates` | BM25 + neural + date phrase expansion |
 | `hybrid` | `keyword` + `semantic` | BM25 + neural, no date extraction |

--- a/middleware/featureFlags/README.md
+++ b/middleware/featureFlags/README.md
@@ -13,7 +13,7 @@ Runtime feature flags are stored in the Express session (`req.session.featureFla
 
 Boolean flags (`align`) are toggled with `on` / `off`.
 
-The `type` flag accepts a direct search mode value:
+The `type` flag accepts a recognised search type value:
 
 ```
 /search?type=hybrid-dates          → hybrid-dates  (default)
@@ -25,7 +25,7 @@ The `type` flag accepts a direct search mode value:
 /search?type=hybrid-dates&align=off → hybrid-dates + alignment off
 ```
 
-The middleware persists the resolved search type to the session, so subsequent requests within the same session retain the setting without repeating the query parameter.
+The middleware persists the resolved value to the session, so subsequent requests within the same session retain the setting without repeating the query parameter.
 
 > **Note:** The value must match a supported search mode **exactly**. An invalid value (for example `semantic,dates`) is ignored and the system falls back to the existing session value, or the default when no session value exists.
 

--- a/middleware/featureFlags/README.md
+++ b/middleware/featureFlags/README.md
@@ -31,13 +31,13 @@ The middleware persists the resolved value to the session, so subsequent request
 
 ## Search mode values
 
-| `type` value | Tokens required | OpenSearch strategy |
-|---|---|---|
-| `hybrid-dates` _(default)_ | `keyword` + `semantic` + `dates` | BM25 + neural + date phrase expansion |
-| `hybrid` | `keyword` + `semantic` | BM25 + neural, no date extraction |
-| `keyword-dates` | `keyword` + `dates` | BM25 + date phrase expansion |
-| `keyword` | `keyword` | BM25 only |
-| `semantic` | `semantic` | Neural vector only |
+| `type` value | Query strategy |
+|---|---|
+| `hybrid-dates` _(default)_ | BM25 + neural + date phrase expansion |
+| `hybrid` | BM25 + neural, no date extraction |
+| `keyword-dates` | BM25 + date phrase expansion |
+| `keyword` | BM25 only |
+| `semantic` | Neural vector only |
 
 ## Implementation
 

--- a/middleware/featureFlags/README.md
+++ b/middleware/featureFlags/README.md
@@ -1,0 +1,45 @@
+# Feature Flags
+
+Runtime feature flags are stored in the Express session (`req.session.featureFlags`) and applied to every request by the `featureFlags` middleware.
+
+## Available flags
+
+| Flag | Type | Default | Purpose |
+|---|---|---|---|
+| `keyword` | `boolean` | `true` | Enable lexical (BM25) keyword search matching |
+| `semantic` | `boolean` | `false` | Enable neural (vector) semantic search matching |
+| `dates` | `boolean` | `true` | Enable date extraction and format-variant expansion in lexical matching |
+| `align` | `boolean` | `true` | Enable alignment of image highlight bounding boxes to prevent overlaps |
+
+## Toggling flags via URL
+
+Any flag can be toggled by including it as a query parameter with `on` or `off`:
+
+```
+/search?keyword=on&semantic=on        → enable hybrid search (keyword + neural)
+/search?keyword=on&semantic=off       → keyword only
+/search?keyword=off&semantic=on       → semantic only
+/search?dates=off                     → disable date extraction
+/search?keyword=on&semantic=on&dates=on → hybrid + date expansion (all capabilities)
+/search?align=off                     → disable bounding-box alignment
+```
+
+The middleware persists the value to the session, so subsequent requests within the same session retain the setting without repeating the query parameter.
+
+## Search mode combinations
+
+| `keyword` | `semantic` | `dates` | Effective mode |
+|:---:|:---:|:---:|---|
+| on | off | off | Keyword only |
+| on | off | on | Keyword + date expansion |
+| off | on | off | Semantic only |
+| off | on | on | Semantic + date phrases |
+| on | on | off | Hybrid |
+| on | on | on | Hybrid + date expansion |
+
+## Implementation
+
+- `FEATURE_FLAG_DEFAULTS` — the baseline value for each flag when not set in session.
+- `parseFeatureFlagValue(value)` — parses `'on'`→`true`, `'off'`→`false`, anything else→`undefined`.
+- `getFeatureFlagValue(session, flagName)` — resolves a flag from session with fallback to defaults.
+- `featureFlags` (default export) — Express middleware that reads query params, updates session, and sets `res.locals.featureFlags`.

--- a/middleware/featureFlags/README.md
+++ b/middleware/featureFlags/README.md
@@ -13,16 +13,16 @@ Runtime feature flags are stored in the Express session (`req.session.featureFla
 
 Boolean flags (`align`) are toggled with `on` / `off`.
 
-The `type` flag accepts a comma-delimited string of capability tokens (`keyword`, `semantic`, `dates`). The tokens are resolved order-independently to a search mode slug:
+The `type` flag accepts a direct search mode slug:
 
 ```
-/search?type=keyword,semantic,dates  → hybrid-dates  (default)
-/search?type=keyword,semantic        → hybrid
-/search?type=keyword,dates           → keyword-dates
-/search?type=keyword                 → keyword
-/search?type=semantic                → semantic
-/search?align=off                    → disable bounding-box alignment
-/search?type=keyword,semantic,dates&align=off → hybrid-dates + alignment off
+/search?type=hybrid-dates          → hybrid-dates  (default)
+/search?type=hybrid                → hybrid
+/search?type=keyword-dates         → keyword-dates
+/search?type=keyword               → keyword
+/search?type=semantic              → semantic
+/search?align=off                  → disable bounding-box alignment
+/search?type=hybrid-dates&align=off → hybrid-dates + alignment off
 ```
 
 The middleware persists the resolved slug to the session, so subsequent requests within the same session retain the setting without repeating the query parameter.

--- a/middleware/featureFlags/README.md
+++ b/middleware/featureFlags/README.md
@@ -7,32 +7,34 @@ Runtime feature flags are stored in the Express session (`req.session.featureFla
 | Flag | Type | Default | Purpose |
 |---|---|---|---|
 | `align` | `boolean` | `true` | Enable alignment of image highlight bounding boxes to prevent overlaps |
-| `type` | `string` | `hybrid,dates` | Search mode - controls which OpenSearch query strategy is used |
+| `type` | `string` | `hybrid-dates` | Search mode - controls which OpenSearch query strategy is used |
 
 ## Toggling flags via URL
 
 Boolean flags (`align`) are toggled with `on` / `off`.
 
-The `type` flag accepts a comma-delimited string of capability tokens (`keyword`, `dates`, `semantic`, `hybrid`). The tokens are resolved order-independently to a search mode slug:
+The `type` flag accepts a comma-delimited string of capability tokens (`keyword`, `semantic`, `dates`). The tokens are resolved order-independently to a search mode slug:
 
 ```
-/search?type=hybrid,dates          → hybrid-dates  (default)
-/search?type=hybrid                → hybrid
-/search?type=keyword,dates         → keyword-dates
-/search?type=keyword               → keyword
-/search?type=semantic              → semantic
-/search?align=off                  → disable bounding-box alignment
-/search?type=hybrid,dates&align=off → hybrid-dates + alignment off
+/search?type=keyword,semantic,dates  → hybrid-dates  (default)
+/search?type=keyword,semantic        → hybrid
+/search?type=keyword,dates           → keyword-dates
+/search?type=keyword                 → keyword
+/search?type=semantic                → semantic
+/search?align=off                    → disable bounding-box alignment
+/search?type=keyword,semantic,dates&align=off → hybrid-dates + alignment off
 ```
 
 The middleware persists the resolved slug to the session, so subsequent requests within the same session retain the setting without repeating the query parameter.
+
+> **Note:** The token set must match a known resolution **exactly** — extra tokens are not ignored. An unresolvable combination (e.g. `semantic,dates`) returns a 400 error rather than falling back to the previous session value.
 
 ## Search mode slugs
 
 | `type` slug | Tokens required | OpenSearch strategy |
 |---|---|---|
-| `hybrid-dates` _(default)_ | `hybrid` + `dates` | BM25 + neural + date phrase expansion |
-| `hybrid` | `hybrid` | BM25 + neural, no date extraction |
+| `hybrid-dates` _(default)_ | `keyword` + `semantic` + `dates` | BM25 + neural + date phrase expansion |
+| `hybrid` | `keyword` + `semantic` | BM25 + neural, no date extraction |
 | `keyword-dates` | `keyword` + `dates` | BM25 + date phrase expansion |
 | `keyword` | `keyword` | BM25 only |
 | `semantic` | `semantic` | Neural vector only |

--- a/middleware/featureFlags/index.js
+++ b/middleware/featureFlags/index.js
@@ -1,6 +1,10 @@
 export const FEATURE_FLAG_DEFAULTS = Object.freeze({
     align: true, // toggle alignment of image highlighting to prevent or show overlapping
-    hybrid: false // toggle hybrid search on and off
+    type: 'keyword' // search type: 'keyword', 'semantic', or 'hybrid'
+});
+
+export const FEATURE_FLAG_ENUM_OPTIONS = Object.freeze({
+    type: Object.freeze(['keyword', 'semantic', 'hybrid'])
 });
 
 /**
@@ -29,14 +33,39 @@ export function parseFeatureFlagValue(value) {
 }
 
 /**
+ * Parses a query-string enum feature flag value against a set of allowed values.
+ *
+ * @param {unknown} value - Raw query-string value.
+ * @param {readonly string[]} allowedValues - Valid values for this flag.
+ * @returns {string | undefined} Matched value when valid, otherwise undefined.
+ */
+export function parseEnumFlagValue(value, allowedValues) {
+    const flagValue = Array.isArray(value) ? value.at(-1) : value;
+
+    if (typeof flagValue !== 'string') {
+        return undefined;
+    }
+
+    const normalized = flagValue.trim().toLowerCase();
+    return allowedValues.includes(normalized) ? normalized : undefined;
+}
+
+/**
  * Resolves a feature flag value from session state, with repo defaults.
  *
  * @param {import('express-session').Session | undefined} session - Request session object.
- * @param {'align' | 'hybrid'} flagName - Supported feature flag name.
- * @returns {boolean} The active feature flag value.
+ * @param {'align' | 'type'} flagName - Supported feature flag name.
+ * @returns {boolean | string} The active feature flag value.
  */
 export function getFeatureFlagValue(session, flagName) {
     const sessionFlagValue = session?.featureFlags?.[flagName];
+
+    if (flagName in FEATURE_FLAG_ENUM_OPTIONS) {
+        if (FEATURE_FLAG_ENUM_OPTIONS[flagName].includes(sessionFlagValue)) {
+            return sessionFlagValue;
+        }
+        return FEATURE_FLAG_DEFAULTS[flagName];
+    }
 
     if (typeof sessionFlagValue === 'boolean') {
         return sessionFlagValue;
@@ -59,14 +88,23 @@ export default function featureFlags(req, res, next) {
         for (const flagName of Object.keys(FEATURE_FLAG_DEFAULTS)) {
             flags[flagName] = getFeatureFlagValue(req.session, flagName);
 
-            const queryFlagValue = parseFeatureFlagValue(req.query?.[flagName]);
-            if (typeof queryFlagValue === 'boolean') {
-                flags[flagName] = queryFlagValue;
+            if (flagName in FEATURE_FLAG_ENUM_OPTIONS) {
+                const queryFlagValue = parseEnumFlagValue(
+                    req.query?.[flagName],
+                    FEATURE_FLAG_ENUM_OPTIONS[flagName]
+                );
+                if (queryFlagValue !== undefined) {
+                    flags[flagName] = queryFlagValue;
+                }
+            } else {
+                const queryFlagValue = parseFeatureFlagValue(req.query?.[flagName]);
+                if (typeof queryFlagValue === 'boolean') {
+                    flags[flagName] = queryFlagValue;
+                }
             }
         }
         req.session.featureFlags = flags;
         res.locals.featureFlags = flags;
     }
-
     next();
 }

--- a/middleware/featureFlags/index.js
+++ b/middleware/featureFlags/index.js
@@ -74,7 +74,7 @@ export function getFeatureFlagValue(session, flagName) {
  * Persists supported feature flags from query-string params into the session.
  *
  * Boolean flags (`align`) accept `on` / `off` query-string values.
- * The `type` flag accepts a direct search mode slug. Invalid values are ignored,
+ * The `type` flag accepts a direct search mode value. Invalid values are ignored,
  * leaving the existing session/default value unchanged.
  *
  * @param {import('express').Request} req - Express request object.

--- a/middleware/featureFlags/index.js
+++ b/middleware/featureFlags/index.js
@@ -74,8 +74,8 @@ export function getFeatureFlagValue(session, flagName) {
  * Persists supported feature flags from query-string params into the session.
  *
  * Boolean flags (`align`) accept `on` / `off` query-string values.
- * The `type` flag accepts a recognised search type value. Invalid values are rejected with
- * a 400 error.
+ * The `type` flag is resolved to a supported search type. Unrecognised values fall back to
+ * the current session value or the default search type.
  *
  * @param {import('express').Request} req - Express request object.
  * @param {import('express').Response} res - Express response object.

--- a/middleware/featureFlags/index.js
+++ b/middleware/featureFlags/index.js
@@ -1,4 +1,7 @@
-import { DEFAULT_SEARCH_TYPE, parseSearchType } from '../../api/search/constants/searchTypes.js';
+import SEARCH_TYPES, {
+    DEFAULT_SEARCH_TYPE,
+    parseSearchType
+} from '../../api/search/constants/searchTypes.js';
 
 export const FEATURE_FLAG_DEFAULTS = Object.freeze({
     align: true, // toggle alignment of image highlighting to prevent or show overlapping
@@ -94,9 +97,15 @@ export default function featureFlags(req, res, next) {
                     flags[flagName] = queryFlagValue;
                 }
             } else if (flagName === 'type' && req.query?.type !== undefined) {
-                const { searchType } = parseSearchType(req.query.type);
-                if (typeof searchType === 'string') {
-                    flags[flagName] = searchType;
+                const { value, invalidValue } = parseSearchType(req.query.type);
+                if (typeof value === 'string') {
+                    flags[flagName] = slug;
+                } else {
+                    const error = new Error(
+                        `Invalid search type: ${invalidValue || '(empty)'}. Allowed values: ${Object.values(SEARCH_TYPES).join(', ')}`
+                    );
+                    error.status = 400;
+                    return next(error);
                 }
             } else {
                 const queryFlagValue = parseEnumFlagValue(req.query?.[flagName]);

--- a/middleware/featureFlags/index.js
+++ b/middleware/featureFlags/index.js
@@ -98,9 +98,9 @@ export default function featureFlags(req, res, next) {
                     flags[flagName] = queryFlagValue;
                 }
             } else if (flagName === 'type' && req.query?.type !== undefined) {
-                const { slug, invalidValue } = parseSearchType(req.query.type);
-                if (typeof slug === 'string') {
-                    flags[flagName] = slug;
+                const { searchType, invalidValue } = parseSearchType(req.query.type);
+                if (typeof searchType === 'string') {
+                    flags[flagName] = searchType;
                 } else {
                     const error = new Error(
                         `Invalid search type: ${invalidValue || '(empty)'}. Allowed values: ${VALID_SEARCH_TYPE_VALUES.join(', ')}`

--- a/middleware/featureFlags/index.js
+++ b/middleware/featureFlags/index.js
@@ -93,16 +93,21 @@ export default function featureFlags(req, res, next) {
                 if (typeof queryFlagValue === 'boolean') {
                     flags[flagName] = queryFlagValue;
                 }
-            } else if (
-                flagName === 'type' &&
-                typeof req.query?.type === 'string' &&
-                req.query.type.trim().length > 0
-            ) {
-                // Only process a non-empty type value. An empty or whitespace-only
-                // ?type= query param is treated as absent so the session value is preserved.
-                const searchType = resolveSearchType(req.query.type, req.session);
-                if (typeof searchType === 'string') {
-                    flags[flagName] = searchType;
+            } else if (flagName === 'type') {
+                // Express parses repeated query params (e.g. ?type=a&type=b) as an array.
+                // Normalize to the last entry first, consistent with parseFeatureFlagValue /
+                // parseEnumFlagValue.
+                const queryType = Array.isArray(req.query?.type)
+                    ? req.query.type.at(-1)
+                    : req.query?.type;
+
+                if (typeof queryType === 'string' && queryType.trim().length > 0) {
+                    // Only process a non-empty type value. An empty or whitespace-only
+                    // ?type= query param is treated as absent so the session value is preserved.
+                    const searchType = resolveSearchType(queryType, req.session);
+                    if (typeof searchType === 'string') {
+                        flags[flagName] = searchType;
+                    }
                 }
             } else {
                 const queryFlagValue = parseEnumFlagValue(req.query?.[flagName]);

--- a/middleware/featureFlags/index.js
+++ b/middleware/featureFlags/index.js
@@ -1,6 +1,11 @@
+import {
+    DEFAULT_SEARCH_TYPE,
+    parseSearchTypeTokens
+} from '../../api/search/constants/searchTypes.js';
+
 export const FEATURE_FLAG_DEFAULTS = Object.freeze({
     align: true, // toggle alignment of image highlighting to prevent or show overlapping
-    type: 'keyword-dates' // search mode: keyword, keyword-dates, semantic, hybrid, or hybrid-dates
+    type: DEFAULT_SEARCH_TYPE // search mode: keyword, keyword-dates, semantic, hybrid, or hybrid-dates
 });
 
 /**
@@ -72,7 +77,9 @@ export function getFeatureFlagValue(session, flagName) {
  * Persists supported feature flags from query-string params into the session.
  *
  * Boolean flags (`align`) accept `on` / `off` query-string values.
- * String flags (`type`) accept any non-empty string query-string value.
+ * The `type` flag accepts a comma-delimited string of SEARCH_TYPE_TOKENS. If the value
+ * contains unrecognised tokens, or the combination of valid tokens does not map to a
+ * known search mode, the request is rejected with a 400 error.
  *
  * @param {import('express').Request} req - Express request object.
  * @param {import('express').Response} res - Express response object.
@@ -89,6 +96,24 @@ export default function featureFlags(req, res, next) {
                 const queryFlagValue = parseFeatureFlagValue(req.query?.[flagName]);
                 if (typeof queryFlagValue === 'boolean') {
                     flags[flagName] = queryFlagValue;
+                }
+            } else if (flagName === 'type' && req.query?.type !== undefined) {
+                const { slug, unknownTokens } = parseSearchTypeTokens(req.query.type);
+                if (unknownTokens.length > 0) {
+                    const error = new Error(
+                        `Invalid search type token(s): ${unknownTokens.join(', ')}`
+                    );
+                    error.status = 400;
+                    return next(error);
+                }
+                if (typeof slug === 'string') {
+                    flags[flagName] = slug;
+                } else {
+                    const error = new Error(
+                        `Invalid search type: tokens do not resolve to a known search mode`
+                    );
+                    error.status = 400;
+                    return next(error);
                 }
             } else {
                 const queryFlagValue = parseEnumFlagValue(req.query?.[flagName]);

--- a/middleware/featureFlags/index.js
+++ b/middleware/featureFlags/index.js
@@ -1,6 +1,7 @@
 import {
     DEFAULT_SEARCH_TYPE,
-    parseSearchTypeTokens
+    parseSearchType,
+    VALID_SEARCH_TYPE_VALUES
 } from '../../api/search/constants/searchTypes.js';
 
 export const FEATURE_FLAG_DEFAULTS = Object.freeze({
@@ -77,9 +78,8 @@ export function getFeatureFlagValue(session, flagName) {
  * Persists supported feature flags from query-string params into the session.
  *
  * Boolean flags (`align`) accept `on` / `off` query-string values.
- * The `type` flag accepts a comma-delimited string of SEARCH_TYPE_TOKENS. If the value
- * contains unrecognised tokens, or the combination of valid tokens does not map to a
- * known search mode, the request is rejected with a 400 error.
+ * The `type` flag accepts a direct search mode slug. Invalid values are rejected with
+ * a 400 error.
  *
  * @param {import('express').Request} req - Express request object.
  * @param {import('express').Response} res - Express response object.
@@ -98,19 +98,12 @@ export default function featureFlags(req, res, next) {
                     flags[flagName] = queryFlagValue;
                 }
             } else if (flagName === 'type' && req.query?.type !== undefined) {
-                const { slug, unknownTokens } = parseSearchTypeTokens(req.query.type);
-                if (unknownTokens.length > 0) {
-                    const error = new Error(
-                        `Invalid search type token(s): ${unknownTokens.join(', ')}`
-                    );
-                    error.status = 400;
-                    return next(error);
-                }
+                const { slug, invalidValue } = parseSearchType(req.query.type);
                 if (typeof slug === 'string') {
                     flags[flagName] = slug;
                 } else {
                     const error = new Error(
-                        `Invalid search type: tokens do not resolve to a known search mode`
+                        `Invalid search type: ${invalidValue || '(empty)'}. Allowed values: ${VALID_SEARCH_TYPE_VALUES.join(', ')}`
                     );
                     error.status = 400;
                     return next(error);

--- a/middleware/featureFlags/index.js
+++ b/middleware/featureFlags/index.js
@@ -77,8 +77,8 @@ export function getFeatureFlagValue(session, flagName) {
  * Persists supported feature flags from query-string params into the session.
  *
  * Boolean flags (`align`) accept `on` / `off` query-string values.
- * The `type` flag accepts a direct search mode value. Invalid values are ignored,
- * leaving the existing session/default value unchanged.
+ * The `type` flag accepts a recognised search type value. Invalid values are rejected with
+ * a 400 error.
  *
  * @param {import('express').Request} req - Express request object.
  * @param {import('express').Response} res - Express response object.
@@ -99,7 +99,7 @@ export default function featureFlags(req, res, next) {
             } else if (flagName === 'type' && req.query?.type !== undefined) {
                 const { value, invalidValue } = parseSearchType(req.query.type);
                 if (typeof value === 'string') {
-                    flags[flagName] = slug;
+                    flags[flagName] = value;
                 } else {
                     const error = new Error(
                         `Invalid search type: ${invalidValue || '(empty)'}. Allowed values: ${Object.values(SEARCH_TYPES).join(', ')}`

--- a/middleware/featureFlags/index.js
+++ b/middleware/featureFlags/index.js
@@ -86,7 +86,14 @@ export default function featureFlags(req, res, next) {
 
     if (req.session) {
         for (const flagName of Object.keys(FEATURE_FLAG_DEFAULTS)) {
-            flags[flagName] = getFeatureFlagValue(req.session, flagName);
+            // Initialize with session value or default, but validate the type flag.
+            // This ensures an invalid existing session type doesn't persist and
+            // get re-added to URLs or exposed through res.locals.featureFlags.
+            if (flagName === 'type') {
+                flags[flagName] = resolveSearchType(req.session?.featureFlags?.type, req.session);
+            } else {
+                flags[flagName] = getFeatureFlagValue(req.session, flagName);
+            }
 
             if (typeof FEATURE_FLAG_DEFAULTS[flagName] === 'boolean') {
                 const queryFlagValue = parseFeatureFlagValue(req.query?.[flagName]);

--- a/middleware/featureFlags/index.js
+++ b/middleware/featureFlags/index.js
@@ -1,8 +1,6 @@
 export const FEATURE_FLAG_DEFAULTS = Object.freeze({
     align: true, // toggle alignment of image highlighting to prevent or show overlapping
-    keyword: true, // enable lexical (BM25) keyword matching
-    semantic: false, // enable neural (vector) semantic matching
-    dates: true // enable date extraction and variant expansion in lexical matching
+    type: 'keyword-dates' // search mode: keyword, keyword-dates, semantic, hybrid, or hybrid-dates
 });
 
 /**
@@ -31,11 +29,12 @@ export function parseFeatureFlagValue(value) {
 }
 
 /**
- * Parses a query-string enum feature flag value against a set of allowed values.
+ * Parses a query-string string feature flag value.
  *
- * @deprecated No longer used — all flags are booleans. Retained for potential external use.
+ * Returns the trimmed string value when provided, otherwise undefined.
+ *
  * @param {unknown} value - Raw query-string value.
- * @param {readonly string[]} allowedValues - Valid values for this flag.
+ * @param {readonly string[] | undefined} allowedValues - Optional allowlist; if omitted any non-empty string is accepted.
  * @returns {string | undefined} Matched value when valid, otherwise undefined.
  */
 export function parseEnumFlagValue(value, allowedValues) {
@@ -46,20 +45,23 @@ export function parseEnumFlagValue(value, allowedValues) {
     }
 
     const normalized = flagValue.trim().toLowerCase();
-    return allowedValues.includes(normalized) ? normalized : undefined;
+    if (!normalized) return undefined;
+    return allowedValues === undefined || allowedValues.includes(normalized)
+        ? normalized
+        : undefined;
 }
 
 /**
  * Resolves a feature flag value from session state, with repo defaults.
  *
  * @param {import('express-session').Session | undefined} session - Request session object.
- * @param {'align' | 'keyword' | 'semantic' | 'dates'} flagName - Supported feature flag name.
- * @returns {boolean} The active feature flag value.
+ * @param {'align' | 'type'} flagName - Supported feature flag name.
+ * @returns {boolean | string} The active feature flag value.
  */
 export function getFeatureFlagValue(session, flagName) {
     const sessionFlagValue = session?.featureFlags?.[flagName];
 
-    if (typeof sessionFlagValue === 'boolean') {
+    if (typeof sessionFlagValue === 'boolean' || typeof sessionFlagValue === 'string') {
         return sessionFlagValue;
     }
 
@@ -69,8 +71,8 @@ export function getFeatureFlagValue(session, flagName) {
 /**
  * Persists supported feature flags from query-string params into the session.
  *
- * Recognised query-string values: `on` (true) and `off` (false).
- * Flags: `keyword`, `semantic`, `dates`, `align`.
+ * Boolean flags (`align`) accept `on` / `off` query-string values.
+ * String flags (`type`) accept any non-empty string query-string value.
  *
  * @param {import('express').Request} req - Express request object.
  * @param {import('express').Response} res - Express response object.
@@ -83,9 +85,16 @@ export default function featureFlags(req, res, next) {
         for (const flagName of Object.keys(FEATURE_FLAG_DEFAULTS)) {
             flags[flagName] = getFeatureFlagValue(req.session, flagName);
 
-            const queryFlagValue = parseFeatureFlagValue(req.query?.[flagName]);
-            if (typeof queryFlagValue === 'boolean') {
-                flags[flagName] = queryFlagValue;
+            if (typeof FEATURE_FLAG_DEFAULTS[flagName] === 'boolean') {
+                const queryFlagValue = parseFeatureFlagValue(req.query?.[flagName]);
+                if (typeof queryFlagValue === 'boolean') {
+                    flags[flagName] = queryFlagValue;
+                }
+            } else {
+                const queryFlagValue = parseEnumFlagValue(req.query?.[flagName]);
+                if (typeof queryFlagValue === 'string') {
+                    flags[flagName] = queryFlagValue;
+                }
             }
         }
         req.session.featureFlags = flags;

--- a/middleware/featureFlags/index.js
+++ b/middleware/featureFlags/index.js
@@ -1,8 +1,4 @@
-import {
-    DEFAULT_SEARCH_TYPE,
-    parseSearchType,
-    VALID_SEARCH_TYPE_VALUES
-} from '../../api/search/constants/searchTypes.js';
+import { DEFAULT_SEARCH_TYPE, parseSearchType } from '../../api/search/constants/searchTypes.js';
 
 export const FEATURE_FLAG_DEFAULTS = Object.freeze({
     align: true, // toggle alignment of image highlighting to prevent or show overlapping
@@ -78,8 +74,8 @@ export function getFeatureFlagValue(session, flagName) {
  * Persists supported feature flags from query-string params into the session.
  *
  * Boolean flags (`align`) accept `on` / `off` query-string values.
- * The `type` flag accepts a direct search mode slug. Invalid values are rejected with
- * a 400 error.
+ * The `type` flag accepts a direct search mode slug. Invalid values are ignored,
+ * leaving the existing session/default value unchanged.
  *
  * @param {import('express').Request} req - Express request object.
  * @param {import('express').Response} res - Express response object.
@@ -98,15 +94,9 @@ export default function featureFlags(req, res, next) {
                     flags[flagName] = queryFlagValue;
                 }
             } else if (flagName === 'type' && req.query?.type !== undefined) {
-                const { searchType, invalidValue } = parseSearchType(req.query.type);
+                const { searchType } = parseSearchType(req.query.type);
                 if (typeof searchType === 'string') {
                     flags[flagName] = searchType;
-                } else {
-                    const error = new Error(
-                        `Invalid search type: ${invalidValue || '(empty)'}. Allowed values: ${VALID_SEARCH_TYPE_VALUES.join(', ')}`
-                    );
-                    error.status = 400;
-                    return next(error);
                 }
             } else {
                 const queryFlagValue = parseEnumFlagValue(req.query?.[flagName]);

--- a/middleware/featureFlags/index.js
+++ b/middleware/featureFlags/index.js
@@ -93,7 +93,13 @@ export default function featureFlags(req, res, next) {
                 if (typeof queryFlagValue === 'boolean') {
                     flags[flagName] = queryFlagValue;
                 }
-            } else if (flagName === 'type' && req.query?.type !== undefined) {
+            } else if (
+                flagName === 'type' &&
+                typeof req.query?.type === 'string' &&
+                req.query.type.trim().length > 0
+            ) {
+                // Only process a non-empty type value. An empty or whitespace-only
+                // ?type= query param is treated as absent so the session value is preserved.
                 const searchType = resolveSearchType(req.query.type, req.session);
                 if (typeof searchType === 'string') {
                     flags[flagName] = searchType;

--- a/middleware/featureFlags/index.js
+++ b/middleware/featureFlags/index.js
@@ -1,7 +1,4 @@
-import SEARCH_TYPES, {
-    DEFAULT_SEARCH_TYPE,
-    parseSearchType
-} from '../../api/search/constants/searchTypes.js';
+import { DEFAULT_SEARCH_TYPE, resolveSearchType } from '../../api/search/constants/searchTypes.js';
 
 export const FEATURE_FLAG_DEFAULTS = Object.freeze({
     align: true, // toggle alignment of image highlighting to prevent or show overlapping
@@ -97,15 +94,9 @@ export default function featureFlags(req, res, next) {
                     flags[flagName] = queryFlagValue;
                 }
             } else if (flagName === 'type' && req.query?.type !== undefined) {
-                const { value, invalidValue } = parseSearchType(req.query.type);
-                if (typeof value === 'string') {
-                    flags[flagName] = value;
-                } else {
-                    const error = new Error(
-                        `Invalid search type: ${invalidValue || '(empty)'}. Allowed values: ${Object.values(SEARCH_TYPES).join(', ')}`
-                    );
-                    error.status = 400;
-                    return next(error);
+                const searchType = resolveSearchType(req.query.type, req.session);
+                if (typeof searchType === 'string') {
+                    flags[flagName] = searchType;
                 }
             } else {
                 const queryFlagValue = parseEnumFlagValue(req.query?.[flagName]);

--- a/middleware/featureFlags/index.js
+++ b/middleware/featureFlags/index.js
@@ -62,12 +62,25 @@ export function parseEnumFlagValue(value, allowedValues) {
  */
 export function getFeatureFlagValue(session, flagName) {
     const sessionFlagValue = session?.featureFlags?.[flagName];
+    const defaultValue = FEATURE_FLAG_DEFAULTS[flagName];
 
-    if (typeof sessionFlagValue === 'boolean' || typeof sessionFlagValue === 'string') {
-        return sessionFlagValue;
+    // Validate the session value matches the expected type for this flag.
+    // Boolean flags like 'align' should only accept booleans; string flags like 'type'
+    // should only accept strings. Stale/corrupt sessions with mismatched types fall back
+    // to the default.
+    if (typeof defaultValue === 'boolean') {
+        // align flag expects a boolean
+        if (typeof sessionFlagValue === 'boolean') {
+            return sessionFlagValue;
+        }
+    } else if (typeof defaultValue === 'string') {
+        // type flag expects a string
+        if (typeof sessionFlagValue === 'string') {
+            return sessionFlagValue;
+        }
     }
 
-    return FEATURE_FLAG_DEFAULTS[flagName];
+    return defaultValue;
 }
 
 /**

--- a/middleware/featureFlags/index.js
+++ b/middleware/featureFlags/index.js
@@ -1,10 +1,8 @@
 export const FEATURE_FLAG_DEFAULTS = Object.freeze({
     align: true, // toggle alignment of image highlighting to prevent or show overlapping
-    type: 'keyword' // search type: 'keyword', 'semantic', or 'hybrid'
-});
-
-export const FEATURE_FLAG_ENUM_OPTIONS = Object.freeze({
-    type: Object.freeze(['keyword', 'semantic', 'hybrid'])
+    keyword: true, // enable lexical (BM25) keyword matching
+    semantic: false, // enable neural (vector) semantic matching
+    dates: true // enable date extraction and variant expansion in lexical matching
 });
 
 /**
@@ -35,6 +33,7 @@ export function parseFeatureFlagValue(value) {
 /**
  * Parses a query-string enum feature flag value against a set of allowed values.
  *
+ * @deprecated No longer used — all flags are booleans. Retained for potential external use.
  * @param {unknown} value - Raw query-string value.
  * @param {readonly string[]} allowedValues - Valid values for this flag.
  * @returns {string | undefined} Matched value when valid, otherwise undefined.
@@ -54,18 +53,11 @@ export function parseEnumFlagValue(value, allowedValues) {
  * Resolves a feature flag value from session state, with repo defaults.
  *
  * @param {import('express-session').Session | undefined} session - Request session object.
- * @param {'align' | 'type'} flagName - Supported feature flag name.
- * @returns {boolean | string} The active feature flag value.
+ * @param {'align' | 'keyword' | 'semantic' | 'dates'} flagName - Supported feature flag name.
+ * @returns {boolean} The active feature flag value.
  */
 export function getFeatureFlagValue(session, flagName) {
     const sessionFlagValue = session?.featureFlags?.[flagName];
-
-    if (flagName in FEATURE_FLAG_ENUM_OPTIONS) {
-        if (FEATURE_FLAG_ENUM_OPTIONS[flagName].includes(sessionFlagValue)) {
-            return sessionFlagValue;
-        }
-        return FEATURE_FLAG_DEFAULTS[flagName];
-    }
 
     if (typeof sessionFlagValue === 'boolean') {
         return sessionFlagValue;
@@ -76,6 +68,9 @@ export function getFeatureFlagValue(session, flagName) {
 
 /**
  * Persists supported feature flags from query-string params into the session.
+ *
+ * Recognised query-string values: `on` (true) and `off` (false).
+ * Flags: `keyword`, `semantic`, `dates`, `align`.
  *
  * @param {import('express').Request} req - Express request object.
  * @param {import('express').Response} res - Express response object.
@@ -88,19 +83,9 @@ export default function featureFlags(req, res, next) {
         for (const flagName of Object.keys(FEATURE_FLAG_DEFAULTS)) {
             flags[flagName] = getFeatureFlagValue(req.session, flagName);
 
-            if (flagName in FEATURE_FLAG_ENUM_OPTIONS) {
-                const queryFlagValue = parseEnumFlagValue(
-                    req.query?.[flagName],
-                    FEATURE_FLAG_ENUM_OPTIONS[flagName]
-                );
-                if (queryFlagValue !== undefined) {
-                    flags[flagName] = queryFlagValue;
-                }
-            } else {
-                const queryFlagValue = parseFeatureFlagValue(req.query?.[flagName]);
-                if (typeof queryFlagValue === 'boolean') {
-                    flags[flagName] = queryFlagValue;
-                }
+            const queryFlagValue = parseFeatureFlagValue(req.query?.[flagName]);
+            if (typeof queryFlagValue === 'boolean') {
+                flags[flagName] = queryFlagValue;
             }
         }
         req.session.featureFlags = flags;

--- a/middleware/featureFlags/index.test.js
+++ b/middleware/featureFlags/index.test.js
@@ -3,7 +3,9 @@ import { describe, it } from 'node:test';
 
 import featureFlags, {
     FEATURE_FLAG_DEFAULTS,
+    FEATURE_FLAG_ENUM_OPTIONS,
     getFeatureFlagValue,
+    parseEnumFlagValue,
     parseFeatureFlagValue
 } from './index.js';
 
@@ -27,7 +29,7 @@ describe('featureFlags middleware', () => {
         assert.deepEqual(res.locals.featureFlags, FEATURE_FLAG_DEFAULTS);
     });
 
-    it('updates hybrid flag from query string', () => {
+    it('ignores unknown boolean flags from query string', () => {
         const req = {
             query: { hybrid: 'on' },
             session: {}
@@ -38,8 +40,9 @@ describe('featureFlags middleware', () => {
 
         featureFlags(req, res, () => {});
 
-        assert.equal(req.session.featureFlags.hybrid, true);
+        assert.equal(req.session.featureFlags.hybrid, undefined);
         assert.equal(req.session.featureFlags.align, true);
+        assert.equal(req.session.featureFlags.type, 'keyword');
     });
 
     it('updates align flag from query string', () => {
@@ -54,7 +57,49 @@ describe('featureFlags middleware', () => {
         featureFlags(req, res, () => {});
 
         assert.equal(req.session.featureFlags.align, false);
-        assert.equal(req.session.featureFlags.hybrid, false);
+        assert.equal(req.session.featureFlags.type, 'keyword');
+    });
+
+    it('updates type flag from query string', () => {
+        const req = {
+            query: { type: 'semantic' },
+            session: {}
+        };
+        const res = {
+            locals: {}
+        };
+
+        featureFlags(req, res, () => {});
+
+        assert.equal(req.session.featureFlags.type, 'semantic');
+    });
+
+    it('accepts all valid type enum values from query string', () => {
+        for (const typeValue of FEATURE_FLAG_ENUM_OPTIONS.type) {
+            const req = {
+                query: { type: typeValue },
+                session: {}
+            };
+            const res = { locals: {} };
+
+            featureFlags(req, res, () => {});
+
+            assert.equal(req.session.featureFlags.type, typeValue);
+        }
+    });
+
+    it('ignores invalid type flag values from query string', () => {
+        const req = {
+            query: { type: 'invalid' },
+            session: {}
+        };
+        const res = {
+            locals: {}
+        };
+
+        featureFlags(req, res, () => {});
+
+        assert.equal(req.session.featureFlags.type, 'keyword');
     });
 
     it('preserves existing feature flag values when the query string is absent', () => {
@@ -63,7 +108,7 @@ describe('featureFlags middleware', () => {
             session: {
                 featureFlags: {
                     align: false,
-                    hybrid: true
+                    type: 'hybrid'
                 }
             }
         };
@@ -75,7 +120,7 @@ describe('featureFlags middleware', () => {
 
         assert.deepEqual(req.session.featureFlags, {
             align: false,
-            hybrid: true
+            type: 'hybrid'
         });
     });
 
@@ -94,6 +139,27 @@ describe('featureFlags middleware', () => {
     });
 });
 
+describe('parseEnumFlagValue', () => {
+    it('returns the value when it is in the allowed set', () => {
+        assert.equal(parseEnumFlagValue('keyword', FEATURE_FLAG_ENUM_OPTIONS.type), 'keyword');
+        assert.equal(parseEnumFlagValue('semantic', FEATURE_FLAG_ENUM_OPTIONS.type), 'semantic');
+        assert.equal(parseEnumFlagValue('hybrid', FEATURE_FLAG_ENUM_OPTIONS.type), 'hybrid');
+    });
+
+    it('accepts the last element when given an array', () => {
+        assert.equal(
+            parseEnumFlagValue(['keyword', 'semantic'], FEATURE_FLAG_ENUM_OPTIONS.type),
+            'semantic'
+        );
+    });
+
+    it('returns undefined for values not in the allowed set', () => {
+        assert.equal(parseEnumFlagValue('all', FEATURE_FLAG_ENUM_OPTIONS.type), undefined);
+        assert.equal(parseEnumFlagValue('', FEATURE_FLAG_ENUM_OPTIONS.type), undefined);
+        assert.equal(parseEnumFlagValue(undefined, FEATURE_FLAG_ENUM_OPTIONS.type), undefined);
+    });
+});
+
 describe('parseFeatureFlagValue', () => {
     it('parses supported on and off values', () => {
         assert.equal(parseFeatureFlagValue('on'), true);
@@ -109,12 +175,25 @@ describe('parseFeatureFlagValue', () => {
 
 describe('getFeatureFlagValue', () => {
     it('returns the session value when present', () => {
-        assert.equal(getFeatureFlagValue({ featureFlags: { hybrid: true } }, 'hybrid'), true);
         assert.equal(getFeatureFlagValue({ featureFlags: { align: false } }, 'align'), false);
     });
 
     it('falls back to defaults when the session value is missing', () => {
-        assert.equal(getFeatureFlagValue({}, 'hybrid'), false);
         assert.equal(getFeatureFlagValue({}, 'align'), true);
+    });
+
+    it('returns the session value for enum flags when valid', () => {
+        assert.equal(
+            getFeatureFlagValue({ featureFlags: { type: 'semantic' } }, 'type'),
+            'semantic'
+        );
+        assert.equal(getFeatureFlagValue({ featureFlags: { type: 'hybrid' } }, 'type'), 'hybrid');
+        assert.equal(getFeatureFlagValue({ featureFlags: { type: 'keyword' } }, 'type'), 'keyword');
+    });
+
+    it('falls back to the default for enum flags when the session value is missing or invalid', () => {
+        assert.equal(getFeatureFlagValue({}, 'type'), 'keyword');
+        assert.equal(getFeatureFlagValue({ featureFlags: { type: 'invalid' } }, 'type'), 'keyword');
+        assert.equal(getFeatureFlagValue({ featureFlags: { type: 123 } }, 'type'), 'keyword');
     });
 });

--- a/middleware/featureFlags/index.test.js
+++ b/middleware/featureFlags/index.test.js
@@ -178,54 +178,54 @@ describe('featureFlags middleware', () => {
 });
 
 describe('parseSearchType', () => {
-    it('resolves supported slugs directly', () => {
+    it('resolves supported values directly', () => {
         assert.deepEqual(parseSearchType('keyword'), {
-            slug: 'keyword',
+            searchType: 'keyword',
             invalidValue: undefined
         });
         assert.deepEqual(parseSearchType('semantic'), {
-            slug: 'semantic',
+            searchType: 'semantic',
             invalidValue: undefined
         });
         assert.deepEqual(parseSearchType('hybrid'), {
-            slug: 'hybrid',
+            searchType: 'hybrid',
             invalidValue: undefined
         });
     });
 
     it('is case-insensitive and trims whitespace', () => {
         assert.deepEqual(parseSearchType('  KEYWORD-DATES  '), {
-            slug: 'keyword-dates',
+            searchType: 'keyword-dates',
             invalidValue: undefined
         });
         assert.deepEqual(parseSearchType('HyBrId-DaTeS'), {
-            slug: 'hybrid-dates',
+            searchType: 'hybrid-dates',
             invalidValue: undefined
         });
     });
 
     it('accepts array input and uses the last value', () => {
         assert.deepEqual(parseSearchType(['keyword', 'semantic']), {
-            slug: 'semantic',
+            searchType: 'semantic',
             invalidValue: undefined
         });
     });
 
-    it('returns invalid values for unsupported slugs', () => {
+    it('returns invalid values for unsupported values', () => {
         assert.deepEqual(parseSearchType('unknown'), {
-            slug: undefined,
+            searchType: undefined,
             invalidValue: 'unknown'
         });
         assert.deepEqual(parseSearchType('keyword,semantic'), {
-            slug: undefined,
+            searchType: undefined,
             invalidValue: 'keyword,semantic'
         });
     });
 
     it('returns empty output for absent or empty input', () => {
-        assert.deepEqual(parseSearchType(''), { slug: undefined, invalidValue: undefined });
+        assert.deepEqual(parseSearchType(''), { searchType: undefined, invalidValue: undefined });
         assert.deepEqual(parseSearchType(undefined), {
-            slug: undefined,
+            searchType: undefined,
             invalidValue: undefined
         });
     });

--- a/middleware/featureFlags/index.test.js
+++ b/middleware/featureFlags/index.test.js
@@ -27,16 +27,14 @@ describe('featureFlags middleware', () => {
         assert.deepEqual(res.locals.featureFlags, FEATURE_FLAG_DEFAULTS);
     });
 
-    it('defaults: align=true, keyword=true, semantic=false, dates=true', () => {
+    it('defaults: align=true, type=keyword-dates', () => {
         const req = { query: {}, session: {} };
         const res = { locals: {} };
 
         featureFlags(req, res, () => {});
 
         assert.equal(req.session.featureFlags.align, true);
-        assert.equal(req.session.featureFlags.keyword, true);
-        assert.equal(req.session.featureFlags.semantic, false);
-        assert.equal(req.session.featureFlags.dates, true);
+        assert.equal(req.session.featureFlags.type, 'keyword-dates');
     });
 
     it('ignores unknown flags from query string', () => {
@@ -48,9 +46,9 @@ describe('featureFlags middleware', () => {
 
         featureFlags(req, res, () => {});
 
-        assert.equal(req.session.featureFlags.type, undefined);
+        assert.equal(req.session.featureFlags.type, 'hybrid');
         assert.equal(req.session.featureFlags.unknown, undefined);
-        assert.equal(req.session.featureFlags.keyword, true);
+        assert.equal(req.session.featureFlags.align, true);
     });
 
     it('updates align flag from query string', () => {
@@ -62,53 +60,13 @@ describe('featureFlags middleware', () => {
         assert.equal(req.session.featureFlags.align, false);
     });
 
-    it('enables semantic flag from query string', () => {
-        const req = { query: { semantic: 'on' }, session: {} };
-        const res = { locals: {} };
-
-        featureFlags(req, res, () => {});
-
-        assert.equal(req.session.featureFlags.semantic, true);
-    });
-
-    it('disables keyword flag from query string', () => {
-        const req = { query: { keyword: 'off' }, session: {} };
-        const res = { locals: {} };
-
-        featureFlags(req, res, () => {});
-
-        assert.equal(req.session.featureFlags.keyword, false);
-    });
-
-    it('disables dates flag from query string', () => {
-        const req = { query: { dates: 'off' }, session: {} };
-        const res = { locals: {} };
-
-        featureFlags(req, res, () => {});
-
-        assert.equal(req.session.featureFlags.dates, false);
-    });
-
-    it('enables all three search flags together (hybrid + dates)', () => {
-        const req = { query: { keyword: 'on', semantic: 'on', dates: 'on' }, session: {} };
-        const res = { locals: {} };
-
-        featureFlags(req, res, () => {});
-
-        assert.equal(req.session.featureFlags.keyword, true);
-        assert.equal(req.session.featureFlags.semantic, true);
-        assert.equal(req.session.featureFlags.dates, true);
-    });
-
     it('preserves existing feature flag values when the query string is absent', () => {
         const req = {
             query: {},
             session: {
                 featureFlags: {
                     align: false,
-                    keyword: true,
-                    semantic: true,
-                    dates: false
+                    type: 'hybrid'
                 }
             }
         };
@@ -117,14 +75,12 @@ describe('featureFlags middleware', () => {
         featureFlags(req, res, () => {});
 
         assert.equal(req.session.featureFlags.align, false);
-        assert.equal(req.session.featureFlags.keyword, true);
-        assert.equal(req.session.featureFlags.semantic, true);
-        assert.equal(req.session.featureFlags.dates, false);
+        assert.equal(req.session.featureFlags.type, 'hybrid');
     });
 
     it('ignores invalid query-string values', () => {
         const req = {
-            query: { keyword: 'maybe', semantic: 'sometimes' },
+            query: { keyword: 'maybe', align: 'not-a-valid-type' },
             session: {}
         };
         const res = { locals: {} };
@@ -151,21 +107,11 @@ describe('parseFeatureFlagValue', () => {
 describe('getFeatureFlagValue', () => {
     it('returns the session value when present', () => {
         assert.equal(getFeatureFlagValue({ featureFlags: { align: false } }, 'align'), false);
-        assert.equal(getFeatureFlagValue({ featureFlags: { keyword: false } }, 'keyword'), false);
-        assert.equal(getFeatureFlagValue({ featureFlags: { semantic: true } }, 'semantic'), true);
-        assert.equal(getFeatureFlagValue({ featureFlags: { dates: false } }, 'dates'), false);
+        assert.equal(getFeatureFlagValue({ featureFlags: { type: 'hybrid' } }, 'type'), 'hybrid');
     });
 
     it('falls back to defaults when the session value is missing', () => {
         assert.equal(getFeatureFlagValue({}, 'align'), true);
-        assert.equal(getFeatureFlagValue({}, 'keyword'), true);
-        assert.equal(getFeatureFlagValue({}, 'semantic'), false);
-        assert.equal(getFeatureFlagValue({}, 'dates'), true);
-    });
-
-    it('falls back to the default for flags when the session value is not a boolean', () => {
-        assert.equal(getFeatureFlagValue({ featureFlags: { keyword: 'hybrid' } }, 'keyword'), true);
-        assert.equal(getFeatureFlagValue({ featureFlags: { semantic: 123 } }, 'semantic'), false);
-        assert.equal(getFeatureFlagValue({ featureFlags: { dates: null } }, 'dates'), true);
+        assert.equal(getFeatureFlagValue({}, 'type'), 'keyword-dates');
     });
 });

--- a/middleware/featureFlags/index.test.js
+++ b/middleware/featureFlags/index.test.js
@@ -181,6 +181,30 @@ describe('featureFlags middleware', () => {
         assert.equal(req.session.featureFlags.align, false);
         assert.equal(req.session.featureFlags.type, 'hybrid');
     });
+
+    it('normalises repeated type parameters to the last valid element', () => {
+        const req = {
+            query: { type: ['invalid', 'keyword'] },
+            session: {}
+        };
+        const res = { locals: {} };
+
+        featureFlags(req, res, () => {});
+
+        assert.equal(req.session.featureFlags.type, 'keyword');
+    });
+
+    it('falls back to session/default when repeated type has invalid final element', () => {
+        const req = {
+            query: { type: ['keyword', 'not-a-type'] },
+            session: { featureFlags: { type: 'semantic' } }
+        };
+        const res = { locals: {} };
+
+        featureFlags(req, res, () => {});
+
+        assert.equal(req.session.featureFlags.type, 'semantic');
+    });
 });
 
 describe('parseEnumFlagValue', () => {

--- a/middleware/featureFlags/index.test.js
+++ b/middleware/featureFlags/index.test.js
@@ -174,54 +174,54 @@ describe('featureFlags middleware', () => {
 });
 
 describe('parseSearchType', () => {
-    it('resolves supported values directly', () => {
+    it('resolves supported type values directly', () => {
         assert.deepEqual(parseSearchType('keyword'), {
-            searchType: 'keyword',
+            value: 'keyword',
             invalidValue: undefined
         });
         assert.deepEqual(parseSearchType('semantic'), {
-            searchType: 'semantic',
+            value: 'semantic',
             invalidValue: undefined
         });
         assert.deepEqual(parseSearchType('hybrid'), {
-            searchType: 'hybrid',
+            value: 'hybrid',
             invalidValue: undefined
         });
     });
 
     it('is case-insensitive and trims whitespace', () => {
         assert.deepEqual(parseSearchType('  KEYWORD-DATES  '), {
-            searchType: 'keyword-dates',
+            value: 'keyword-dates',
             invalidValue: undefined
         });
         assert.deepEqual(parseSearchType('HyBrId-DaTeS'), {
-            searchType: 'hybrid-dates',
+            value: 'hybrid-dates',
             invalidValue: undefined
         });
     });
 
     it('accepts array input and uses the last value', () => {
         assert.deepEqual(parseSearchType(['keyword', 'semantic']), {
-            searchType: 'semantic',
+            value: 'semantic',
             invalidValue: undefined
         });
     });
 
-    it('returns invalid values for unsupported values', () => {
+    it('returns invalid value for unrecognised type values', () => {
         assert.deepEqual(parseSearchType('unknown'), {
-            searchType: undefined,
+            value: undefined,
             invalidValue: 'unknown'
         });
         assert.deepEqual(parseSearchType('keyword,semantic'), {
-            searchType: undefined,
+            value: undefined,
             invalidValue: 'keyword,semantic'
         });
     });
 
     it('returns empty output for absent or empty input', () => {
-        assert.deepEqual(parseSearchType(''), { searchType: undefined, invalidValue: undefined });
+        assert.deepEqual(parseSearchType(''), { value: undefined, invalidValue: undefined });
         assert.deepEqual(parseSearchType(undefined), {
-            searchType: undefined,
+            value: undefined,
             invalidValue: undefined
         });
     });

--- a/middleware/featureFlags/index.test.js
+++ b/middleware/featureFlags/index.test.js
@@ -292,4 +292,42 @@ describe('getFeatureFlagValue', () => {
         assert.equal(getFeatureFlagValue({}, 'align'), true);
         assert.equal(getFeatureFlagValue({}, 'type'), DEFAULT_SEARCH_TYPE);
     });
+
+    it('rejects mismatched types and falls back to defaults', () => {
+        // String value for boolean flag (align) should be rejected
+        assert.equal(
+            getFeatureFlagValue({ featureFlags: { align: 'false' } }, 'align'),
+            true,
+            'String value for align should fall back to default (true)'
+        );
+        assert.equal(
+            getFeatureFlagValue({ featureFlags: { align: 'off' } }, 'align'),
+            true,
+            'String "off" for align should fall back to default (true)'
+        );
+
+        // Boolean value for string flag (type) should be rejected
+        assert.equal(
+            getFeatureFlagValue({ featureFlags: { type: false } }, 'type'),
+            DEFAULT_SEARCH_TYPE,
+            'Boolean value for type should fall back to default'
+        );
+        assert.equal(
+            getFeatureFlagValue({ featureFlags: { type: true } }, 'type'),
+            DEFAULT_SEARCH_TYPE,
+            'Boolean true for type should fall back to default'
+        );
+
+        // Other invalid types should also be rejected
+        assert.equal(
+            getFeatureFlagValue({ featureFlags: { align: 42 } }, 'align'),
+            true,
+            'Number value for align should fall back to default'
+        );
+        assert.equal(
+            getFeatureFlagValue({ featureFlags: { type: 42 } }, 'type'),
+            DEFAULT_SEARCH_TYPE,
+            'Number value for type should fall back to default'
+        );
+    });
 });

--- a/middleware/featureFlags/index.test.js
+++ b/middleware/featureFlags/index.test.js
@@ -1,9 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import {
-    DEFAULT_SEARCH_TYPE,
-    parseSearchTypeTokens
-} from '../../api/search/constants/searchTypes.js';
+import { DEFAULT_SEARCH_TYPE, parseSearchType } from '../../api/search/constants/searchTypes.js';
 import featureFlags, {
     FEATURE_FLAG_DEFAULTS,
     getFeatureFlagValue,
@@ -42,7 +39,7 @@ describe('featureFlags middleware', () => {
 
     it('ignores unknown flags from query string', () => {
         const req = {
-            query: { type: 'keyword,semantic', unknown: 'on' },
+            query: { type: 'hybrid', unknown: 'on' },
             session: {}
         };
         const res = { locals: {} };
@@ -93,8 +90,8 @@ describe('featureFlags middleware', () => {
         assert.deepEqual(req.session.featureFlags, FEATURE_FLAG_DEFAULTS);
     });
 
-    it('resolves type from comma-delimited tokens (keyword,semantic,dates)', () => {
-        const req = { query: { type: 'keyword,semantic,dates' }, session: {} };
+    it('accepts supported search type slugs directly', () => {
+        const req = { query: { type: 'hybrid-dates' }, session: {} };
         const res = { locals: {} };
 
         featureFlags(req, res, () => {});
@@ -102,8 +99,8 @@ describe('featureFlags middleware', () => {
         assert.equal(req.session.featureFlags.type, 'hybrid-dates');
     });
 
-    it('resolves type from comma-delimited tokens in any order (dates,keyword)', () => {
-        const req = { query: { type: 'dates,keyword' }, session: {} };
+    it('normalises supported search type slugs', () => {
+        const req = { query: { type: ' KEYWORD-DATES ' }, session: {} };
         const res = { locals: {} };
 
         featureFlags(req, res, () => {});
@@ -111,9 +108,9 @@ describe('featureFlags middleware', () => {
         assert.equal(req.session.featureFlags.type, 'keyword-dates');
     });
 
-    it('calls next with a 400 error when type contains unrecognised tokens', () => {
+    it('calls next with a 400 error when type is not recognised', () => {
         const req = {
-            query: { type: 'unknown,foo' },
+            query: { type: 'unknown' },
             session: { featureFlags: { align: true, type: DEFAULT_SEARCH_TYPE } }
         };
         const res = { locals: {} };
@@ -125,12 +122,12 @@ describe('featureFlags middleware', () => {
 
         assert.ok(errorPassed instanceof Error);
         assert.equal(errorPassed.status, 400);
-        assert.match(errorPassed.message, /unknown, foo/);
+        assert.match(errorPassed.message, /unknown/);
     });
 
-    it('calls next with a 400 when type mixes valid and invalid tokens', () => {
+    it('calls next with a 400 when type uses the old token-combination format', () => {
         const req = {
-            query: { type: 'hybrid,badtoken' },
+            query: { type: 'keyword,semantic,dates' },
             session: {}
         };
         const res = { locals: {} };
@@ -142,12 +139,12 @@ describe('featureFlags middleware', () => {
 
         assert.ok(errorPassed instanceof Error);
         assert.equal(errorPassed.status, 400);
-        assert.match(errorPassed.message, /badtoken/);
+        assert.match(errorPassed.message, /keyword,semantic,dates/);
     });
 
-    it('calls next with a 400 when type tokens are all valid but do not resolve to a known search mode', () => {
+    it('calls next with a 400 when type is empty', () => {
         const req = {
-            query: { type: 'semantic,dates' },
+            query: { type: '   ' },
             session: { featureFlags: { align: true, type: 'hybrid-dates' } }
         };
         const res = { locals: {} };
@@ -159,10 +156,10 @@ describe('featureFlags middleware', () => {
 
         assert.ok(errorPassed instanceof Error);
         assert.equal(errorPassed.status, 400);
-        assert.match(errorPassed.message, /do not resolve to a known search mode/);
+        assert.match(errorPassed.message, /\(empty\)/);
     });
 
-    it('does not fall through to the previous session value when type is an unresolvable combination', () => {
+    it('does not fall through to the previous session value when type is invalid', () => {
         const req = {
             query: { type: 'semantic,dates' },
             session: { featureFlags: { align: true, type: 'hybrid-dates' } }
@@ -180,111 +177,57 @@ describe('featureFlags middleware', () => {
     });
 });
 
-describe('parseSearchTypeTokens', () => {
-    it('resolves single tokens', () => {
-        assert.deepEqual(parseSearchTypeTokens('keyword'), { slug: 'keyword', unknownTokens: [] });
-        assert.deepEqual(parseSearchTypeTokens('semantic'), {
+describe('parseSearchType', () => {
+    it('resolves supported slugs directly', () => {
+        assert.deepEqual(parseSearchType('keyword'), {
+            slug: 'keyword',
+            invalidValue: undefined
+        });
+        assert.deepEqual(parseSearchType('semantic'), {
             slug: 'semantic',
-            unknownTokens: []
+            invalidValue: undefined
         });
-        assert.deepEqual(parseSearchTypeTokens('hybrid'), { slug: undefined, unknownTokens: [] });
-    });
-
-    it('resolves two-token combinations regardless of order', () => {
-        assert.deepEqual(parseSearchTypeTokens('keyword,dates'), {
-            slug: 'keyword-dates',
-            unknownTokens: []
-        });
-        assert.deepEqual(parseSearchTypeTokens('dates,keyword'), {
-            slug: 'keyword-dates',
-            unknownTokens: []
-        });
-        assert.deepEqual(parseSearchTypeTokens('keyword,semantic'), {
+        assert.deepEqual(parseSearchType('hybrid'), {
             slug: 'hybrid',
-            unknownTokens: []
-        });
-        assert.deepEqual(parseSearchTypeTokens('semantic,keyword'), {
-            slug: 'hybrid',
-            unknownTokens: []
-        });
-    });
-
-    it('keyword+semantic+dates resolves to hybrid-dates', () => {
-        assert.deepEqual(parseSearchTypeTokens('keyword,semantic,dates'), {
-            slug: 'hybrid-dates',
-            unknownTokens: []
-        });
-        assert.deepEqual(parseSearchTypeTokens('keyword,semantic,dates'), {
-            slug: 'hybrid-dates',
-            unknownTokens: []
-        });
-    });
-
-    it('dates paired with semantic alone does not resolve (keyword required for hybrid)', () => {
-        assert.deepEqual(parseSearchTypeTokens('semantic,dates'), {
-            slug: undefined,
-            unknownTokens: []
-        });
-    });
-
-    it('collects unrecognised tokens and still resolves from valid remainder', () => {
-        assert.deepEqual(parseSearchTypeTokens('keyword,unknown,dates'), {
-            slug: 'keyword-dates',
-            unknownTokens: ['unknown']
-        });
-        assert.deepEqual(parseSearchTypeTokens('unknown,keyword,semantic'), {
-            slug: 'hybrid',
-            unknownTokens: ['unknown']
+            invalidValue: undefined
         });
     });
 
     it('is case-insensitive and trims whitespace', () => {
-        assert.deepEqual(parseSearchTypeTokens('Keyword, Semantic, Dates'), {
-            slug: 'hybrid-dates',
-            unknownTokens: []
-        });
-        assert.deepEqual(parseSearchTypeTokens('  KEYWORD , DATES  '), {
+        assert.deepEqual(parseSearchType('  KEYWORD-DATES  '), {
             slug: 'keyword-dates',
-            unknownTokens: []
+            invalidValue: undefined
+        });
+        assert.deepEqual(parseSearchType('HyBrId-DaTeS'), {
+            slug: 'hybrid-dates',
+            invalidValue: undefined
         });
     });
 
     it('accepts array input and uses the last value', () => {
-        assert.deepEqual(parseSearchTypeTokens(['keyword', 'keyword,semantic,dates']), {
-            slug: 'hybrid-dates',
-            unknownTokens: []
+        assert.deepEqual(parseSearchType(['keyword', 'semantic']), {
+            slug: 'semantic',
+            invalidValue: undefined
         });
     });
 
-    it('returns undefined slug with unknownTokens for direct hyphenated slugs', () => {
-        assert.deepEqual(parseSearchTypeTokens('hybrid-dates'), {
+    it('returns invalid values for unsupported slugs', () => {
+        assert.deepEqual(parseSearchType('unknown'), {
             slug: undefined,
-            unknownTokens: ['hybrid-dates']
+            invalidValue: 'unknown'
         });
-        assert.deepEqual(parseSearchTypeTokens('keyword-dates'), {
+        assert.deepEqual(parseSearchType('keyword,semantic'), {
             slug: undefined,
-            unknownTokens: ['keyword-dates']
-        });
-    });
-
-    it('returns undefined slug with unknownTokens when all tokens are unrecognised', () => {
-        assert.deepEqual(parseSearchTypeTokens('unknown'), {
-            slug: undefined,
-            unknownTokens: ['unknown']
-        });
-        assert.deepEqual(parseSearchTypeTokens('unknown,foo'), {
-            slug: undefined,
-            unknownTokens: ['unknown', 'foo']
+            invalidValue: 'keyword,semantic'
         });
     });
 
-    it('returns undefined slug with empty unknownTokens for absent or empty input', () => {
-        assert.deepEqual(parseSearchTypeTokens(''), { slug: undefined, unknownTokens: [] });
-        assert.deepEqual(parseSearchTypeTokens(undefined), { slug: undefined, unknownTokens: [] });
-    });
-
-    it('returns undefined slug with empty unknownTokens for dates alone', () => {
-        assert.deepEqual(parseSearchTypeTokens('dates'), { slug: undefined, unknownTokens: [] });
+    it('returns empty output for absent or empty input', () => {
+        assert.deepEqual(parseSearchType(''), { slug: undefined, invalidValue: undefined });
+        assert.deepEqual(parseSearchType(undefined), {
+            slug: undefined,
+            invalidValue: undefined
+        });
     });
 });
 

--- a/middleware/featureFlags/index.test.js
+++ b/middleware/featureFlags/index.test.js
@@ -90,7 +90,7 @@ describe('featureFlags middleware', () => {
         assert.deepEqual(req.session.featureFlags, FEATURE_FLAG_DEFAULTS);
     });
 
-    it('accepts supported search type slugs directly', () => {
+    it('accepts supported search type values directly', () => {
         const req = { query: { type: 'hybrid-dates' }, session: {} };
         const res = { locals: {} };
 
@@ -99,7 +99,7 @@ describe('featureFlags middleware', () => {
         assert.equal(req.session.featureFlags.type, 'hybrid-dates');
     });
 
-    it('normalises supported search type slugs', () => {
+    it('normalises supported search type values', () => {
         const req = { query: { type: ' KEYWORD-DATES ' }, session: {} };
         const res = { locals: {} };
 

--- a/middleware/featureFlags/index.test.js
+++ b/middleware/featureFlags/index.test.js
@@ -108,72 +108,68 @@ describe('featureFlags middleware', () => {
         assert.equal(req.session.featureFlags.type, 'keyword-dates');
     });
 
-    it('calls next with a 400 error when type is not recognised', () => {
+    it('keeps session/default type when type is not recognised', () => {
         const req = {
             query: { type: 'unknown' },
             session: { featureFlags: { align: true, type: DEFAULT_SEARCH_TYPE } }
         };
         const res = { locals: {} };
-        let errorPassed;
+        let errorPassed = null;
 
         featureFlags(req, res, (err) => {
             errorPassed = err;
         });
 
-        assert.ok(errorPassed instanceof Error);
-        assert.equal(errorPassed.status, 400);
-        assert.match(errorPassed.message, /unknown/);
+        assert.equal(errorPassed, undefined);
+        assert.equal(req.session.featureFlags.type, DEFAULT_SEARCH_TYPE);
     });
 
-    it('calls next with a 400 when type uses the old token-combination format', () => {
+    it('keeps existing session type when type uses token-combination format', () => {
         const req = {
             query: { type: 'keyword,semantic,dates' },
-            session: {}
+            session: { featureFlags: { align: true, type: 'keyword' } }
         };
         const res = { locals: {} };
-        let errorPassed;
+        let errorPassed = null;
 
         featureFlags(req, res, (err) => {
             errorPassed = err;
         });
 
-        assert.ok(errorPassed instanceof Error);
-        assert.equal(errorPassed.status, 400);
-        assert.match(errorPassed.message, /keyword,semantic,dates/);
+        assert.equal(errorPassed, undefined);
+        assert.equal(req.session.featureFlags.type, 'keyword');
     });
 
-    it('calls next with a 400 when type is empty', () => {
+    it('keeps existing session type when type is empty', () => {
         const req = {
             query: { type: '   ' },
             session: { featureFlags: { align: true, type: 'hybrid-dates' } }
         };
         const res = { locals: {} };
-        let errorPassed;
+        let errorPassed = null;
 
         featureFlags(req, res, (err) => {
             errorPassed = err;
         });
 
-        assert.ok(errorPassed instanceof Error);
-        assert.equal(errorPassed.status, 400);
-        assert.match(errorPassed.message, /\(empty\)/);
+        assert.equal(errorPassed, undefined);
+        assert.equal(req.session.featureFlags.type, 'hybrid-dates');
     });
 
-    it('does not fall through to the previous session value when type is invalid', () => {
+    it('falls back to the previous session value when type is invalid', () => {
         const req = {
             query: { type: 'semantic,dates' },
             session: { featureFlags: { align: true, type: 'hybrid-dates' } }
         };
         const res = { locals: {} };
-        let errorPassed;
+        let errorPassed = null;
 
         featureFlags(req, res, (err) => {
             errorPassed = err;
         });
 
-        // session must NOT be silently updated to the stale 'hybrid-dates' value
-        assert.ok(errorPassed instanceof Error);
-        assert.equal(req.session.featureFlags?.type, 'hybrid-dates'); // unchanged
+        assert.equal(errorPassed, undefined);
+        assert.equal(req.session.featureFlags?.type, 'hybrid-dates');
     });
 });
 

--- a/middleware/featureFlags/index.test.js
+++ b/middleware/featureFlags/index.test.js
@@ -205,6 +205,34 @@ describe('featureFlags middleware', () => {
 
         assert.equal(req.session.featureFlags.type, 'semantic');
     });
+
+    it('corrects stale/invalid session type to DEFAULT_SEARCH_TYPE when no query param provided', () => {
+        const req = {
+            query: {},
+            session: { featureFlags: { type: 'old-invalid-type' } }
+        };
+        const res = { locals: {} };
+
+        featureFlags(req, res, () => {});
+
+        // Invalid session type should be corrected to the default
+        assert.equal(req.session.featureFlags.type, DEFAULT_SEARCH_TYPE);
+        assert.equal(res.locals.featureFlags.type, DEFAULT_SEARCH_TYPE);
+    });
+
+    it('overrides stale session type with valid query param', () => {
+        const req = {
+            query: { type: 'hybrid' },
+            session: { featureFlags: { type: 'old-invalid-type' } }
+        };
+        const res = { locals: {} };
+
+        featureFlags(req, res, () => {});
+
+        // Valid query param should override stale session type
+        assert.equal(req.session.featureFlags.type, 'hybrid');
+        assert.equal(res.locals.featureFlags.type, 'hybrid');
+    });
 });
 
 describe('parseEnumFlagValue', () => {

--- a/middleware/featureFlags/index.test.js
+++ b/middleware/featureFlags/index.test.js
@@ -108,68 +108,91 @@ describe('featureFlags middleware', () => {
         assert.equal(req.session.featureFlags.type, 'keyword-dates');
     });
 
-    it('keeps session/default type when type is not recognised', () => {
+    it('calls next with a 400 error when type is not recognised', () => {
         const req = {
             query: { type: 'unknown' },
             session: { featureFlags: { align: true, type: DEFAULT_SEARCH_TYPE } }
         };
         const res = { locals: {} };
-        let errorPassed = null;
+        let errorPassed;
 
         featureFlags(req, res, (err) => {
             errorPassed = err;
         });
 
-        assert.equal(errorPassed, undefined);
-        assert.equal(req.session.featureFlags.type, DEFAULT_SEARCH_TYPE);
+        assert.ok(errorPassed instanceof Error);
+        assert.equal(errorPassed.status, 400);
+        assert.match(errorPassed.message, /unknown/);
     });
 
-    it('keeps existing session type when type uses token-combination format', () => {
+    it('error message lists all allowed type values', () => {
         const req = {
-            query: { type: 'keyword,semantic,dates' },
-            session: { featureFlags: { align: true, type: 'keyword' } }
+            query: { type: 'unknown' },
+            session: {}
         };
         const res = { locals: {} };
-        let errorPassed = null;
+        let errorPassed;
 
         featureFlags(req, res, (err) => {
             errorPassed = err;
         });
 
-        assert.equal(errorPassed, undefined);
-        assert.equal(req.session.featureFlags.type, 'keyword');
+        assert.ok(errorPassed instanceof Error);
+        assert.match(errorPassed.message, /hybrid-dates/);
+        assert.match(errorPassed.message, /keyword-dates/);
+        assert.match(errorPassed.message, /hybrid/);
+        assert.match(errorPassed.message, /keyword/);
+        assert.match(errorPassed.message, /semantic/);
     });
 
-    it('keeps existing session type when type is empty', () => {
+    it('calls next with a 400 when type uses the old token-combination format', () => {
+        const req = {
+            query: { type: 'keyword,semantic,dates' },
+            session: {}
+        };
+        const res = { locals: {} };
+        let errorPassed;
+
+        featureFlags(req, res, (err) => {
+            errorPassed = err;
+        });
+
+        assert.ok(errorPassed instanceof Error);
+        assert.equal(errorPassed.status, 400);
+        assert.match(errorPassed.message, /keyword,semantic,dates/);
+    });
+
+    it('calls next with a 400 when type is empty', () => {
         const req = {
             query: { type: '   ' },
             session: { featureFlags: { align: true, type: 'hybrid-dates' } }
         };
         const res = { locals: {} };
-        let errorPassed = null;
+        let errorPassed;
 
         featureFlags(req, res, (err) => {
             errorPassed = err;
         });
 
-        assert.equal(errorPassed, undefined);
-        assert.equal(req.session.featureFlags.type, 'hybrid-dates');
+        assert.ok(errorPassed instanceof Error);
+        assert.equal(errorPassed.status, 400);
+        assert.match(errorPassed.message, /\(empty\)/);
     });
 
-    it('falls back to the previous session value when type is invalid', () => {
+    it('does not fall through to the previous session value when type is invalid', () => {
         const req = {
             query: { type: 'semantic,dates' },
             session: { featureFlags: { align: true, type: 'hybrid-dates' } }
         };
         const res = { locals: {} };
-        let errorPassed = null;
+        let errorPassed;
 
         featureFlags(req, res, (err) => {
             errorPassed = err;
         });
 
-        assert.equal(errorPassed, undefined);
-        assert.equal(req.session.featureFlags?.type, 'hybrid-dates');
+        assert.ok(errorPassed instanceof Error);
+        assert.equal(req.session.featureFlags?.type, 'hybrid-dates'); // unchanged
     });
 });
 

--- a/middleware/featureFlags/index.test.js
+++ b/middleware/featureFlags/index.test.js
@@ -1,9 +1,10 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { DEFAULT_SEARCH_TYPE, parseSearchType } from '../../api/search/constants/searchTypes.js';
+import { DEFAULT_SEARCH_TYPE } from '../../api/search/constants/searchTypes.js';
 import featureFlags, {
     FEATURE_FLAG_DEFAULTS,
     getFeatureFlagValue,
+    parseEnumFlagValue,
     parseFeatureFlagValue
 } from './index.js';
 
@@ -108,145 +109,99 @@ describe('featureFlags middleware', () => {
         assert.equal(req.session.featureFlags.type, 'keyword-dates');
     });
 
-    it('calls next with a 400 error when type is not recognised', () => {
+    it('falls back to session type value when type query param is unrecognised', () => {
         const req = {
             query: { type: 'unknown' },
-            session: { featureFlags: { align: true, type: DEFAULT_SEARCH_TYPE } }
+            session: { featureFlags: { align: true, type: 'semantic' } }
         };
         const res = { locals: {} };
-        let errorPassed;
 
-        featureFlags(req, res, (err) => {
-            errorPassed = err;
-        });
+        featureFlags(req, res, () => {});
 
-        assert.ok(errorPassed instanceof Error);
-        assert.equal(errorPassed.status, 400);
-        assert.match(errorPassed.message, /unknown/);
+        assert.equal(req.session.featureFlags.type, 'semantic');
     });
 
-    it('error message lists all allowed type values', () => {
+    it('falls back to DEFAULT_SEARCH_TYPE when type is unrecognised and no session override exists', () => {
         const req = {
             query: { type: 'unknown' },
             session: {}
         };
         const res = { locals: {} };
-        let errorPassed;
 
-        featureFlags(req, res, (err) => {
-            errorPassed = err;
-        });
+        featureFlags(req, res, () => {});
 
-        assert.ok(errorPassed instanceof Error);
-        assert.match(errorPassed.message, /hybrid-dates/);
-        assert.match(errorPassed.message, /keyword-dates/);
-        assert.match(errorPassed.message, /hybrid/);
-        assert.match(errorPassed.message, /keyword/);
-        assert.match(errorPassed.message, /semantic/);
+        assert.equal(req.session.featureFlags.type, DEFAULT_SEARCH_TYPE);
     });
 
-    it('calls next with a 400 when type uses the old token-combination format', () => {
+    it('falls back to DEFAULT_SEARCH_TYPE when type uses an old comma-separated format', () => {
         const req = {
             query: { type: 'keyword,semantic,dates' },
             session: {}
         };
         const res = { locals: {} };
-        let errorPassed;
 
-        featureFlags(req, res, (err) => {
-            errorPassed = err;
-        });
+        featureFlags(req, res, () => {});
 
-        assert.ok(errorPassed instanceof Error);
-        assert.equal(errorPassed.status, 400);
-        assert.match(errorPassed.message, /keyword,semantic,dates/);
+        assert.equal(req.session.featureFlags.type, DEFAULT_SEARCH_TYPE);
     });
 
-    it('calls next with a 400 when type is empty', () => {
+    it('falls back to DEFAULT_SEARCH_TYPE when type is empty', () => {
         const req = {
             query: { type: '   ' },
-            session: { featureFlags: { align: true, type: 'hybrid-dates' } }
+            session: {}
         };
         const res = { locals: {} };
-        let errorPassed;
 
-        featureFlags(req, res, (err) => {
-            errorPassed = err;
-        });
+        featureFlags(req, res, () => {});
 
-        assert.ok(errorPassed instanceof Error);
-        assert.equal(errorPassed.status, 400);
-        assert.match(errorPassed.message, /\(empty\)/);
+        assert.equal(req.session.featureFlags.type, DEFAULT_SEARCH_TYPE);
     });
 
-    it('does not fall through to the previous session value when type is invalid', () => {
+    it('preserves existing session type value when type query param is absent', () => {
         const req = {
-            query: { type: 'semantic,dates' },
-            session: { featureFlags: { align: true, type: 'hybrid-dates' } }
+            query: {},
+            session: { featureFlags: { align: false, type: 'hybrid' } }
         };
         const res = { locals: {} };
-        let errorPassed;
 
-        featureFlags(req, res, (err) => {
-            errorPassed = err;
-        });
+        featureFlags(req, res, () => {});
 
-        assert.ok(errorPassed instanceof Error);
-        assert.equal(req.session.featureFlags?.type, 'hybrid-dates'); // unchanged
+        assert.equal(req.session.featureFlags.align, false);
+        assert.equal(req.session.featureFlags.type, 'hybrid');
     });
 });
 
-describe('parseSearchType', () => {
-    it('resolves supported type values directly', () => {
-        assert.deepEqual(parseSearchType('keyword'), {
-            value: 'keyword',
-            invalidValue: undefined
-        });
-        assert.deepEqual(parseSearchType('semantic'), {
-            value: 'semantic',
-            invalidValue: undefined
-        });
-        assert.deepEqual(parseSearchType('hybrid'), {
-            value: 'hybrid',
-            invalidValue: undefined
-        });
+describe('parseEnumFlagValue', () => {
+    it('returns the trimmed lowercase value when it matches the allowlist', () => {
+        assert.equal(parseEnumFlagValue('hybrid', ['hybrid', 'semantic']), 'hybrid');
+        assert.equal(parseEnumFlagValue('  SEMANTIC  ', ['hybrid', 'semantic']), 'semantic');
     });
 
-    it('is case-insensitive and trims whitespace', () => {
-        assert.deepEqual(parseSearchType('  KEYWORD-DATES  '), {
-            value: 'keyword-dates',
-            invalidValue: undefined
-        });
-        assert.deepEqual(parseSearchType('HyBrId-DaTeS'), {
-            value: 'hybrid-dates',
-            invalidValue: undefined
-        });
+    it('returns undefined when the value is not in the allowlist', () => {
+        assert.equal(parseEnumFlagValue('unknown', ['hybrid', 'semantic']), undefined);
     });
 
-    it('accepts array input and uses the last value', () => {
-        assert.deepEqual(parseSearchType(['keyword', 'semantic']), {
-            value: 'semantic',
-            invalidValue: undefined
-        });
+    it('accepts any non-empty string when no allowlist is provided', () => {
+        assert.equal(parseEnumFlagValue('anything'), 'anything');
+        assert.equal(parseEnumFlagValue('  trimmed  '), 'trimmed');
     });
 
-    it('returns invalid value for unrecognised type values', () => {
-        assert.deepEqual(parseSearchType('unknown'), {
-            value: undefined,
-            invalidValue: 'unknown'
-        });
-        assert.deepEqual(parseSearchType('keyword,semantic'), {
-            value: undefined,
-            invalidValue: 'keyword,semantic'
-        });
+    it('returns undefined for empty or whitespace-only strings', () => {
+        assert.equal(parseEnumFlagValue(''), undefined);
+        assert.equal(parseEnumFlagValue('   '), undefined);
     });
 
-    it('returns empty output for absent or empty input', () => {
-        assert.deepEqual(parseSearchType(''), { value: undefined, invalidValue: undefined });
-        assert.deepEqual(parseSearchType(undefined), {
-            value: undefined,
-            invalidValue: undefined
-        });
+    it('returns undefined for non-string values', () => {
+        assert.equal(parseEnumFlagValue(undefined), undefined);
+        assert.equal(parseEnumFlagValue(null), undefined);
+        assert.equal(parseEnumFlagValue(42), undefined);
+    });
+
+    it('uses the last element when given an array', () => {
+        assert.equal(
+            parseEnumFlagValue(['hybrid', 'semantic'], ['hybrid', 'semantic']),
+            'semantic'
+        );
     });
 });
 

--- a/middleware/featureFlags/index.test.js
+++ b/middleware/featureFlags/index.test.js
@@ -145,7 +145,7 @@ describe('featureFlags middleware', () => {
         assert.equal(req.session.featureFlags.type, DEFAULT_SEARCH_TYPE);
     });
 
-    it('falls back to DEFAULT_SEARCH_TYPE when type is empty', () => {
+    it('falls back to DEFAULT_SEARCH_TYPE when type is empty/whitespace and no session value exists', () => {
         const req = {
             query: { type: '   ' },
             session: {}
@@ -155,6 +155,18 @@ describe('featureFlags middleware', () => {
         featureFlags(req, res, () => {});
 
         assert.equal(req.session.featureFlags.type, DEFAULT_SEARCH_TYPE);
+    });
+
+    it('preserves existing session type when type query param is empty/whitespace', () => {
+        const req = {
+            query: { type: '   ' },
+            session: { featureFlags: { type: 'semantic' } }
+        };
+        const res = { locals: {} };
+
+        featureFlags(req, res, () => {});
+
+        assert.equal(req.session.featureFlags.type, 'semantic');
     });
 
     it('preserves existing session type value when type query param is absent', () => {

--- a/middleware/featureFlags/index.test.js
+++ b/middleware/featureFlags/index.test.js
@@ -3,9 +3,7 @@ import { describe, it } from 'node:test';
 
 import featureFlags, {
     FEATURE_FLAG_DEFAULTS,
-    FEATURE_FLAG_ENUM_OPTIONS,
     getFeatureFlagValue,
-    parseEnumFlagValue,
     parseFeatureFlagValue
 } from './index.js';
 
@@ -29,77 +27,77 @@ describe('featureFlags middleware', () => {
         assert.deepEqual(res.locals.featureFlags, FEATURE_FLAG_DEFAULTS);
     });
 
-    it('ignores unknown boolean flags from query string', () => {
-        const req = {
-            query: { hybrid: 'on' },
-            session: {}
-        };
-        const res = {
-            locals: {}
-        };
+    it('defaults: align=true, keyword=true, semantic=false, dates=true', () => {
+        const req = { query: {}, session: {} };
+        const res = { locals: {} };
 
         featureFlags(req, res, () => {});
 
-        assert.equal(req.session.featureFlags.hybrid, undefined);
         assert.equal(req.session.featureFlags.align, true);
-        assert.equal(req.session.featureFlags.type, 'keyword');
+        assert.equal(req.session.featureFlags.keyword, true);
+        assert.equal(req.session.featureFlags.semantic, false);
+        assert.equal(req.session.featureFlags.dates, true);
+    });
+
+    it('ignores unknown flags from query string', () => {
+        const req = {
+            query: { type: 'hybrid', unknown: 'on' },
+            session: {}
+        };
+        const res = { locals: {} };
+
+        featureFlags(req, res, () => {});
+
+        assert.equal(req.session.featureFlags.type, undefined);
+        assert.equal(req.session.featureFlags.unknown, undefined);
+        assert.equal(req.session.featureFlags.keyword, true);
     });
 
     it('updates align flag from query string', () => {
-        const req = {
-            query: { align: 'off' },
-            session: {}
-        };
-        const res = {
-            locals: {}
-        };
+        const req = { query: { align: 'off' }, session: {} };
+        const res = { locals: {} };
 
         featureFlags(req, res, () => {});
 
         assert.equal(req.session.featureFlags.align, false);
-        assert.equal(req.session.featureFlags.type, 'keyword');
     });
 
-    it('updates type flag from query string', () => {
-        const req = {
-            query: { type: 'semantic' },
-            session: {}
-        };
-        const res = {
-            locals: {}
-        };
+    it('enables semantic flag from query string', () => {
+        const req = { query: { semantic: 'on' }, session: {} };
+        const res = { locals: {} };
 
         featureFlags(req, res, () => {});
 
-        assert.equal(req.session.featureFlags.type, 'semantic');
+        assert.equal(req.session.featureFlags.semantic, true);
     });
 
-    it('accepts all valid type enum values from query string', () => {
-        for (const typeValue of FEATURE_FLAG_ENUM_OPTIONS.type) {
-            const req = {
-                query: { type: typeValue },
-                session: {}
-            };
-            const res = { locals: {} };
-
-            featureFlags(req, res, () => {});
-
-            assert.equal(req.session.featureFlags.type, typeValue);
-        }
-    });
-
-    it('ignores invalid type flag values from query string', () => {
-        const req = {
-            query: { type: 'invalid' },
-            session: {}
-        };
-        const res = {
-            locals: {}
-        };
+    it('disables keyword flag from query string', () => {
+        const req = { query: { keyword: 'off' }, session: {} };
+        const res = { locals: {} };
 
         featureFlags(req, res, () => {});
 
-        assert.equal(req.session.featureFlags.type, 'keyword');
+        assert.equal(req.session.featureFlags.keyword, false);
+    });
+
+    it('disables dates flag from query string', () => {
+        const req = { query: { dates: 'off' }, session: {} };
+        const res = { locals: {} };
+
+        featureFlags(req, res, () => {});
+
+        assert.equal(req.session.featureFlags.dates, false);
+    });
+
+    it('enables all three search flags together (hybrid + dates)', () => {
+        const req = { query: { keyword: 'on', semantic: 'on', dates: 'on' }, session: {} };
+        const res = { locals: {} };
+
+        featureFlags(req, res, () => {});
+
+        assert.equal(req.session.featureFlags.keyword, true);
+        assert.equal(req.session.featureFlags.semantic, true);
+        assert.equal(req.session.featureFlags.dates, true);
     });
 
     it('preserves existing feature flag values when the query string is absent', () => {
@@ -108,55 +106,32 @@ describe('featureFlags middleware', () => {
             session: {
                 featureFlags: {
                     align: false,
-                    type: 'hybrid'
+                    keyword: true,
+                    semantic: true,
+                    dates: false
                 }
             }
         };
-        const res = {
-            locals: {}
-        };
+        const res = { locals: {} };
 
         featureFlags(req, res, () => {});
 
-        assert.deepEqual(req.session.featureFlags, {
-            align: false,
-            type: 'hybrid'
-        });
+        assert.equal(req.session.featureFlags.align, false);
+        assert.equal(req.session.featureFlags.keyword, true);
+        assert.equal(req.session.featureFlags.semantic, true);
+        assert.equal(req.session.featureFlags.dates, false);
     });
 
     it('ignores invalid query-string values', () => {
         const req = {
-            query: { hybrid: 'maybe', align: 'sometimes' },
+            query: { keyword: 'maybe', semantic: 'sometimes' },
             session: {}
         };
-        const res = {
-            locals: {}
-        };
+        const res = { locals: {} };
 
         featureFlags(req, res, () => {});
 
         assert.deepEqual(req.session.featureFlags, FEATURE_FLAG_DEFAULTS);
-    });
-});
-
-describe('parseEnumFlagValue', () => {
-    it('returns the value when it is in the allowed set', () => {
-        assert.equal(parseEnumFlagValue('keyword', FEATURE_FLAG_ENUM_OPTIONS.type), 'keyword');
-        assert.equal(parseEnumFlagValue('semantic', FEATURE_FLAG_ENUM_OPTIONS.type), 'semantic');
-        assert.equal(parseEnumFlagValue('hybrid', FEATURE_FLAG_ENUM_OPTIONS.type), 'hybrid');
-    });
-
-    it('accepts the last element when given an array', () => {
-        assert.equal(
-            parseEnumFlagValue(['keyword', 'semantic'], FEATURE_FLAG_ENUM_OPTIONS.type),
-            'semantic'
-        );
-    });
-
-    it('returns undefined for values not in the allowed set', () => {
-        assert.equal(parseEnumFlagValue('all', FEATURE_FLAG_ENUM_OPTIONS.type), undefined);
-        assert.equal(parseEnumFlagValue('', FEATURE_FLAG_ENUM_OPTIONS.type), undefined);
-        assert.equal(parseEnumFlagValue(undefined, FEATURE_FLAG_ENUM_OPTIONS.type), undefined);
     });
 });
 
@@ -176,24 +151,21 @@ describe('parseFeatureFlagValue', () => {
 describe('getFeatureFlagValue', () => {
     it('returns the session value when present', () => {
         assert.equal(getFeatureFlagValue({ featureFlags: { align: false } }, 'align'), false);
+        assert.equal(getFeatureFlagValue({ featureFlags: { keyword: false } }, 'keyword'), false);
+        assert.equal(getFeatureFlagValue({ featureFlags: { semantic: true } }, 'semantic'), true);
+        assert.equal(getFeatureFlagValue({ featureFlags: { dates: false } }, 'dates'), false);
     });
 
     it('falls back to defaults when the session value is missing', () => {
         assert.equal(getFeatureFlagValue({}, 'align'), true);
+        assert.equal(getFeatureFlagValue({}, 'keyword'), true);
+        assert.equal(getFeatureFlagValue({}, 'semantic'), false);
+        assert.equal(getFeatureFlagValue({}, 'dates'), true);
     });
 
-    it('returns the session value for enum flags when valid', () => {
-        assert.equal(
-            getFeatureFlagValue({ featureFlags: { type: 'semantic' } }, 'type'),
-            'semantic'
-        );
-        assert.equal(getFeatureFlagValue({ featureFlags: { type: 'hybrid' } }, 'type'), 'hybrid');
-        assert.equal(getFeatureFlagValue({ featureFlags: { type: 'keyword' } }, 'type'), 'keyword');
-    });
-
-    it('falls back to the default for enum flags when the session value is missing or invalid', () => {
-        assert.equal(getFeatureFlagValue({}, 'type'), 'keyword');
-        assert.equal(getFeatureFlagValue({ featureFlags: { type: 'invalid' } }, 'type'), 'keyword');
-        assert.equal(getFeatureFlagValue({ featureFlags: { type: 123 } }, 'type'), 'keyword');
+    it('falls back to the default for flags when the session value is not a boolean', () => {
+        assert.equal(getFeatureFlagValue({ featureFlags: { keyword: 'hybrid' } }, 'keyword'), true);
+        assert.equal(getFeatureFlagValue({ featureFlags: { semantic: 123 } }, 'semantic'), false);
+        assert.equal(getFeatureFlagValue({ featureFlags: { dates: null } }, 'dates'), true);
     });
 });

--- a/middleware/featureFlags/index.test.js
+++ b/middleware/featureFlags/index.test.js
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-
+import {
+    DEFAULT_SEARCH_TYPE,
+    parseSearchTypeTokens
+} from '../../api/search/constants/searchTypes.js';
 import featureFlags, {
     FEATURE_FLAG_DEFAULTS,
     getFeatureFlagValue,
@@ -27,19 +30,19 @@ describe('featureFlags middleware', () => {
         assert.deepEqual(res.locals.featureFlags, FEATURE_FLAG_DEFAULTS);
     });
 
-    it('defaults: align=true, type=keyword-dates', () => {
+    it(`defaults: align=true, type=${DEFAULT_SEARCH_TYPE}`, () => {
         const req = { query: {}, session: {} };
         const res = { locals: {} };
 
         featureFlags(req, res, () => {});
 
         assert.equal(req.session.featureFlags.align, true);
-        assert.equal(req.session.featureFlags.type, 'keyword-dates');
+        assert.equal(req.session.featureFlags.type, DEFAULT_SEARCH_TYPE);
     });
 
     it('ignores unknown flags from query string', () => {
         const req = {
-            query: { type: 'hybrid', unknown: 'on' },
+            query: { type: 'keyword,semantic', unknown: 'on' },
             session: {}
         };
         const res = { locals: {} };
@@ -89,6 +92,200 @@ describe('featureFlags middleware', () => {
 
         assert.deepEqual(req.session.featureFlags, FEATURE_FLAG_DEFAULTS);
     });
+
+    it('resolves type from comma-delimited tokens (keyword,semantic,dates)', () => {
+        const req = { query: { type: 'keyword,semantic,dates' }, session: {} };
+        const res = { locals: {} };
+
+        featureFlags(req, res, () => {});
+
+        assert.equal(req.session.featureFlags.type, 'hybrid-dates');
+    });
+
+    it('resolves type from comma-delimited tokens in any order (dates,keyword)', () => {
+        const req = { query: { type: 'dates,keyword' }, session: {} };
+        const res = { locals: {} };
+
+        featureFlags(req, res, () => {});
+
+        assert.equal(req.session.featureFlags.type, 'keyword-dates');
+    });
+
+    it('calls next with a 400 error when type contains unrecognised tokens', () => {
+        const req = {
+            query: { type: 'unknown,foo' },
+            session: { featureFlags: { align: true, type: DEFAULT_SEARCH_TYPE } }
+        };
+        const res = { locals: {} };
+        let errorPassed;
+
+        featureFlags(req, res, (err) => {
+            errorPassed = err;
+        });
+
+        assert.ok(errorPassed instanceof Error);
+        assert.equal(errorPassed.status, 400);
+        assert.match(errorPassed.message, /unknown, foo/);
+    });
+
+    it('calls next with a 400 when type mixes valid and invalid tokens', () => {
+        const req = {
+            query: { type: 'hybrid,badtoken' },
+            session: {}
+        };
+        const res = { locals: {} };
+        let errorPassed;
+
+        featureFlags(req, res, (err) => {
+            errorPassed = err;
+        });
+
+        assert.ok(errorPassed instanceof Error);
+        assert.equal(errorPassed.status, 400);
+        assert.match(errorPassed.message, /badtoken/);
+    });
+
+    it('calls next with a 400 when type tokens are all valid but do not resolve to a known search mode', () => {
+        const req = {
+            query: { type: 'semantic,dates' },
+            session: { featureFlags: { align: true, type: 'hybrid-dates' } }
+        };
+        const res = { locals: {} };
+        let errorPassed;
+
+        featureFlags(req, res, (err) => {
+            errorPassed = err;
+        });
+
+        assert.ok(errorPassed instanceof Error);
+        assert.equal(errorPassed.status, 400);
+        assert.match(errorPassed.message, /do not resolve to a known search mode/);
+    });
+
+    it('does not fall through to the previous session value when type is an unresolvable combination', () => {
+        const req = {
+            query: { type: 'semantic,dates' },
+            session: { featureFlags: { align: true, type: 'hybrid-dates' } }
+        };
+        const res = { locals: {} };
+        let errorPassed;
+
+        featureFlags(req, res, (err) => {
+            errorPassed = err;
+        });
+
+        // session must NOT be silently updated to the stale 'hybrid-dates' value
+        assert.ok(errorPassed instanceof Error);
+        assert.equal(req.session.featureFlags?.type, 'hybrid-dates'); // unchanged
+    });
+});
+
+describe('parseSearchTypeTokens', () => {
+    it('resolves single tokens', () => {
+        assert.deepEqual(parseSearchTypeTokens('keyword'), { slug: 'keyword', unknownTokens: [] });
+        assert.deepEqual(parseSearchTypeTokens('semantic'), {
+            slug: 'semantic',
+            unknownTokens: []
+        });
+        assert.deepEqual(parseSearchTypeTokens('hybrid'), { slug: undefined, unknownTokens: [] });
+    });
+
+    it('resolves two-token combinations regardless of order', () => {
+        assert.deepEqual(parseSearchTypeTokens('keyword,dates'), {
+            slug: 'keyword-dates',
+            unknownTokens: []
+        });
+        assert.deepEqual(parseSearchTypeTokens('dates,keyword'), {
+            slug: 'keyword-dates',
+            unknownTokens: []
+        });
+        assert.deepEqual(parseSearchTypeTokens('keyword,semantic'), {
+            slug: 'hybrid',
+            unknownTokens: []
+        });
+        assert.deepEqual(parseSearchTypeTokens('semantic,keyword'), {
+            slug: 'hybrid',
+            unknownTokens: []
+        });
+    });
+
+    it('keyword+semantic+dates resolves to hybrid-dates', () => {
+        assert.deepEqual(parseSearchTypeTokens('keyword,semantic,dates'), {
+            slug: 'hybrid-dates',
+            unknownTokens: []
+        });
+        assert.deepEqual(parseSearchTypeTokens('keyword,semantic,dates'), {
+            slug: 'hybrid-dates',
+            unknownTokens: []
+        });
+    });
+
+    it('dates paired with semantic alone does not resolve (keyword required for hybrid)', () => {
+        assert.deepEqual(parseSearchTypeTokens('semantic,dates'), {
+            slug: undefined,
+            unknownTokens: []
+        });
+    });
+
+    it('collects unrecognised tokens and still resolves from valid remainder', () => {
+        assert.deepEqual(parseSearchTypeTokens('keyword,unknown,dates'), {
+            slug: 'keyword-dates',
+            unknownTokens: ['unknown']
+        });
+        assert.deepEqual(parseSearchTypeTokens('unknown,keyword,semantic'), {
+            slug: 'hybrid',
+            unknownTokens: ['unknown']
+        });
+    });
+
+    it('is case-insensitive and trims whitespace', () => {
+        assert.deepEqual(parseSearchTypeTokens('Keyword, Semantic, Dates'), {
+            slug: 'hybrid-dates',
+            unknownTokens: []
+        });
+        assert.deepEqual(parseSearchTypeTokens('  KEYWORD , DATES  '), {
+            slug: 'keyword-dates',
+            unknownTokens: []
+        });
+    });
+
+    it('accepts array input and uses the last value', () => {
+        assert.deepEqual(parseSearchTypeTokens(['keyword', 'keyword,semantic,dates']), {
+            slug: 'hybrid-dates',
+            unknownTokens: []
+        });
+    });
+
+    it('returns undefined slug with unknownTokens for direct hyphenated slugs', () => {
+        assert.deepEqual(parseSearchTypeTokens('hybrid-dates'), {
+            slug: undefined,
+            unknownTokens: ['hybrid-dates']
+        });
+        assert.deepEqual(parseSearchTypeTokens('keyword-dates'), {
+            slug: undefined,
+            unknownTokens: ['keyword-dates']
+        });
+    });
+
+    it('returns undefined slug with unknownTokens when all tokens are unrecognised', () => {
+        assert.deepEqual(parseSearchTypeTokens('unknown'), {
+            slug: undefined,
+            unknownTokens: ['unknown']
+        });
+        assert.deepEqual(parseSearchTypeTokens('unknown,foo'), {
+            slug: undefined,
+            unknownTokens: ['unknown', 'foo']
+        });
+    });
+
+    it('returns undefined slug with empty unknownTokens for absent or empty input', () => {
+        assert.deepEqual(parseSearchTypeTokens(''), { slug: undefined, unknownTokens: [] });
+        assert.deepEqual(parseSearchTypeTokens(undefined), { slug: undefined, unknownTokens: [] });
+    });
+
+    it('returns undefined slug with empty unknownTokens for dates alone', () => {
+        assert.deepEqual(parseSearchTypeTokens('dates'), { slug: undefined, unknownTokens: [] });
+    });
 });
 
 describe('parseFeatureFlagValue', () => {
@@ -112,6 +309,6 @@ describe('getFeatureFlagValue', () => {
 
     it('falls back to defaults when the session value is missing', () => {
         assert.equal(getFeatureFlagValue({}, 'align'), true);
-        assert.equal(getFeatureFlagValue({}, 'type'), 'keyword-dates');
+        assert.equal(getFeatureFlagValue({}, 'type'), DEFAULT_SEARCH_TYPE);
     });
 });

--- a/middleware/logger/index.js
+++ b/middleware/logger/index.js
@@ -54,6 +54,7 @@ export function buildRedactConfig() {
 function createLogger(options = {}) {
     const { stream, ...pinoOptions } = options;
     const useTransport = !isProd && !stream;
+    const prettyJsonEnabled = process.env.APP_LOG_PRETTY_JSON === 'true';
     const logger = pinoHttp({
         logger: pino(
             {
@@ -67,7 +68,9 @@ function createLogger(options = {}) {
                                   levelFirst: true,
                                   translateTime: 'SYS:standard',
                                   ignore: 'pid,hostname',
-                                  singleLine: true
+                                  // Keep normal logs compact, but allow multiline blocks
+                                  // when explicitly debugging pretty JSON payloads.
+                                  singleLine: !prettyJsonEnabled
                               }
                           }
                       }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "webpack:dev": "webpack --config webpack.config.js",
         "webpack": "webpack --config webpack.config.prod.js",
         "babel": "babel src/js/scripts.js -o src/js/scripts.babel.generated.js",
-        "test": "c8 node --env-file=.env.test --test --test-reporter=spec",
+        "test": "c8 node --env-file=.env.test --test --test-reporter=dot",
         "coverage:html": "c8 report --reporter=html",
         "lint": "biome check --write",
         "format": "biome format --write",

--- a/search/macro/search-result-item/template.njk
+++ b/search/macro/search-result-item/template.njk
@@ -2,7 +2,7 @@
 <p class="govuk-hint govuk-visually-hidden">Received on {{ params._source.received_date | formatDate}}</p>
 <p class="govuk-body">{{ params._source.chunk_text | safe }}</p>
 
-<p class="govuk-body"><strong>Found on:</strong> <a href="/document/{{ params.docUuid }}/view/page/{{ params._source.page_number or '0' }}?crn={{ params.caseReferenceNumber }}&searchTerm={{ params.searchTerm }}" class="govuk-link">Page {{ params._source.page_number }}</a></p>
+<p class="govuk-body"><strong>Found on:</strong> <a href="/document/{{ params.docUuid }}/view/page/{{ params._source.page_number or '0' }}?crn={{ params.caseReferenceNumber }}&searchTerm={{ params.searchTerm }}&type={{ params.searchType | default('keyword') }}" class="govuk-link">Page {{ params._source.page_number }}</a></p>
 
 {% if caller %}
     {{ caller() }}

--- a/search/macro/search-result-item/template.njk
+++ b/search/macro/search-result-item/template.njk
@@ -2,7 +2,7 @@
 <p class="govuk-hint govuk-visually-hidden">Received on {{ params._source.received_date | formatDate}}</p>
 <p class="govuk-body">{{ params._source.chunk_text | safe }}</p>
 
-<p class="govuk-body"><strong>Found on:</strong> <a href="/document/{{ params.docUuid }}/view/page/{{ params._source.page_number or '0' }}?crn={{ params.caseReferenceNumber | urlencode }}&searchTerm={{ params.searchTerm | urlencode }}" class="govuk-link">Page {{ params._source.page_number }}</a></p>
+<p class="govuk-body"><strong>Found on:</strong> <a href="/document/{{ params.docUuid }}/view/page/{{ params._source.page_number or '0' }}?crn={{ params.caseReferenceNumber | urlencode }}&searchTerm={{ params.searchTerm | urlencode }}&type={{ params.searchType | urlencode }}" class="govuk-link">Page {{ params._source.page_number }}</a></p>
 
 {% if caller %}
     {{ caller() }}

--- a/search/macro/search-result-item/template.njk
+++ b/search/macro/search-result-item/template.njk
@@ -2,7 +2,7 @@
 <p class="govuk-hint govuk-visually-hidden">Received on {{ params._source.received_date | formatDate}}</p>
 <p class="govuk-body">{{ params._source.chunk_text | safe }}</p>
 
-<p class="govuk-body"><strong>Found on:</strong> <a href="/document/{{ params.docUuid }}/view/page/{{ params._source.page_number or '0' }}?crn={{ params.caseReferenceNumber | urlencode }}&searchTerm={{ params.searchTerm | urlencode }}&type={{ (params.searchType | default('keyword')) | urlencode }}" class="govuk-link">Page {{ params._source.page_number }}</a></p>
+<p class="govuk-body"><strong>Found on:</strong> <a href="/document/{{ params.docUuid }}/view/page/{{ params._source.page_number or '0' }}?crn={{ params.caseReferenceNumber | urlencode }}&searchTerm={{ params.searchTerm | urlencode }}" class="govuk-link">Page {{ params._source.page_number }}</a></p>
 
 {% if caller %}
     {{ caller() }}

--- a/search/macro/search-result-item/template.njk
+++ b/search/macro/search-result-item/template.njk
@@ -2,7 +2,7 @@
 <p class="govuk-hint govuk-visually-hidden">Received on {{ params._source.received_date | formatDate}}</p>
 <p class="govuk-body">{{ params._source.chunk_text | safe }}</p>
 
-<p class="govuk-body"><strong>Found on:</strong> <a href="/document/{{ params.docUuid }}/view/page/{{ params._source.page_number or '0' }}?crn={{ params.caseReferenceNumber }}&searchTerm={{ params.searchTerm }}&type={{ params.searchType | default('keyword') }}" class="govuk-link">Page {{ params._source.page_number }}</a></p>
+<p class="govuk-body"><strong>Found on:</strong> <a href="/document/{{ params.docUuid }}/view/page/{{ params._source.page_number or '0' }}?crn={{ params.caseReferenceNumber | urlencode }}&searchTerm={{ params.searchTerm | urlencode }}&type={{ (params.searchType | default('keyword')) | urlencode }}" class="govuk-link">Page {{ params._source.page_number }}</a></p>
 
 {% if caller %}
     {{ caller() }}

--- a/search/page/index.njk
+++ b/search/page/index.njk
@@ -22,6 +22,7 @@
     {% endif %}
 
     <form method="post" action="/search">
+        <input type="hidden" name="type" value="{{ searchType | default('keyword') }}">
         {% call govukFieldset({
             legend: {
                 text: "Find",

--- a/search/page/index.njk
+++ b/search/page/index.njk
@@ -30,6 +30,7 @@
             }
         }) %}
 
+            <input type="hidden" name="type" value="{{ searchType }}">
             <p class="govuk-body">You can search the TC-19 medical document for your case here.</p>
 
             <h2 class="govuk-heading-l">How to use this tool</h2>

--- a/search/page/index.njk
+++ b/search/page/index.njk
@@ -22,7 +22,6 @@
     {% endif %}
 
     <form method="post" action="/search">
-        <input type="hidden" name="type" value="{{ searchType | default('keyword') }}">
         {% call govukFieldset({
             legend: {
                 text: "Find",

--- a/search/page/results.njk
+++ b/search/page/results.njk
@@ -32,6 +32,7 @@
     {% endif %}
 
     <form method="post" action="/search">
+        <input type="hidden" name="type" value="{{ searchType | default('keyword') }}">
         {% call govukFieldset({
             legend: {
                 text: "Search results",
@@ -70,12 +71,12 @@
     {% set paginationItems = [] %}
     {% set paginationPrevious = {
             text: "Previous",
-            href: ["/search/?query=", query, "&pageNumber=", pagination.currentPageIndex - 1, "&crn=", caseReferenceNumber] | join
+            href: ["/search/?query=", query, "&pageNumber=", pagination.currentPageIndex - 1, "&crn=", caseReferenceNumber, "&type=", searchType | default('keyword')] | join
         }
     %}
     {% set paginationNext = {
             text: "Next",
-            href: ["/search/?query=", query, "&pageNumber=", pagination.currentPageIndex + 1, "&crn=", caseReferenceNumber] | join
+            href: ["/search/?query=", query, "&pageNumber=", pagination.currentPageIndex + 1, "&crn=", caseReferenceNumber, "&type=", searchType | default('keyword')] | join
         }
     %}
     {# only show pagination item links if there is more than one page #}
@@ -84,7 +85,7 @@
             {%
                 set paginationItems = (paginationItems.push({
                     text: i,
-                    href: ["/search/?query=", query, "&pageNumber=", i, "&crn=", caseReferenceNumber] | join,
+                    href: ["/search/?query=", query, "&pageNumber=", i, "&crn=", caseReferenceNumber, "&type=", searchType | default('keyword')] | join,
                     selected: i == pagination.currentPageIndex
                 }), paginationItems)
             %}

--- a/search/page/results.njk
+++ b/search/page/results.njk
@@ -71,12 +71,12 @@
     {% set paginationItems = [] %}
     {% set paginationPrevious = {
             text: "Previous",
-            href: ["/search/?query=", query, "&pageNumber=", pagination.currentPageIndex - 1, "&crn=", caseReferenceNumber, "&type=", searchType | default('keyword')] | join
+            href: ["/search/?query=", query | urlencode, "&pageNumber=", pagination.currentPageIndex - 1, "&crn=", caseReferenceNumber | urlencode, "&type=", searchType | default('keyword') | urlencode] | join
         }
     %}
     {% set paginationNext = {
             text: "Next",
-            href: ["/search/?query=", query, "&pageNumber=", pagination.currentPageIndex + 1, "&crn=", caseReferenceNumber, "&type=", searchType | default('keyword')] | join
+            href: ["/search/?query=", query | urlencode, "&pageNumber=", pagination.currentPageIndex + 1, "&crn=", caseReferenceNumber | urlencode, "&type=", searchType | default('keyword') | urlencode] | join
         }
     %}
     {# only show pagination item links if there is more than one page #}
@@ -85,7 +85,7 @@
             {%
                 set paginationItems = (paginationItems.push({
                     text: i,
-                    href: ["/search/?query=", query, "&pageNumber=", i, "&crn=", caseReferenceNumber, "&type=", searchType | default('keyword')] | join,
+                    href: ["/search/?query=", query | urlencode, "&pageNumber=", i, "&crn=", caseReferenceNumber | urlencode, "&type=", searchType | default('keyword') | urlencode] | join,
                     selected: i == pagination.currentPageIndex
                 }), paginationItems)
             %}

--- a/search/page/results.njk
+++ b/search/page/results.njk
@@ -32,7 +32,6 @@
     {% endif %}
 
     <form method="post" action="/search">
-        <input type="hidden" name="type" value="{{ searchType | default('keyword') }}">
         {% call govukFieldset({
             legend: {
                 text: "Search results",
@@ -71,12 +70,12 @@
     {% set paginationItems = [] %}
     {% set paginationPrevious = {
             text: "Previous",
-            href: ["/search/?query=", query | urlencode, "&pageNumber=", pagination.currentPageIndex - 1, "&crn=", caseReferenceNumber | urlencode, "&type=", searchType | default('keyword') | urlencode] | join
+            href: ["/search/?query=", query | urlencode, "&pageNumber=", pagination.currentPageIndex - 1, "&crn=", caseReferenceNumber | urlencode] | join
         }
     %}
     {% set paginationNext = {
             text: "Next",
-            href: ["/search/?query=", query | urlencode, "&pageNumber=", pagination.currentPageIndex + 1, "&crn=", caseReferenceNumber | urlencode, "&type=", searchType | default('keyword') | urlencode] | join
+            href: ["/search/?query=", query | urlencode, "&pageNumber=", pagination.currentPageIndex + 1, "&crn=", caseReferenceNumber | urlencode] | join
         }
     %}
     {# only show pagination item links if there is more than one page #}
@@ -85,7 +84,7 @@
             {%
                 set paginationItems = (paginationItems.push({
                     text: i,
-                    href: ["/search/?query=", query | urlencode, "&pageNumber=", i, "&crn=", caseReferenceNumber | urlencode, "&type=", searchType | default('keyword') | urlencode] | join,
+                    href: ["/search/?query=", query | urlencode, "&pageNumber=", i, "&crn=", caseReferenceNumber | urlencode] | join,
                     selected: i == pagination.currentPageIndex
                 }), paginationItems)
             %}

--- a/search/page/results.njk
+++ b/search/page/results.njk
@@ -34,7 +34,7 @@
     <form method="post" action="/search">
         {% call govukFieldset({
             legend: {
-                text: ["Search results"],
+                text: "Search results",
                 classes: "govuk-fieldset__legend--xl",
                 isPageHeading: true
             }

--- a/search/page/results.njk
+++ b/search/page/results.njk
@@ -34,7 +34,7 @@
     <form method="post" action="/search">
         {% call govukFieldset({
             legend: {
-                text: ["Search results - ", searchType] | join(''),
+                text: ["Search results"],
                 classes: "govuk-fieldset__legend--xl",
                 isPageHeading: true
             }
@@ -60,6 +60,7 @@
                 }
             }) }}
 
+            <input type="hidden" name="type" value="{{ searchType }}">
             <input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
         {% endcall %}
@@ -70,12 +71,12 @@
     {% set paginationItems = [] %}
     {% set paginationPrevious = {
             text: "Previous",
-            href: ["/search/?query=", query | urlencode, "&pageNumber=", pagination.currentPageIndex - 1, "&crn=", caseReferenceNumber | urlencode] | join
+            href: ["/search/?query=", query | urlencode, "&pageNumber=", pagination.currentPageIndex - 1, "&crn=", caseReferenceNumber | urlencode, "&type=", searchType | urlencode] | join
         }
     %}
     {% set paginationNext = {
             text: "Next",
-            href: ["/search/?query=", query | urlencode, "&pageNumber=", pagination.currentPageIndex + 1, "&crn=", caseReferenceNumber | urlencode] | join
+            href: ["/search/?query=", query | urlencode, "&pageNumber=", pagination.currentPageIndex + 1, "&crn=", caseReferenceNumber | urlencode, "&type=", searchType | urlencode] | join
         }
     %}
     {# only show pagination item links if there is more than one page #}
@@ -84,7 +85,7 @@
             {%
                 set paginationItems = (paginationItems.push({
                     text: i,
-                    href: ["/search/?query=", query | urlencode, "&pageNumber=", i, "&crn=", caseReferenceNumber | urlencode] | join,
+                    href: ["/search/?query=", query | urlencode, "&pageNumber=", i, "&crn=", caseReferenceNumber | urlencode, "&type=", searchType | urlencode] | join,
                     selected: i == pagination.currentPageIndex
                 }), paginationItems)
             %}

--- a/search/page/results.njk
+++ b/search/page/results.njk
@@ -34,7 +34,7 @@
     <form method="post" action="/search">
         {% call govukFieldset({
             legend: {
-                text: "Search results",
+                text: ["Search results - ", searchType] | join(''),
                 classes: "govuk-fieldset__legend--xl",
                 isPageHeading: true
             }

--- a/search/page/templates.test.js
+++ b/search/page/templates.test.js
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import express from 'express';
+import createTemplateEngineService from '../../templateEngine/index.js';
+
+const createRenderer = () => {
+    const app = express();
+    const templateEngineService = createTemplateEngineService(app);
+    templateEngineService.init();
+    return templateEngineService;
+};
+
+describe('search page templates', () => {
+    it('renders the search index form with the current search type as a hidden input', () => {
+        const html = createRenderer().render('search/page/index.njk', {
+            caseSelected: true,
+            caseReferenceNumber: '12-745678',
+            pageType: 'search',
+            csrfToken: 'csrf-token',
+            cspNonce: 'nonce',
+            userName: 'search.user@example.com',
+            searchType: 'semantic'
+        });
+
+        assert.match(html, /name="type" value="semantic"/);
+    });
+
+    it('renders results links and pagination with the current search type preserved', () => {
+        const html = createRenderer().render('search/page/results.njk', {
+            caseSelected: true,
+            caseReferenceNumber: '12-745678',
+            pageType: 'search',
+            csrfToken: 'csrf-token',
+            cspNonce: 'nonce',
+            userName: 'search.user@example.com',
+            query: 'jaw fracture',
+            searchType: 'semantic',
+            searchTerm: 'jaw fracture',
+            showPaginationItems: true,
+            searchResults: [
+                {
+                    docUuid: 'doc-123',
+                    searchTerm: 'jaw fracture',
+                    searchType: 'semantic',
+                    caseReferenceNumber: '12-745678',
+                    _source: {
+                        correspondence_type: 'Medical report',
+                        source_file_name: 'report.pdf',
+                        chunk_text: 'Result snippet',
+                        page_number: 3,
+                        received_date: '2026-01-12T00:00:00Z'
+                    }
+                }
+            ],
+            pagination: {
+                totalItemCount: 3,
+                totalPageCount: 3,
+                currentPageIndex: 2,
+                itemsPerPage: 1,
+                from: 2,
+                to: 2,
+                isFirstPage: false,
+                isLastPage: false
+            }
+        });
+
+        assert.match(html, /name="type" value="semantic"/);
+        assert.match(
+            html,
+            /\/search\/\?query=jaw%20fracture&amp;pageNumber=1&amp;crn=12-745678&amp;type=semantic/
+        );
+        assert.match(
+            html,
+            /\/search\/\?query=jaw%20fracture&amp;pageNumber=3&amp;crn=12-745678&amp;type=semantic/
+        );
+        assert.match(
+            html,
+            /\/document\/doc-123\/view\/page\/3\?crn=12-745678&searchTerm=jaw%20fracture&type=semantic/
+        );
+    });
+});

--- a/search/routes.js
+++ b/search/routes.js
@@ -1,4 +1,9 @@
 import express from 'express';
+import {
+    FEATURE_FLAG_ENUM_OPTIONS,
+    getFeatureFlagValue,
+    parseEnumFlagValue
+} from '../middleware/featureFlags/index.js';
 import createApiJwtToken from '../service/request/create-api-jwt-token.js';
 
 /**
@@ -17,12 +22,20 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
 
     router.post('/', (req, res, next) => {
         try {
-            const { query } = req.body;
+            const { query, type: rawSearchType } = req.body;
             const { pageNumber = 1 } = req.query;
+            const searchType = parseEnumFlagValue(rawSearchType, FEATURE_FLAG_ENUM_OPTIONS.type);
 
-            return res.redirect(
-                `/search?query=${encodeURIComponent(query.trim())}&pageNumber=${pageNumber}`
-            );
+            const redirectParams = new URLSearchParams({
+                query: query.trim(),
+                pageNumber: String(pageNumber)
+            });
+
+            if (searchType) {
+                redirectParams.set('type', searchType);
+            }
+
+            return res.redirect(`/search?${redirectParams.toString()}`);
         } catch (err) {
             next(err);
         }
@@ -35,6 +48,7 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
 
             const { query, pageNumber: rawPageNumber, itemsPerPage: rawItemsPerPage } = req.query;
             const userName = req.session?.username;
+            const searchType = getFeatureFlagValue(req.session, 'type');
 
             if (!query) {
                 const html = render('search/page/index.njk', {
@@ -43,7 +57,8 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
                     pageType: 'search',
                     csrfToken: res.locals.csrfToken,
                     cspNonce: res.locals.cspNonce,
-                    userName
+                    userName,
+                    searchType
                 });
                 return res.send(html);
             }
@@ -61,7 +76,8 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
                 csrfToken: res.locals.csrfToken,
                 cspNonce: res.locals.cspNonce,
                 userName,
-                query
+                query,
+                searchType
             };
 
             req.log.info({ query, pageNumber, itemsPerPage }, 'Creating search service');
@@ -75,7 +91,10 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
                 encodeURIComponent(query),
                 pageNumber,
                 itemsPerPage,
-                token
+                token,
+                {
+                    searchType
+                }
             );
             const { body } = response || {};
 
@@ -98,6 +117,7 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
                 ...hit,
                 docUuid: hit._source?.source_doc_id || 0,
                 searchTerm: query,
+                searchType,
                 caseReferenceNumber: req.session?.caseReferenceNumber
             }));
 

--- a/search/routes.js
+++ b/search/routes.js
@@ -21,11 +21,7 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
         try {
             const { query } = req.body;
             const { pageNumber = 1 } = req.query;
-            const resolvedSearchType = resolveSearchType(req.body?.type);
-            const searchType =
-                resolvedSearchType ||
-                getFeatureFlagValue(req.session, 'type') ||
-                DEFAULT_SEARCH_TYPE;
+            const searchType = resolveSearchType(req.body?.type, req.session);
 
             const redirectParams = new URLSearchParams({
                 query: query.trim(),

--- a/search/routes.js
+++ b/search/routes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import SEARCH_TYPES from '../api/search/constants/searchTypes.js';
+import { DEFAULT_SEARCH_TYPE } from '../api/search/constants/searchTypes.js';
 import { getFeatureFlagValue } from '../middleware/featureFlags/index.js';
 import createApiJwtToken from '../service/request/create-api-jwt-token.js';
 
@@ -40,8 +40,7 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
 
             const { query, pageNumber: rawPageNumber, itemsPerPage: rawItemsPerPage } = req.query;
             const userName = req.session?.username;
-            const searchType =
-                getFeatureFlagValue(req.session, 'type') || SEARCH_TYPES.KEYWORD_DATES;
+            const searchType = getFeatureFlagValue(req.session, 'type') || DEFAULT_SEARCH_TYPE;
 
             if (!query) {
                 const html = render('search/page/index.njk', {

--- a/search/routes.js
+++ b/search/routes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { DEFAULT_SEARCH_TYPE } from '../api/search/constants/searchTypes.js';
+import { DEFAULT_SEARCH_TYPE, parseSearchType } from '../api/search/constants/searchTypes.js';
 import { getFeatureFlagValue } from '../middleware/featureFlags/index.js';
 import createApiJwtToken from '../service/request/create-api-jwt-token.js';
 
@@ -21,10 +21,14 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
         try {
             const { query } = req.body;
             const { pageNumber = 1 } = req.query;
+            const { slug: postedSearchType } = parseSearchType(req.body?.type);
+            const searchType =
+                postedSearchType || getFeatureFlagValue(req.session, 'type') || DEFAULT_SEARCH_TYPE;
 
             const redirectParams = new URLSearchParams({
                 query: query.trim(),
-                pageNumber: String(pageNumber)
+                pageNumber: String(pageNumber),
+                type: searchType
             });
 
             return res.redirect(`/search?${redirectParams.toString()}`);
@@ -41,6 +45,16 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
             const { query, pageNumber: rawPageNumber, itemsPerPage: rawItemsPerPage } = req.query;
             const userName = req.session?.username;
             const searchType = getFeatureFlagValue(req.session, 'type') || DEFAULT_SEARCH_TYPE;
+
+            // Ensure the URL is canonical: when no `type` is supplied (e.g. the
+            // sub-nav "Search" tab links to plain /search), redirect with the
+            // resolved search type appended so the URL is bookmarkable and
+            // visible to the user.
+            if (req.query.type === undefined) {
+                const redirectQuery = new URLSearchParams(req.query);
+                redirectQuery.set('type', searchType);
+                return res.redirect(`/search?${redirectQuery.toString()}`);
+            }
 
             if (!query) {
                 const html = render('search/page/index.njk', {

--- a/search/routes.js
+++ b/search/routes.js
@@ -21,9 +21,9 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
         try {
             const { query } = req.body;
             const { pageNumber = 1 } = req.query;
-            const requestSearchType = parseSearchType(req.body?.type);
+            const { value: postedSearchType } = parseSearchType(req.body?.type);
             const searchType =
-                requestSearchType.searchType ||
+                postedSearchType.searchType ||
                 getFeatureFlagValue(req.session, 'type') ||
                 DEFAULT_SEARCH_TYPE;
 

--- a/search/routes.js
+++ b/search/routes.js
@@ -23,9 +23,7 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
             const { pageNumber = 1 } = req.query;
             const { value: postedSearchType } = parseSearchType(req.body?.type);
             const searchType =
-                postedSearchType.searchType ||
-                getFeatureFlagValue(req.session, 'type') ||
-                DEFAULT_SEARCH_TYPE;
+                postedSearchType || getFeatureFlagValue(req.session, 'type') || DEFAULT_SEARCH_TYPE;
 
             const redirectParams = new URLSearchParams({
                 query: query.trim(),

--- a/search/routes.js
+++ b/search/routes.js
@@ -1,6 +1,5 @@
 import express from 'express';
 import { DEFAULT_SEARCH_TYPE, parseSearchType } from '../api/search/constants/searchTypes.js';
-import enforceSearchTypeInQuery from '../middleware/enforceSearchTypeInQuery/index.js';
 import { getFeatureFlagValue } from '../middleware/featureFlags/index.js';
 import createApiJwtToken from '../service/request/create-api-jwt-token.js';
 
@@ -38,7 +37,7 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
         }
     });
 
-    router.get('/', enforceSearchTypeInQuery, async (req, res, next) => {
+    router.get('/', async (req, res, next) => {
         try {
             const templateEngineService = createTemplateEngineService();
             const { render } = templateEngineService;

--- a/search/routes.js
+++ b/search/routes.js
@@ -1,6 +1,5 @@
 import express from 'express';
-import { DEFAULT_SEARCH_TYPE, resolveSearchType } from '../api/search/constants/searchTypes.js';
-import { getFeatureFlagValue } from '../middleware/featureFlags/index.js';
+import { resolveSearchType } from '../api/search/constants/searchTypes.js';
 import createApiJwtToken from '../service/request/create-api-jwt-token.js';
 
 /**
@@ -42,7 +41,7 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
 
             const { query, pageNumber: rawPageNumber, itemsPerPage: rawItemsPerPage } = req.query;
             const userName = req.session?.username;
-            const searchType = getFeatureFlagValue(req.session, 'type') || DEFAULT_SEARCH_TYPE;
+            const searchType = resolveSearchType(req.session?.featureFlags?.type, req.session);
 
             if (!query) {
                 const html = render('search/page/index.njk', {

--- a/search/routes.js
+++ b/search/routes.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import { DEFAULT_SEARCH_TYPE, parseSearchType } from '../api/search/constants/searchTypes.js';
+import enforceSearchTypeInQuery from '../middleware/enforceSearchTypeInQuery/index.js';
 import { getFeatureFlagValue } from '../middleware/featureFlags/index.js';
 import createApiJwtToken from '../service/request/create-api-jwt-token.js';
 
@@ -37,7 +38,7 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
         }
     });
 
-    router.get('/', async (req, res, next) => {
+    router.get('/', enforceSearchTypeInQuery, async (req, res, next) => {
         try {
             const templateEngineService = createTemplateEngineService();
             const { render } = templateEngineService;
@@ -45,16 +46,6 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
             const { query, pageNumber: rawPageNumber, itemsPerPage: rawItemsPerPage } = req.query;
             const userName = req.session?.username;
             const searchType = getFeatureFlagValue(req.session, 'type') || DEFAULT_SEARCH_TYPE;
-
-            // Ensure the URL is canonical: when no `type` is supplied (e.g. the
-            // sub-nav "Search" tab links to plain /search), redirect with the
-            // resolved search type appended so the URL is bookmarkable and
-            // visible to the user.
-            if (req.query.type === undefined) {
-                const redirectQuery = new URLSearchParams(req.query);
-                redirectQuery.set('type', searchType);
-                return res.redirect(`/search?${redirectQuery.toString()}`);
-            }
 
             if (!query) {
                 const html = render('search/page/index.njk', {

--- a/search/routes.js
+++ b/search/routes.js
@@ -1,9 +1,5 @@
 import express from 'express';
-import {
-    FEATURE_FLAG_ENUM_OPTIONS,
-    getFeatureFlagValue,
-    parseEnumFlagValue
-} from '../middleware/featureFlags/index.js';
+import { getFeatureFlagValue } from '../middleware/featureFlags/index.js';
 import createApiJwtToken from '../service/request/create-api-jwt-token.js';
 
 /**
@@ -22,18 +18,13 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
 
     router.post('/', (req, res, next) => {
         try {
-            const { query, type: rawSearchType } = req.body;
+            const { query } = req.body;
             const { pageNumber = 1 } = req.query;
-            const searchType = parseEnumFlagValue(rawSearchType, FEATURE_FLAG_ENUM_OPTIONS.type);
 
             const redirectParams = new URLSearchParams({
                 query: query.trim(),
                 pageNumber: String(pageNumber)
             });
-
-            if (searchType) {
-                redirectParams.set('type', searchType);
-            }
 
             return res.redirect(`/search?${redirectParams.toString()}`);
         } catch (err) {
@@ -48,7 +39,10 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
 
             const { query, pageNumber: rawPageNumber, itemsPerPage: rawItemsPerPage } = req.query;
             const userName = req.session?.username;
-            const searchType = getFeatureFlagValue(req.session, 'type');
+            const useKeyword = getFeatureFlagValue(req.session, 'keyword');
+            const useSemantic = getFeatureFlagValue(req.session, 'semantic');
+            const useDates = getFeatureFlagValue(req.session, 'dates');
+            const searchFlags = { useKeyword, useSemantic, useDates };
 
             if (!query) {
                 const html = render('search/page/index.njk', {
@@ -58,7 +52,7 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
                     csrfToken: res.locals.csrfToken,
                     cspNonce: res.locals.cspNonce,
                     userName,
-                    searchType
+                    ...searchFlags
                 });
                 return res.send(html);
             }
@@ -77,7 +71,7 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
                 cspNonce: res.locals.cspNonce,
                 userName,
                 query,
-                searchType
+                ...searchFlags
             };
 
             req.log.info({ query, pageNumber, itemsPerPage }, 'Creating search service');
@@ -92,9 +86,7 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
                 pageNumber,
                 itemsPerPage,
                 token,
-                {
-                    searchType
-                }
+                searchFlags
             );
             const { body } = response || {};
 
@@ -117,7 +109,7 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
                 ...hit,
                 docUuid: hit._source?.source_doc_id || 0,
                 searchTerm: query,
-                searchType,
+                ...searchFlags,
                 caseReferenceNumber: req.session?.caseReferenceNumber
             }));
 

--- a/search/routes.js
+++ b/search/routes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { DEFAULT_SEARCH_TYPE, parseSearchType } from '../api/search/constants/searchTypes.js';
+import { DEFAULT_SEARCH_TYPE, resolveSearchType } from '../api/search/constants/searchTypes.js';
 import { getFeatureFlagValue } from '../middleware/featureFlags/index.js';
 import createApiJwtToken from '../service/request/create-api-jwt-token.js';
 
@@ -21,9 +21,11 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
         try {
             const { query } = req.body;
             const { pageNumber = 1 } = req.query;
-            const { value: postedSearchType } = parseSearchType(req.body?.type);
+            const resolvedSearchType = resolveSearchType(req.body?.type);
             const searchType =
-                postedSearchType || getFeatureFlagValue(req.session, 'type') || DEFAULT_SEARCH_TYPE;
+                resolvedSearchType ||
+                getFeatureFlagValue(req.session, 'type') ||
+                DEFAULT_SEARCH_TYPE;
 
             const redirectParams = new URLSearchParams({
                 query: query.trim(),

--- a/search/routes.js
+++ b/search/routes.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import SEARCH_TYPES from '../api/search/constants/searchTypes.js';
 import { getFeatureFlagValue } from '../middleware/featureFlags/index.js';
 import createApiJwtToken from '../service/request/create-api-jwt-token.js';
 
@@ -39,10 +40,8 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
 
             const { query, pageNumber: rawPageNumber, itemsPerPage: rawItemsPerPage } = req.query;
             const userName = req.session?.username;
-            const useKeyword = getFeatureFlagValue(req.session, 'keyword');
-            const useSemantic = getFeatureFlagValue(req.session, 'semantic');
-            const useDates = getFeatureFlagValue(req.session, 'dates');
-            const searchFlags = { useKeyword, useSemantic, useDates };
+            const searchType =
+                getFeatureFlagValue(req.session, 'type') || SEARCH_TYPES.KEYWORD_DATES;
 
             if (!query) {
                 const html = render('search/page/index.njk', {
@@ -52,7 +51,7 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
                     csrfToken: res.locals.csrfToken,
                     cspNonce: res.locals.cspNonce,
                     userName,
-                    ...searchFlags
+                    searchType
                 });
                 return res.send(html);
             }
@@ -71,7 +70,7 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
                 cspNonce: res.locals.cspNonce,
                 userName,
                 query,
-                ...searchFlags
+                searchType
             };
 
             req.log.info({ query, pageNumber, itemsPerPage }, 'Creating search service');
@@ -86,7 +85,7 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
                 pageNumber,
                 itemsPerPage,
                 token,
-                searchFlags
+                { searchType }
             );
             const { body } = response || {};
 
@@ -109,7 +108,7 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
                 ...hit,
                 docUuid: hit._source?.source_doc_id || 0,
                 searchTerm: query,
-                ...searchFlags,
+                searchType,
                 caseReferenceNumber: req.session?.caseReferenceNumber
             }));
 

--- a/search/routes.js
+++ b/search/routes.js
@@ -21,9 +21,11 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
         try {
             const { query } = req.body;
             const { pageNumber = 1 } = req.query;
-            const { slug: postedSearchType } = parseSearchType(req.body?.type);
+            const requestSearchType = parseSearchType(req.body?.type);
             const searchType =
-                postedSearchType || getFeatureFlagValue(req.session, 'type') || DEFAULT_SEARCH_TYPE;
+                requestSearchType.searchType ||
+                getFeatureFlagValue(req.session, 'type') ||
+                DEFAULT_SEARCH_TYPE;
 
             const redirectParams = new URLSearchParams({
                 query: query.trim(),

--- a/search/routes.test.js
+++ b/search/routes.test.js
@@ -82,6 +82,57 @@ describe('Search Routes', () => {
             assert.strictEqual(res.statusCode, 200);
             assert.match(res.text, /search\/page\/results.njk/);
             assert.strictEqual(lastRenderParams.userName, 'search.user@example.com');
+            assert.strictEqual(lastRenderParams.searchType, 'keyword');
+        });
+
+        it('should pass the search type to the search service when set in session', async () => {
+            let serviceCallArgs;
+            mockCreateSearchService = () => ({
+                getSearchResults: async (...args) => {
+                    serviceCallArgs = args;
+                    return {
+                        body: {
+                            data: {
+                                attributes: {
+                                    results: {
+                                        hits: [],
+                                        total: { value: 0 }
+                                    }
+                                }
+                            }
+                        }
+                    };
+                }
+            });
+
+            const searchRouter = createSearchRouter({
+                createTemplateEngineService: mockCreateTemplateEngineService,
+                createSearchService: mockCreateSearchService
+            });
+
+            const testApp = express();
+            testApp.use(express.json());
+            testApp.use(express.urlencoded({ extended: true }));
+            testApp.use((req, res, next) => {
+                req.session = {
+                    caseSelected: true,
+                    caseReferenceNumber: '12345',
+                    username: 'search.user@example.com',
+                    featureFlags: {
+                        type: 'hybrid'
+                    }
+                };
+                req.log = { info: () => {}, error: () => {} };
+                res.locals.csrfToken = 'test-csrf-token';
+                res.locals.cspNonce = 'test-csp-nonce';
+                next();
+            });
+            testApp.use('/search', searchRouter);
+
+            const res = await request(testApp).get('/search?query=test');
+
+            assert.strictEqual(res.statusCode, 200);
+            assert.deepStrictEqual(serviceCallArgs[4], { searchType: 'hybrid' });
         });
 
         it('should handle errors from the search service', async () => {
@@ -292,13 +343,25 @@ describe('Search Routes', () => {
         it('should redirect to the GET route with the query parameter', async () => {
             const res = await request(app).post('/search').send({ query: ' search term ' });
             assert.strictEqual(res.statusCode, 302);
-            assert.strictEqual(res.headers.location, '/search?query=search%20term&pageNumber=1');
+            assert.strictEqual(res.headers.location, '/search?query=search+term&pageNumber=1');
         });
 
         it('should redirect with pageNumber when provided', async () => {
             const res = await request(app).post('/search?pageNumber=5').send({ query: 'test' });
             assert.strictEqual(res.statusCode, 302);
             assert.strictEqual(res.headers.location, '/search?query=test&pageNumber=5');
+        });
+
+        it('should preserve the type value in the redirect when provided', async () => {
+            const res = await request(app)
+                .post('/search?pageNumber=2')
+                .send({ query: 'test', type: 'semantic' });
+
+            assert.strictEqual(res.statusCode, 302);
+            assert.strictEqual(
+                res.headers.location,
+                '/search?query=test&pageNumber=2&type=semantic'
+            );
         });
 
         it('handles errors in POST /search route', async () => {

--- a/search/routes.test.js
+++ b/search/routes.test.js
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { beforeEach, describe, it } from 'node:test';
 import express from 'express';
 import request from 'supertest';
+import { DEFAULT_SEARCH_TYPE } from '../api/search/constants/searchTypes.js';
 import createSearchRouter from './routes.js';
 
 describe('Search Routes', () => {
@@ -82,7 +83,7 @@ describe('Search Routes', () => {
             assert.strictEqual(res.statusCode, 200);
             assert.match(res.text, /search\/page\/results.njk/);
             assert.strictEqual(lastRenderParams.userName, 'search.user@example.com');
-            assert.strictEqual(lastRenderParams.searchType, 'keyword-dates');
+            assert.strictEqual(lastRenderParams.searchType, DEFAULT_SEARCH_TYPE);
         });
 
         it('should pass the search type to the search service when set in session', async () => {

--- a/search/routes.test.js
+++ b/search/routes.test.js
@@ -82,9 +82,7 @@ describe('Search Routes', () => {
             assert.strictEqual(res.statusCode, 200);
             assert.match(res.text, /search\/page\/results.njk/);
             assert.strictEqual(lastRenderParams.userName, 'search.user@example.com');
-            assert.strictEqual(lastRenderParams.useKeyword, true);
-            assert.strictEqual(lastRenderParams.useSemantic, false);
-            assert.strictEqual(lastRenderParams.useDates, true);
+            assert.strictEqual(lastRenderParams.searchType, 'keyword-dates');
         });
 
         it('should pass the search type to the search service when set in session', async () => {
@@ -121,9 +119,7 @@ describe('Search Routes', () => {
                     caseReferenceNumber: '12345',
                     username: 'search.user@example.com',
                     featureFlags: {
-                        keyword: true,
-                        semantic: true,
-                        dates: true
+                        type: 'semantic'
                     }
                 };
                 req.log = { info: () => {}, error: () => {} };
@@ -137,9 +133,7 @@ describe('Search Routes', () => {
 
             assert.strictEqual(res.statusCode, 200);
             assert.deepStrictEqual(serviceCallArgs[4], {
-                useKeyword: true,
-                useSemantic: true,
-                useDates: true
+                searchType: 'semantic'
             });
         });
 

--- a/search/routes.test.js
+++ b/search/routes.test.js
@@ -71,15 +71,6 @@ describe('Search Routes', () => {
     });
 
     describe('GET /', () => {
-        it('should redirect to include the resolved search type when type is missing', async () => {
-            const res = await request(app).get('/search?crn=12345');
-            assert.strictEqual(res.statusCode, 302);
-            assert.strictEqual(
-                res.headers.location,
-                `/search?crn=12345&type=${DEFAULT_SEARCH_TYPE}`
-            );
-        });
-
         it('should render the search index page if no query is provided', async () => {
             const res = await request(app).get(`/search?type=${DEFAULT_SEARCH_TYPE}`);
             assert.strictEqual(res.statusCode, 200);

--- a/search/routes.test.js
+++ b/search/routes.test.js
@@ -139,6 +139,62 @@ describe('Search Routes', () => {
             });
         });
 
+        it('should fall back to default search type when session type is invalid', async () => {
+            const testApp = express();
+            const captured = { searchType: undefined };
+
+            const router = createSearchRouter({
+                createTemplateEngineService: mockCreateTemplateEngineService,
+                createSearchService: () => ({
+                    getSearchResults: async (
+                        _query,
+                        _pageNumber,
+                        _itemsPerPage,
+                        _token,
+                        options
+                    ) => {
+                        captured.searchType = options.searchType;
+                        return {
+                            body: {
+                                data: {
+                                    attributes: {
+                                        results: {
+                                            hits: [],
+                                            total: { value: 0 }
+                                        }
+                                    }
+                                }
+                            }
+                        };
+                    }
+                })
+            });
+
+            testApp.use(express.json());
+            testApp.use(express.urlencoded({ extended: true }));
+            testApp.use((req, res, next) => {
+                req.session = {
+                    caseSelected: true,
+                    caseReferenceNumber: '12345',
+                    username: 'search.user@example.com',
+                    featureFlags: {
+                        type: 'old-value'
+                    }
+                };
+                req.log = { info: () => {}, error: () => {} };
+                res.locals.csrfToken = 'test-csrf-token';
+                res.locals.cspNonce = 'test-csp-nonce';
+                next();
+            });
+            testApp.use('/search', router);
+
+            const res = await request(testApp).get('/search?query=test&type=old-value');
+
+            assert.strictEqual(res.statusCode, 200);
+            assert.strictEqual(captured.searchType, DEFAULT_SEARCH_TYPE);
+            assert.strictEqual(lastRenderParams.searchType, DEFAULT_SEARCH_TYPE);
+        });
+
         it('should handle errors from the search service', async () => {
             // This test needs a fresh app instance to re-initialize the router with new mocks
             const testApp = express();

--- a/search/routes.test.js
+++ b/search/routes.test.js
@@ -82,7 +82,9 @@ describe('Search Routes', () => {
             assert.strictEqual(res.statusCode, 200);
             assert.match(res.text, /search\/page\/results.njk/);
             assert.strictEqual(lastRenderParams.userName, 'search.user@example.com');
-            assert.strictEqual(lastRenderParams.searchType, 'keyword');
+            assert.strictEqual(lastRenderParams.useKeyword, true);
+            assert.strictEqual(lastRenderParams.useSemantic, false);
+            assert.strictEqual(lastRenderParams.useDates, true);
         });
 
         it('should pass the search type to the search service when set in session', async () => {
@@ -119,7 +121,9 @@ describe('Search Routes', () => {
                     caseReferenceNumber: '12345',
                     username: 'search.user@example.com',
                     featureFlags: {
-                        type: 'hybrid'
+                        keyword: true,
+                        semantic: true,
+                        dates: true
                     }
                 };
                 req.log = { info: () => {}, error: () => {} };
@@ -132,7 +136,11 @@ describe('Search Routes', () => {
             const res = await request(testApp).get('/search?query=test');
 
             assert.strictEqual(res.statusCode, 200);
-            assert.deepStrictEqual(serviceCallArgs[4], { searchType: 'hybrid' });
+            assert.deepStrictEqual(serviceCallArgs[4], {
+                useKeyword: true,
+                useSemantic: true,
+                useDates: true
+            });
         });
 
         it('should handle errors from the search service', async () => {
@@ -346,22 +354,20 @@ describe('Search Routes', () => {
             assert.strictEqual(res.headers.location, '/search?query=search+term&pageNumber=1');
         });
 
-        it('should redirect with pageNumber when provided', async () => {
+        it('should preserve pageNumber in the redirect when provided', async () => {
             const res = await request(app).post('/search?pageNumber=5').send({ query: 'test' });
             assert.strictEqual(res.statusCode, 302);
             assert.strictEqual(res.headers.location, '/search?query=test&pageNumber=5');
         });
 
-        it('should preserve the type value in the redirect when provided', async () => {
+        it('ignores type field in POST body (flags are session-based)', async () => {
             const res = await request(app)
                 .post('/search?pageNumber=2')
                 .send({ query: 'test', type: 'semantic' });
 
             assert.strictEqual(res.statusCode, 302);
-            assert.strictEqual(
-                res.headers.location,
-                '/search?query=test&pageNumber=2&type=semantic'
-            );
+            // type is no longer carried through the redirect URL
+            assert.strictEqual(res.headers.location, '/search?query=test&pageNumber=2');
         });
 
         it('handles errors in POST /search route', async () => {

--- a/search/routes.test.js
+++ b/search/routes.test.js
@@ -71,15 +71,25 @@ describe('Search Routes', () => {
     });
 
     describe('GET /', () => {
+        it('should redirect to include the resolved search type when type is missing', async () => {
+            const res = await request(app).get('/search?crn=12345');
+            assert.strictEqual(res.statusCode, 302);
+            assert.strictEqual(
+                res.headers.location,
+                `/search?crn=12345&type=${DEFAULT_SEARCH_TYPE}`
+            );
+        });
+
         it('should render the search index page if no query is provided', async () => {
-            const res = await request(app).get('/search');
+            const res = await request(app).get(`/search?type=${DEFAULT_SEARCH_TYPE}`);
             assert.strictEqual(res.statusCode, 200);
             assert.match(res.text, /search\/page\/index.njk/);
             assert.strictEqual(lastRenderParams.userName, 'search.user@example.com');
+            assert.strictEqual(lastRenderParams.searchType, DEFAULT_SEARCH_TYPE);
         });
 
         it('should call search service and render results when a query is provided', async () => {
-            const res = await request(app).get('/search?query=test');
+            const res = await request(app).get(`/search?query=test&type=${DEFAULT_SEARCH_TYPE}`);
             assert.strictEqual(res.statusCode, 200);
             assert.match(res.text, /search\/page\/results.njk/);
             assert.strictEqual(lastRenderParams.userName, 'search.user@example.com');
@@ -130,7 +140,7 @@ describe('Search Routes', () => {
             });
             testApp.use('/search', searchRouter);
 
-            const res = await request(testApp).get('/search?query=test');
+            const res = await request(testApp).get('/search?query=test&type=semantic');
 
             assert.strictEqual(res.statusCode, 200);
             assert.deepStrictEqual(serviceCallArgs[4], {
@@ -343,26 +353,46 @@ describe('Search Routes', () => {
     });
 
     describe('POST /', () => {
-        it('should redirect to the GET route with the query parameter', async () => {
+        it('should redirect to the GET route with the query parameter and default type', async () => {
             const res = await request(app).post('/search').send({ query: ' search term ' });
             assert.strictEqual(res.statusCode, 302);
-            assert.strictEqual(res.headers.location, '/search?query=search+term&pageNumber=1');
+            assert.strictEqual(
+                res.headers.location,
+                `/search?query=search+term&pageNumber=1&type=${DEFAULT_SEARCH_TYPE}`
+            );
         });
 
-        it('should preserve pageNumber in the redirect when provided', async () => {
+        it('should preserve pageNumber and type in the redirect when provided', async () => {
             const res = await request(app).post('/search?pageNumber=5').send({ query: 'test' });
             assert.strictEqual(res.statusCode, 302);
-            assert.strictEqual(res.headers.location, '/search?query=test&pageNumber=5');
+            assert.strictEqual(
+                res.headers.location,
+                `/search?query=test&pageNumber=5&type=${DEFAULT_SEARCH_TYPE}`
+            );
         });
 
-        it('ignores type field in POST body (flags are session-based)', async () => {
+        it('uses a valid type field in POST body so subsequent requests keep the current search mode', async () => {
             const res = await request(app)
                 .post('/search?pageNumber=2')
                 .send({ query: 'test', type: 'semantic' });
 
             assert.strictEqual(res.statusCode, 302);
-            // type is no longer carried through the redirect URL
-            assert.strictEqual(res.headers.location, '/search?query=test&pageNumber=2');
+            assert.strictEqual(
+                res.headers.location,
+                '/search?query=test&pageNumber=2&type=semantic'
+            );
+        });
+
+        it('falls back to the session/default type when the POST body type is invalid', async () => {
+            const res = await request(app)
+                .post('/search?pageNumber=2')
+                .send({ query: 'test', type: 'keyword,semantic' });
+
+            assert.strictEqual(res.statusCode, 302);
+            assert.strictEqual(
+                res.headers.location,
+                `/search?query=test&pageNumber=2&type=${DEFAULT_SEARCH_TYPE}`
+            );
         });
 
         it('handles errors in POST /search route', async () => {

--- a/search/routes.test.js
+++ b/search/routes.test.js
@@ -174,7 +174,9 @@ describe('Search Routes', () => {
                 res.status(500).send('Internal Server Error');
             });
 
-            const res = await request(testApp).get('/search?query=error');
+            const res = await request(testApp).get(
+                `/search?query=error&type=${DEFAULT_SEARCH_TYPE}`
+            );
             assert.strictEqual(res.statusCode, 500);
             assert.strictEqual(res.text, 'Internal Server Error');
         });
@@ -205,7 +207,7 @@ describe('Search Routes', () => {
             });
             testApp.use('/search', routerWithErrorService);
 
-            const res = await request(testApp).get('/search?query=bad');
+            const res = await request(testApp).get(`/search?query=bad&type=${DEFAULT_SEARCH_TYPE}`);
             assert.strictEqual(res.statusCode, 400);
         });
 
@@ -235,7 +237,7 @@ describe('Search Routes', () => {
             });
             testApp.use('/search', routerWithErrorService);
 
-            const res = await request(testApp).get('/search?query=bad');
+            const res = await request(testApp).get(`/search?query=bad&type=${DEFAULT_SEARCH_TYPE}`);
             assert.strictEqual(res.statusCode, 400);
         });
 
@@ -265,7 +267,7 @@ describe('Search Routes', () => {
             });
             testApp.use('/search', routerWithErrorService);
 
-            const res = await request(testApp).get('/search?query=a');
+            const res = await request(testApp).get(`/search?query=a&type=${DEFAULT_SEARCH_TYPE}`);
             assert.strictEqual(res.statusCode, 400);
             // Should use default anchor #error
             assert.ok(res.text.includes('error') || res.statusCode === 400);
@@ -300,7 +302,9 @@ describe('Search Routes', () => {
             });
             testApp.use('/search', routerWithErrorService);
 
-            const res = await request(testApp).get('/search?query=test');
+            const res = await request(testApp).get(
+                `/search?query=test&type=${DEFAULT_SEARCH_TYPE}`
+            );
             assert.strictEqual(res.statusCode, 400);
         });
 
@@ -346,7 +350,9 @@ describe('Search Routes', () => {
             });
             testApp.use('/search', routerWithResults);
 
-            const res = await request(testApp).get('/search?query=test');
+            const res = await request(testApp).get(
+                `/search?query=test&type=${DEFAULT_SEARCH_TYPE}`
+            );
             assert.strictEqual(res.statusCode, 200);
             assert.match(res.text, /search\/page\/results.njk/);
         });

--- a/search/search-pagination.test.js
+++ b/search/search-pagination.test.js
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { beforeEach, describe, it, mock } from 'node:test';
 import express from 'express';
 import request from 'supertest';
+import { DEFAULT_SEARCH_TYPE } from '../api/search/constants/searchTypes.js';
 import createSearchRouter from './routes.js';
 
 describe('Search Pagination Persistence', () => {
@@ -75,7 +76,9 @@ describe('Search Pagination Persistence', () => {
 
     describe('Search results enrichment', () => {
         it('should pass document search context to result items', async () => {
-            const res = await request(app).get('/search?query=test&pageNumber=3');
+            const res = await request(app).get(
+                `/search?query=test&pageNumber=3&type=${DEFAULT_SEARCH_TYPE}`
+            );
 
             assert.strictEqual(res.statusCode, 200);
             assert.ok(mockRender.lastParams);
@@ -88,7 +91,7 @@ describe('Search Pagination Persistence', () => {
         });
 
         it('should omit legacy back-link pagination context from result items', async () => {
-            const res = await request(app).get('/search?query=test');
+            const res = await request(app).get(`/search?query=test&type=${DEFAULT_SEARCH_TYPE}`);
 
             assert.strictEqual(res.statusCode, 200);
             const firstResult = mockRender.lastParams.searchResults[0];
@@ -108,7 +111,9 @@ describe('Search Pagination Persistence', () => {
 
     describe('Pagination metadata', () => {
         it('should calculate pagination correctly for page 1', async () => {
-            const res = await request(app).get('/search?query=test&pageNumber=1');
+            const res = await request(app).get(
+                `/search?query=test&pageNumber=1&type=${DEFAULT_SEARCH_TYPE}`
+            );
 
             assert.strictEqual(res.statusCode, 200);
             const pagination = mockRender.lastParams.pagination;

--- a/search/search-service.js
+++ b/search/search-service.js
@@ -24,12 +24,23 @@ function createSearchService({
      * @param {number} pageNumber - The page number of results to fetch.
      * @param {number} itemsPerPage - Number of items per page.
      * @param {string} token - The authentication token.
+     * @param {Object} [options] - Additional request options.
+     * @param {'keyword' | 'semantic' | 'hybrid'} [options.searchType='keyword'] - Which search mode to use.
      * @returns {Promise<object>} A promise that resolves to the search results.
      */
-    async function getSearchResults(query, pageNumber, itemsPerPage, token) {
+    async function getSearchResults(
+        query,
+        pageNumber,
+        itemsPerPage,
+        token,
+        { searchType = 'keyword' } = {}
+    ) {
         logger.info({ query, pageNumber, itemsPerPage }, 'Fetching search results');
         const opts = {
-            url: `${process.env.APP_API_URL}/search/?query=${query}&pageNumber=${pageNumber}&itemsPerPage=${itemsPerPage}`,
+            url:
+                `${process.env.APP_API_URL}/search/?query=${query}` +
+                `&pageNumber=${pageNumber}&itemsPerPage=${itemsPerPage}` +
+                `&type=${searchType}`,
             headers: {
                 'On-Behalf-Of': caseReferenceNumber
             }

--- a/search/search-service.js
+++ b/search/search-service.js
@@ -25,9 +25,7 @@ function createSearchService({
      * @param {number} itemsPerPage - Number of items per page.
      * @param {string} token - The authentication token.
      * @param {Object} [options] - Additional request options.
-     * @param {boolean} [options.useKeyword=true] - Enable lexical (BM25) keyword matching.
-     * @param {boolean} [options.useSemantic=false] - Enable neural (vector) semantic matching.
-     * @param {boolean} [options.useDates=true] - Enable date extraction and variant expansion.
+     * @param {string} [options.searchType='keyword-dates'] - Search mode (one of SEARCH_TYPES: keyword, keyword-dates, semantic, hybrid, hybrid-dates).
      * @returns {Promise<object>} A promise that resolves to the search results.
      */
     async function getSearchResults(
@@ -35,15 +33,14 @@ function createSearchService({
         pageNumber,
         itemsPerPage,
         token,
-        { useKeyword = true, useSemantic = false, useDates = true } = {}
+        { searchType = 'keyword-dates' } = {}
     ) {
         logger.info({ query, pageNumber, itemsPerPage }, 'Fetching search results');
-        const flag = (val) => (val ? 'on' : 'off');
         const opts = {
             url:
                 `${process.env.APP_API_URL}/search/?query=${query}` +
                 `&pageNumber=${pageNumber}&itemsPerPage=${itemsPerPage}` +
-                `&keyword=${flag(useKeyword)}&semantic=${flag(useSemantic)}&dates=${flag(useDates)}`,
+                `&type=${searchType}`,
             headers: {
                 'On-Behalf-Of': caseReferenceNumber
             }

--- a/search/search-service.js
+++ b/search/search-service.js
@@ -38,11 +38,12 @@ function createSearchService({
         { useKeyword = true, useSemantic = false, useDates = true } = {}
     ) {
         logger.info({ query, pageNumber, itemsPerPage }, 'Fetching search results');
+        const flag = (val) => (val ? 'on' : 'off');
         const opts = {
             url:
                 `${process.env.APP_API_URL}/search/?query=${query}` +
                 `&pageNumber=${pageNumber}&itemsPerPage=${itemsPerPage}` +
-                `&keyword=${useKeyword}&semantic=${useSemantic}&dates=${useDates}`,
+                `&keyword=${flag(useKeyword)}&semantic=${flag(useSemantic)}&dates=${flag(useDates)}`,
             headers: {
                 'On-Behalf-Of': caseReferenceNumber
             }

--- a/search/search-service.js
+++ b/search/search-service.js
@@ -25,7 +25,9 @@ function createSearchService({
      * @param {number} itemsPerPage - Number of items per page.
      * @param {string} token - The authentication token.
      * @param {Object} [options] - Additional request options.
-     * @param {'keyword' | 'semantic' | 'hybrid'} [options.searchType='keyword'] - Which search mode to use.
+     * @param {boolean} [options.useKeyword=true] - Enable lexical (BM25) keyword matching.
+     * @param {boolean} [options.useSemantic=false] - Enable neural (vector) semantic matching.
+     * @param {boolean} [options.useDates=true] - Enable date extraction and variant expansion.
      * @returns {Promise<object>} A promise that resolves to the search results.
      */
     async function getSearchResults(
@@ -33,14 +35,14 @@ function createSearchService({
         pageNumber,
         itemsPerPage,
         token,
-        { searchType = 'keyword' } = {}
+        { useKeyword = true, useSemantic = false, useDates = true } = {}
     ) {
         logger.info({ query, pageNumber, itemsPerPage }, 'Fetching search results');
         const opts = {
             url:
                 `${process.env.APP_API_URL}/search/?query=${query}` +
                 `&pageNumber=${pageNumber}&itemsPerPage=${itemsPerPage}` +
-                `&type=${searchType}`,
+                `&keyword=${useKeyword}&semantic=${useSemantic}&dates=${useDates}`,
             headers: {
                 'On-Behalf-Of': caseReferenceNumber
             }

--- a/search/search-service.js
+++ b/search/search-service.js
@@ -1,3 +1,4 @@
+import { DEFAULT_SEARCH_TYPE } from '../api/search/constants/searchTypes.js';
 import createRequestServiceDefault from '../service/request/index.js';
 
 /**
@@ -25,7 +26,7 @@ function createSearchService({
      * @param {number} itemsPerPage - Number of items per page.
      * @param {string} token - The authentication token.
      * @param {Object} [options] - Additional request options.
-     * @param {string} [options.searchType='keyword-dates'] - Search mode (one of SEARCH_TYPES: keyword, keyword-dates, semantic, hybrid, hybrid-dates).
+     * @param {string} [options.searchType=DEFAULT_SEARCH_TYPE] - Search mode (one of SEARCH_TYPES: keyword, keyword-dates, semantic, hybrid, hybrid-dates).
      * @returns {Promise<object>} A promise that resolves to the search results.
      */
     async function getSearchResults(
@@ -33,7 +34,7 @@ function createSearchService({
         pageNumber,
         itemsPerPage,
         token,
-        { searchType = 'keyword-dates' } = {}
+        { searchType = DEFAULT_SEARCH_TYPE } = {}
     ) {
         logger.info({ query, pageNumber, itemsPerPage }, 'Fetching search results');
         const opts = {

--- a/search/search-service.test.js
+++ b/search/search-service.test.js
@@ -33,16 +33,19 @@ describe('search-service', () => {
         const query = 'example';
         const pageNumber = 2;
         const itemsPerPage = 5;
+        const searchType = 'semantic';
 
         const req = { headers: { cookie: 'session=abc123' } };
-        const result = await service.getSearchResults(query, pageNumber, itemsPerPage, req);
+        const result = await service.getSearchResults(query, pageNumber, itemsPerPage, req, {
+            searchType
+        });
 
         assert.deepEqual(result, { body: { data: 'fake results' } });
         assert.equal(mockCreateRequestService.mock.callCount(), 1);
         const mockGetCallArguments = mockGet.mock.calls[0].arguments[0];
         assert.equal(
             mockGetCallArguments.url,
-            `${process.env.APP_API_URL}/search/?query=${query}&pageNumber=${pageNumber}&itemsPerPage=${itemsPerPage}`
+            `${process.env.APP_API_URL}/search/?query=${query}&pageNumber=${pageNumber}&itemsPerPage=${itemsPerPage}&type=semantic`
         );
         assert.equal(mockGetCallArguments.headers['On-Behalf-Of'], '12-745678');
     });

--- a/search/search-service.test.js
+++ b/search/search-service.test.js
@@ -33,10 +33,11 @@ describe('search-service', () => {
         const query = 'example';
         const pageNumber = 2;
         const itemsPerPage = 5;
-        const searchType = 'semantic';
 
         const result = await service.getSearchResults(query, pageNumber, itemsPerPage, undefined, {
-            searchType
+            useKeyword: false,
+            useSemantic: true,
+            useDates: false
         });
 
         assert.deepEqual(result, { body: { data: 'fake results' } });
@@ -44,7 +45,7 @@ describe('search-service', () => {
         const mockGetCallArguments = mockGet.mock.calls[0].arguments[0];
         assert.equal(
             mockGetCallArguments.url,
-            `${process.env.APP_API_URL}/search/?query=${query}&pageNumber=${pageNumber}&itemsPerPage=${itemsPerPage}&type=semantic`
+            `${process.env.APP_API_URL}/search/?query=${query}&pageNumber=${pageNumber}&itemsPerPage=${itemsPerPage}&keyword=false&semantic=true&dates=false`
         );
         assert.equal(mockGetCallArguments.headers['On-Behalf-Of'], '12-745678');
     });

--- a/search/search-service.test.js
+++ b/search/search-service.test.js
@@ -35,8 +35,7 @@ describe('search-service', () => {
         const itemsPerPage = 5;
         const searchType = 'semantic';
 
-        const req = { headers: { cookie: 'session=abc123' } };
-        const result = await service.getSearchResults(query, pageNumber, itemsPerPage, req, {
+        const result = await service.getSearchResults(query, pageNumber, itemsPerPage, undefined, {
             searchType
         });
 

--- a/search/search-service.test.js
+++ b/search/search-service.test.js
@@ -45,7 +45,7 @@ describe('search-service', () => {
         const mockGetCallArguments = mockGet.mock.calls[0].arguments[0];
         assert.equal(
             mockGetCallArguments.url,
-            `${process.env.APP_API_URL}/search/?query=${query}&pageNumber=${pageNumber}&itemsPerPage=${itemsPerPage}&keyword=false&semantic=true&dates=false`
+            `${process.env.APP_API_URL}/search/?query=${query}&pageNumber=${pageNumber}&itemsPerPage=${itemsPerPage}&keyword=off&semantic=on&dates=off`
         );
         assert.equal(mockGetCallArguments.headers['On-Behalf-Of'], '12-745678');
     });

--- a/search/search-service.test.js
+++ b/search/search-service.test.js
@@ -35,9 +35,7 @@ describe('search-service', () => {
         const itemsPerPage = 5;
 
         const result = await service.getSearchResults(query, pageNumber, itemsPerPage, undefined, {
-            useKeyword: false,
-            useSemantic: true,
-            useDates: false
+            searchType: 'semantic'
         });
 
         assert.deepEqual(result, { body: { data: 'fake results' } });
@@ -45,7 +43,7 @@ describe('search-service', () => {
         const mockGetCallArguments = mockGet.mock.calls[0].arguments[0];
         assert.equal(
             mockGetCallArguments.url,
-            `${process.env.APP_API_URL}/search/?query=${query}&pageNumber=${pageNumber}&itemsPerPage=${itemsPerPage}&keyword=off&semantic=on&dates=off`
+            `${process.env.APP_API_URL}/search/?query=${query}&pageNumber=${pageNumber}&itemsPerPage=${itemsPerPage}&type=semantic`
         );
         assert.equal(mockGetCallArguments.headers['On-Behalf-Of'], '12-745678');
     });


### PR DESCRIPTION
This PR updates the search experience to make the active “search type” (e.g., hybrid-dates, semantic) explicit and persistent via URLs and form submissions, while also updating query-building internals and improving static asset caching/logging behavior.

Changes:

- Preserve and enforce the type search mode across search pages, pagination, and document viewer links (including a new middleware to canonicalize URLs).
- Update feature-flag parsing/docs for the new type semantics and add template coverage to ensure the mode is carried through hidden inputs/links.
- Refactor OpenSearch query DSL construction (configurable tuning via queryDslConfig, shift from bool.must → bool.filter) and adjust logging + static asset cache headers.