### PR TITLE
Cherry pick from fork feat hybrid search

### DIFF
--- a/api/DAL/document-dal.js
+++ b/api/DAL/document-dal.js
@@ -127,7 +127,7 @@ function createDocumentDAL({
 
             // safe query hash for correlation, not raw text.
             const queryHash = crypto.createHash('sha256').update(keyword).digest('hex').slice(0, 8);
-            logger.info(
+            logger?.debug?.(
                 {
                     index: process.env.OPENSEARCH_INDEX_CHUNKS_NAME,
                     queryBody,

--- a/api/DAL/document-dal.test.js
+++ b/api/DAL/document-dal.test.js
@@ -125,9 +125,10 @@ describe('document-dal', () => {
 
         await dal.getDocumentsChunksByKeyword('keyword', 2, 10);
 
+        // Assertions are structural so the test does not couple to production tuning
+        // constants in DEFAULT_QUERY_DSL_CONFIG (min_score, boosts, k may change).
         assert.equal(typeof queryArgs.body.min_score, 'number');
         assert.ok(queryArgs.body.min_score >= 0);
-        assert.ok(queryArgs.body.min_score <= 1);
         assert.deepStrictEqual(queryArgs.body.query.bool.filter, [
             { term: { case_ref: '12-745678' } }
         ]);
@@ -139,10 +140,12 @@ describe('document-dal', () => {
             (clause) => clause.neural?.embedding
         );
         assert.equal(keywordClause.match.chunk_text.query, 'keyword');
-        assert.equal(keywordClause.match.chunk_text.boost, 20);
+        assert.equal(typeof keywordClause.match.chunk_text.boost, 'number');
+        assert.ok(keywordClause.match.chunk_text.boost > 0);
         assert.equal(typeof neuralClause.neural.embedding.k, 'number');
         assert.ok(neuralClause.neural.embedding.k > 0);
-        assert.equal(neuralClause.neural.embedding.boost, 4);
+        assert.equal(typeof neuralClause.neural.embedding.boost, 'number');
+        assert.ok(neuralClause.neural.embedding.boost > 0);
     });
 
     it('Should rethrow if an error if db.query throws', async () => {
@@ -687,7 +690,6 @@ describe('document-dal', () => {
 
             assert.equal(typeof queryArgs.body.min_score, 'number');
             assert.ok(queryArgs.body.min_score >= 0);
-            assert.ok(queryArgs.body.min_score <= 1);
             assert.equal(queryArgs.body.query.neural.embedding.query_text, 'needle');
             assert.deepStrictEqual(queryArgs.body.query.neural.embedding.filter, {
                 bool: {

--- a/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
+++ b/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
@@ -349,17 +349,27 @@ describe('buildQueryJson', () => {
     });
 
     it('Should build a hybrid query when searchType is hybrid', () => {
+        // Test owns its tuning via explicit overrides so it is decoupled from
+        // production defaults in DEFAULT_QUERY_DSL_CONFIG.
+        const testQueryDslConfig = {
+            semanticMinScore: 0.5,
+            semanticK: 50,
+            lexicalBoost: 20,
+            dateBoost: 1,
+            neuralBoost: 4
+        };
         const params = {
             keyword: 'Important meeting',
             caseReferenceNumber: '26-711111',
             pageNumber: 2,
             itemsPerPage: 5,
-            options: { searchType: 'hybrid' }
+            options: { searchType: 'hybrid', queryDslConfig: testQueryDslConfig }
         };
 
         const expected = {
             from: 5,
             size: 5,
+            min_score: 0.5,
             query: {
                 bool: {
                     filter: [{ term: { case_ref: '26-711111' } }],
@@ -376,6 +386,7 @@ describe('buildQueryJson', () => {
                             neural: {
                                 embedding: {
                                     query_text: 'Important meeting',
+                                    k: 50,
                                     filter: { term: { case_ref: '26-711111' } },
                                     boost: 4
                                 }
@@ -388,21 +399,7 @@ describe('buildQueryJson', () => {
         };
 
         const result = buildQueryJson(params);
-        assert.equal(typeof result.min_score, 'number');
-        assert.ok(result.min_score >= 0);
-        assert.ok(result.min_score <= 1);
-
-        const { min_score: _hybridMinScore, ...resultWithoutMinScore } = result;
-        const hybridNeuralClause = resultWithoutMinScore.query.bool.should.find(
-            (clause) => clause.neural?.embedding
-        );
-        const { k: hybridK, ...hybridEmbeddingWithoutK } = hybridNeuralClause.neural.embedding;
-        assert.equal(typeof hybridK, 'number');
-        assert.ok(hybridK > 0);
-        hybridNeuralClause.neural.embedding = hybridEmbeddingWithoutK;
-        // Update expected filter to match what code now produces
-        expected.query.bool.filter = [{ term: { case_ref: '26-711111' } }];
-        assert.deepStrictEqual(resultWithoutMinScore, expected);
+        assert.deepStrictEqual(result, expected);
     });
 
     it('Should build a semantic query when searchType is semantic', () => {
@@ -411,16 +408,28 @@ describe('buildQueryJson', () => {
             caseReferenceNumber: '26-711111',
             pageNumber: 2,
             itemsPerPage: 5,
-            options: { searchType: 'semantic' }
+            options: {
+                searchType: 'semantic',
+                queryDslConfig: {
+                    // Pure semantic mode uses semanticOnlyMinScore (cosine 0..1).
+                    semanticOnlyMinScore: 0.5,
+                    semanticK: 50,
+                    lexicalBoost: 20,
+                    dateBoost: 1,
+                    neuralBoost: 4
+                }
+            }
         };
 
         const expected = {
             from: 5,
             size: 5,
+            min_score: 0.5,
             query: {
                 neural: {
                     embedding: {
                         query_text: 'Important meeting',
+                        k: 50,
                         filter: {
                             term: {
                                 case_ref: '26-711111'
@@ -432,26 +441,25 @@ describe('buildQueryJson', () => {
         };
 
         const result = buildQueryJson(params);
-        assert.equal(typeof result.min_score, 'number');
-        assert.ok(result.min_score >= 0);
-        assert.ok(result.min_score <= 1);
-
-        const { min_score: _semanticMinScore, ...resultWithoutMinScore } = result;
-        const { k: semanticK, ...semanticEmbeddingWithoutK } =
-            resultWithoutMinScore.query.neural.embedding;
-        assert.equal(typeof semanticK, 'number');
-        assert.ok(semanticK > 0);
-        resultWithoutMinScore.query.neural.embedding = semanticEmbeddingWithoutK;
-        assert.deepStrictEqual(resultWithoutMinScore, expected);
+        assert.deepStrictEqual(result, expected);
     });
 
     it('Should apply separate boosts for date and keyword clauses in hybrid mode', () => {
+        // Test owns its tuning via explicit overrides so assertions don't depend
+        // on production tuning in DEFAULT_QUERY_DSL_CONFIG.
+        const testQueryDslConfig = {
+            semanticMinScore: 0.5,
+            semanticK: 50,
+            lexicalBoost: 17,
+            dateBoost: 3,
+            neuralBoost: 11
+        };
         const params = {
             keyword: 'brain injury september 2021',
             caseReferenceNumber: '26-711111',
             pageNumber: 1,
             itemsPerPage: 5,
-            options: { searchType: 'hybrid-dates' }
+            options: { searchType: 'hybrid-dates', queryDslConfig: testQueryDslConfig }
         };
 
         const result = buildQueryJson(params);
@@ -465,10 +473,10 @@ describe('buildQueryJson', () => {
         const lexicalFilter = result.query.bool.filter;
         assert.ok(Array.isArray(lexicalFilter) && lexicalFilter[0]?.term?.case_ref === '26-711111');
         assert.strictEqual(result.query.bool.minimum_should_match, 1);
-        assert.strictEqual(dateBoolClause.bool.boost, 1);
+        assert.strictEqual(dateBoolClause.bool.boost, 3);
         assert.strictEqual(dateBoolClause.bool.minimum_should_match, 1);
-        assert.strictEqual(keywordClause.match.chunk_text.boost, 20);
-        assert.strictEqual(neuralClause.neural.embedding.boost, 4);
+        assert.strictEqual(keywordClause.match.chunk_text.boost, 17);
+        assert.strictEqual(neuralClause.neural.embedding.boost, 11);
     });
 
     it('Should correctly compute hybrid pagination when page params are strings', () => {
@@ -832,11 +840,13 @@ describe('buildQueryJson', () => {
     });
 
     it('Should apply queryDslConfig overrides for min score, k and default boosts', () => {
+        // Use a simple first-page request and verify the configured semanticK
+        // override is passed through unchanged in the built query.
         const result = buildQueryJson({
             keyword: 'acute 28/11/2022',
             caseReferenceNumber: '26-711111',
             pageNumber: 1,
-            itemsPerPage: 10,
+            itemsPerPage: 5,
             options: {
                 searchType: 'hybrid-dates',
                 queryDslConfig: {
@@ -1067,7 +1077,9 @@ describe('buildQueryJson', () => {
             documentId: 'doc-456',
             queryDslConfig: {
                 semanticK: 11,
-                semanticMinScore: 0.66
+                // Pure neural mode uses semanticOnlyMinScore (cosine 0..1 range),
+                // not semanticMinScore (which is for combined hybrid scores).
+                semanticOnlyMinScore: 0.66
             }
         });
 
@@ -1105,6 +1117,16 @@ describe('buildQueryJson', () => {
     it('Should fall back to defaults when queryDslConfig contains undefined values', () => {
         // When overrides contain undefined values, they should not replace defaults.
         // This ensures partial config objects like { semanticK: undefined } don't break queries.
+        const baseline = buildQueryJson({
+            keyword: 'test search',
+            caseReferenceNumber: '26-711111',
+            pageNumber: 1,
+            itemsPerPage: 10,
+            options: {
+                searchType: SEARCH_TYPES.SEMANTIC
+            }
+        });
+
         const result = buildQueryJson({
             keyword: 'test search',
             caseReferenceNumber: '26-711111',
@@ -1120,11 +1142,9 @@ describe('buildQueryJson', () => {
             }
         });
 
-        const neuralEmbedding = result.query.neural.embedding;
-        // Should use the default semanticK (15) not undefined
-        assert.strictEqual(neuralEmbedding.k, 15);
-        // Should use the default semanticMinScore (0.55) not undefined
-        assert.strictEqual(result.min_score, 0.55);
+        // Undefined overrides should behave exactly like no overrides.
+        assert.strictEqual(result.query.neural.embedding.k, baseline.query.neural.embedding.k);
+        assert.strictEqual(result.min_score, baseline.min_score);
     });
 
     it('Should remove min_score from hybrid query when keyword is empty with no date phrases', () => {

--- a/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
+++ b/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
@@ -909,7 +909,7 @@ describe('buildQueryJson', () => {
 
         assert.strictEqual(result.query.bool.filter[0].term.case_ref, '26-711111');
         assert.ok(debugCalls.length >= 5);
-        assert.strictEqual(infoCalls.length, 1);
+        assert.strictEqual(infoCalls.length, 0);
         assert.strictEqual(warnCalls.length, 0);
 
         const debugMessages = debugCalls.map((call) => call[1]).filter(Boolean);

--- a/api/DAL/utils/buildQueryJson/index.js
+++ b/api/DAL/utils/buildQueryJson/index.js
@@ -70,10 +70,8 @@ function buildQueryJson({
 }) {
     const buildStart = Date.now();
 
-    const { safePageNumber, safeItemsPerPage } = normalisePagination(pageNumber, itemsPerPage);
-
-    // Only build a new queryTypeBuilders map when queryDslConfig overrides are supplied.
-    // Otherwise reuse the module-level default map to avoid per-request allocations.
+    // Re-use the module-level default builder map when no config overrides are
+    // provided — avoids rebuilding the map and re-merging config on every request.
     const queryTypeBuilders = queryDslConfig
         ? createQueryTypeBuilders({ queryDslConfig })
         : defaultQueryTypeBuilders;
@@ -86,6 +84,8 @@ function buildQueryJson({
             `Invalid searchType "${searchType}". Must be one of: ${Object.values(SEARCH_TYPES).join(', ')}`
         );
     }
+
+    const { safePageNumber, safeItemsPerPage } = normalisePagination(pageNumber, itemsPerPage);
 
     const builderParams = {
         keyword,

--- a/api/DAL/utils/buildQueryJson/index.js
+++ b/api/DAL/utils/buildQueryJson/index.js
@@ -73,10 +73,10 @@ function buildQueryJson({
     const { safePageNumber, safeItemsPerPage } = normalisePagination(pageNumber, itemsPerPage);
 
     // Only build a new queryTypeBuilders map when queryDslConfig overrides are supplied.
-     // Otherwise reuse the module-level default map to avoid per-request allocations.
-     const queryTypeBuilders = queryDslConfig
-         ? createQueryTypeBuilders({ queryDslConfig })
-         : defaultQueryTypeBuilders;
+    // Otherwise reuse the module-level default map to avoid per-request allocations.
+    const queryTypeBuilders = queryDslConfig
+        ? createQueryTypeBuilders({ queryDslConfig })
+        : defaultQueryTypeBuilders;
     // dispatch to the appropriate mode-specific builder. Each builder handles
     // its own date preprocessing (keyword and hybrid extract dates, semantic
     // skips preprocessing entirely for efficiency).

--- a/api/DAL/utils/buildQueryJson/index.js
+++ b/api/DAL/utils/buildQueryJson/index.js
@@ -70,12 +70,13 @@ function buildQueryJson({
 }) {
     const buildStart = Date.now();
 
-    // Re-use the module-level default builder map when no config overrides are
-    // provided — avoids rebuilding the map and re-merging config on every request.
-    const queryTypeBuilders = queryDslConfig
-        ? createQueryTypeBuilders({ queryDslConfig })
-        : defaultQueryTypeBuilders;
+    const { safePageNumber, safeItemsPerPage } = normalisePagination(pageNumber, itemsPerPage);
 
+    // Only build a new queryTypeBuilders map when queryDslConfig overrides are supplied.
+     // Otherwise reuse the module-level default map to avoid per-request allocations.
+     const queryTypeBuilders = queryDslConfig
+         ? createQueryTypeBuilders({ queryDslConfig })
+         : defaultQueryTypeBuilders;
     // dispatch to the appropriate mode-specific builder. Each builder handles
     // its own date preprocessing (keyword and hybrid extract dates, semantic
     // skips preprocessing entirely for efficiency).
@@ -85,8 +86,6 @@ function buildQueryJson({
             `Invalid searchType "${searchType}". Must be one of: ${Object.values(SEARCH_TYPES).join(', ')}`
         );
     }
-
-    const { safePageNumber, safeItemsPerPage } = normalisePagination(pageNumber, itemsPerPage);
 
     const builderParams = {
         keyword,

--- a/api/DAL/utils/buildQueryJson/queryTypeBuilders.js
+++ b/api/DAL/utils/buildQueryJson/queryTypeBuilders.js
@@ -22,12 +22,14 @@ import generateDateFormatVariants from '../generateDateFormatVariants/index.js';
  * behavioural tests to production tuning constants.
  */
 export const DEFAULT_QUERY_DSL_CONFIG = Object.freeze({
-    /** @type {number} Minimum neural score — needs tuning or replaced with a low K value. */
-    semanticMinScore: 0.55,
-    /** @type {number} Default number of nearest-neighbour candidates for neural queries. */
-    semanticK: 15,
+    /** @type {number} Minimum score threshold for hybrid queries where lexical, date, and neural scores combine after boosting. */
+    semanticMinScore: 2.25,
+    /** @type {number} Minimum score threshold for pure neural queries — cosine similarity is bounded to 0..1, so a lower cut-off applies. */
+    semanticOnlyMinScore: 0.5,
+    /** @type {number} Number of nearest-neighbour candidates for neural queries. Set high enough to cover the deepest expected pagination so result ranking is stable across pages. */
+    semanticK: 250,
     lexicalBoost: 20,
-    dateBoost: 1,
+    dateBoost: 4,
     neuralBoost: 4
 });
 
@@ -293,7 +295,7 @@ export function buildSemanticQuery({
     matchPhraseClauses = [],
     queryDslConfig = DEFAULT_QUERY_DSL_CONFIG
 }) {
-    const { semanticK, semanticMinScore } = queryDslConfig;
+    const { semanticK, semanticMinScore, semanticOnlyMinScore } = queryDslConfig;
 
     // When date phrases are present, produce a bool query with the neural clause and
     // date phrase clauses as sibling should branches. A non-empty keyword is implied
@@ -334,7 +336,7 @@ export function buildSemanticQuery({
         keyword,
         caseReferenceNumber,
         semanticK,
-        semanticMinScore
+        semanticMinScore: semanticOnlyMinScore
     });
 
     if (documentId) {

--- a/api/DAL/utils/logQueryMetrics/index.js
+++ b/api/DAL/utils/logQueryMetrics/index.js
@@ -50,7 +50,7 @@ function logQueryMetrics({
         return;
     }
 
-    logger.info(
+    logger?.debug?.(
         {
             caseReferenceNumber,
             ...metrics

--- a/api/app.js
+++ b/api/app.js
@@ -10,7 +10,9 @@ import swaggerUi from 'swagger-ui-express';
 import createApiRouter from './document/routes.js';
 import errorHandler from './middleware/errorHandler/index.js';
 import authenticateJWTToken from './middleware/jwt-authentication/index.js';
-import dynamicRateLimiter from './middleware/rateLimiter/index.js';
+import dynamicRateLimiter, {
+    unauthenticatedApiRateLimiter
+} from './middleware/rateLimiter/index.js';
 import createOpenApiValidatorMiddleware from './middleware/validator/index.js';
 import createSearchService from './search/search-service.js';
 
@@ -97,8 +99,11 @@ export default async function createApi(options = {}) {
 
     app.use(
         '/',
-        dynamicRateLimiter,
+        // Defense-in-depth: Rate limit by IP before auth to prevent brute-force attacks on the token endpoint
+        unauthenticatedApiRateLimiter,
         authenticateJWTToken,
+        // Rate limit authenticated users by user ID after successful auth
+        dynamicRateLimiter,
         apiSetupMiddleware,
         openApiValidator,
         apiRouter

--- a/api/app.js
+++ b/api/app.js
@@ -10,9 +10,7 @@ import swaggerUi from 'swagger-ui-express';
 import createApiRouter from './document/routes.js';
 import errorHandler from './middleware/errorHandler/index.js';
 import authenticateJWTToken from './middleware/jwt-authentication/index.js';
-import dynamicRateLimiter, {
-    unauthenticatedApiRateLimiter
-} from './middleware/rateLimiter/index.js';
+import dynamicRateLimiter from './middleware/rateLimiter/index.js';
 import createOpenApiValidatorMiddleware from './middleware/validator/index.js';
 import createSearchService from './search/search-service.js';
 
@@ -99,8 +97,6 @@ export default async function createApi(options = {}) {
 
     app.use(
         '/',
-        // Defense-in-depth: Rate limit by IP before auth to prevent brute-force attacks on the token endpoint
-        unauthenticatedApiRateLimiter,
         authenticateJWTToken,
         // Rate limit authenticated users by user ID after successful auth
         dynamicRateLimiter,

--- a/api/app.test.js
+++ b/api/app.test.js
@@ -374,23 +374,6 @@ describe('API Application', () => {
             assert.strictEqual(secondUserFirstRequest.statusCode, 200);
         });
 
-        test('rate limits unauthenticated API requests in production', async () => {
-            process.env.NODE_ENV = 'production';
-            process.env.API_RATE_LIMIT_MAX_UNAUTH = '2';
-
-            const prodLikeApp = await createApi({
-                createSearchService: mockCreateSearchService
-            });
-
-            const first = await request(prodLikeApp).get('/search?query=test');
-            const second = await request(prodLikeApp).get('/search?query=test');
-            const third = await request(prodLikeApp).get('/search?query=test');
-
-            assert.strictEqual(first.statusCode, 401);
-            assert.strictEqual(second.statusCode, 401);
-            assert.strictEqual(third.statusCode, 429);
-        });
-
         test('returns 403 when JWT is valid but missing required identity claims', async () => {
             const identitylessToken = signApiToken({ email: 'missing-identity@example.com' });
 

--- a/api/app.test.js
+++ b/api/app.test.js
@@ -6,11 +6,14 @@ import createApi from './app.js';
 
 const API_ENV_VARS = [
     'APP_LOG_LEVEL',
+    'NODE_ENV',
     'DEPLOY_ENV',
     'npm_package_version',
     'APP_JWT_SECRET',
     'APP_API_JWT_ISSUER',
-    'APP_API_JWT_AUDIENCE'
+    'APP_API_JWT_AUDIENCE',
+    'API_RATE_LIMIT_MAX_AUTH',
+    'API_RATE_LIMIT_MAX_UNAUTH'
 ];
 
 /**
@@ -274,6 +277,133 @@ describe('API Application', () => {
 
             assert.match(res.headers['content-type'], /application\/vnd\.api\+json/);
             assert.strictEqual(res.headers['application-version'], '1.0.0-test');
+        });
+
+        test('rate limits authenticated API requests in production using API_RATE_LIMIT_MAX_AUTH', async () => {
+            process.env.NODE_ENV = 'production';
+            process.env.API_RATE_LIMIT_MAX_AUTH = '2';
+            process.env.API_RATE_LIMIT_MAX_UNAUTH = '1';
+
+            const prodLikeApp = await createApi({
+                createSearchService: mockCreateSearchService
+            });
+
+            const token = signApiToken({ userId: 'auth-rate-limit-user' });
+
+            const first = await request(prodLikeApp)
+                .get('/search?query=test&pageNumber=1&itemsPerPage=1')
+                .set('Authorization', `Bearer ${token}`)
+                .set('On-Behalf-Of', '25-711111');
+
+            const second = await request(prodLikeApp)
+                .get('/search?query=test&pageNumber=1&itemsPerPage=1')
+                .set('Authorization', `Bearer ${token}`)
+                .set('On-Behalf-Of', '25-711111');
+
+            const third = await request(prodLikeApp)
+                .get('/search?query=test&pageNumber=1&itemsPerPage=1')
+                .set('Authorization', `Bearer ${token}`)
+                .set('On-Behalf-Of', '25-711111');
+
+            assert.strictEqual(first.statusCode, 200);
+            assert.strictEqual(second.statusCode, 200);
+            assert.strictEqual(third.statusCode, 429);
+        });
+
+        test('applies authenticated rate limits independently for different JWT users', async () => {
+            process.env.NODE_ENV = 'production';
+            process.env.API_RATE_LIMIT_MAX_AUTH = '1';
+            process.env.API_RATE_LIMIT_MAX_UNAUTH = '1';
+
+            const prodLikeApp = await createApi({
+                createSearchService: mockCreateSearchService
+            });
+
+            const firstUserToken = signApiToken({ userId: 'rate-user-1' });
+            const secondUserToken = signApiToken({ userId: 'rate-user-2' });
+
+            const firstUserFirstRequest = await request(prodLikeApp)
+                .get('/search?query=test&pageNumber=1&itemsPerPage=1')
+                .set('Authorization', `Bearer ${firstUserToken}`)
+                .set('On-Behalf-Of', '25-711111');
+
+            const firstUserSecondRequest = await request(prodLikeApp)
+                .get('/search?query=test&pageNumber=1&itemsPerPage=1')
+                .set('Authorization', `Bearer ${firstUserToken}`)
+                .set('On-Behalf-Of', '25-711111');
+
+            const secondUserFirstRequest = await request(prodLikeApp)
+                .get('/search?query=test&pageNumber=1&itemsPerPage=1')
+                .set('Authorization', `Bearer ${secondUserToken}`)
+                .set('On-Behalf-Of', '25-711111');
+
+            assert.strictEqual(firstUserFirstRequest.statusCode, 200);
+            assert.strictEqual(firstUserSecondRequest.statusCode, 429);
+            assert.strictEqual(secondUserFirstRequest.statusCode, 200);
+        });
+
+        test('applies authenticated rate limits independently when JWT identity is username', async () => {
+            process.env.NODE_ENV = 'production';
+            process.env.API_RATE_LIMIT_MAX_AUTH = '1';
+            process.env.API_RATE_LIMIT_MAX_UNAUTH = '1';
+
+            const prodLikeApp = await createApi({
+                createSearchService: mockCreateSearchService
+            });
+
+            const firstUsernameToken = signApiToken({ username: 'username-user-1' });
+            const secondUsernameToken = signApiToken({ username: 'username-user-2' });
+
+            const firstUserFirstRequest = await request(prodLikeApp)
+                .get('/search?query=test&pageNumber=1&itemsPerPage=1')
+                .set('Authorization', `Bearer ${firstUsernameToken}`)
+                .set('On-Behalf-Of', '25-711111');
+
+            const firstUserSecondRequest = await request(prodLikeApp)
+                .get('/search?query=test&pageNumber=1&itemsPerPage=1')
+                .set('Authorization', `Bearer ${firstUsernameToken}`)
+                .set('On-Behalf-Of', '25-711111');
+
+            const secondUserFirstRequest = await request(prodLikeApp)
+                .get('/search?query=test&pageNumber=1&itemsPerPage=1')
+                .set('Authorization', `Bearer ${secondUsernameToken}`)
+                .set('On-Behalf-Of', '25-711111');
+
+            assert.strictEqual(firstUserFirstRequest.statusCode, 200);
+            assert.strictEqual(firstUserSecondRequest.statusCode, 429);
+            assert.strictEqual(secondUserFirstRequest.statusCode, 200);
+        });
+
+        test('rate limits unauthenticated API requests in production', async () => {
+            process.env.NODE_ENV = 'production';
+            process.env.API_RATE_LIMIT_MAX_UNAUTH = '2';
+
+            const prodLikeApp = await createApi({
+                createSearchService: mockCreateSearchService
+            });
+
+            const first = await request(prodLikeApp).get('/search?query=test');
+            const second = await request(prodLikeApp).get('/search?query=test');
+            const third = await request(prodLikeApp).get('/search?query=test');
+
+            assert.strictEqual(first.statusCode, 401);
+            assert.strictEqual(second.statusCode, 401);
+            assert.strictEqual(third.statusCode, 429);
+        });
+
+        test('returns 403 when JWT is valid but missing required identity claims', async () => {
+            const identitylessToken = signApiToken({ email: 'missing-identity@example.com' });
+
+            const res = await request(app)
+                .get('/search?query=test&pageNumber=1&itemsPerPage=1')
+                .set('Authorization', `Bearer ${identitylessToken}`)
+                .set('On-Behalf-Of', '25-711111');
+
+            assert.strictEqual(res.statusCode, 403);
+            assert.strictEqual(
+                res.body.errors[0].detail,
+                'Authentication token is missing required identity claims'
+            );
         });
     });
 

--- a/api/middleware/jwt-authentication/index.js
+++ b/api/middleware/jwt-authentication/index.js
@@ -7,11 +7,15 @@ import normalizeApiJwtUser from '../utils/normalizeApiJwtUser.js';
  */
 function getTokenFromRequest(req) {
     const authHeader = req.headers?.authorization;
-    if (!authHeader) return null;
+    if (!authHeader) {
+        return null;
+    }
 
     // Must follow: "Bearer <token>"
     const [scheme, token] = authHeader.split(' ');
-    if (scheme !== 'Bearer' || !token) return null;
+    if (scheme !== 'Bearer' || !token) {
+        return null;
+    }
 
     return token;
 }

--- a/api/middleware/jwt-authentication/index.js
+++ b/api/middleware/jwt-authentication/index.js
@@ -1,5 +1,6 @@
 import jwt from 'jsonwebtoken';
 import { getApiJwtAudience, getApiJwtIssuer } from '../../auth/apiJwtClaims/index.js';
+import normalizeApiJwtUser from '../utils/normalizeApiJwtUser.js';
 
 /**
  * Extracts a bearer token from the Authorization header.
@@ -25,6 +26,10 @@ function getTokenFromRequest(req) {
  * @param {Function} next - Express next middleware function.
  */
 function authenticateJWTToken(req, res, next) {
+    if (req.apiJwtVerified === true && req.user) {
+        return next();
+    }
+
     const token = getTokenFromRequest(req);
 
     if (!token) {
@@ -69,7 +74,22 @@ function authenticateJWTToken(req, res, next) {
 
     try {
         const user = jwt.verify(token, process.env.APP_JWT_SECRET, jwtVerificationOptions);
-        req.user = user;
+        req.user = normalizeApiJwtUser(user);
+        if (req.user?.id == null || req.user.id === '') {
+            req.log?.warn(
+                { url: req.originalUrl },
+                'Authentication token is missing a usable identity claim'
+            );
+            return res.status(403).json({
+                errors: [
+                    {
+                        status: '403',
+                        title: 'Forbidden',
+                        detail: 'Authentication token is missing required identity claims'
+                    }
+                ]
+            });
+        }
         next();
     } catch (err) {
         req.log?.warn({ url: req.originalUrl, error: err.message }, 'Invalid authentication token');

--- a/api/middleware/jwt-authentication/index.test.js
+++ b/api/middleware/jwt-authentication/index.test.js
@@ -160,3 +160,45 @@ test('authenticateToken returns 500 when auth configuration is invalid', async (
         'Authentication service is not configured correctly'
     );
 });
+
+test('authenticateToken normalizes to username when userId is null', async () => {
+    const token = jwt.sign({ userId: null, username: 'fallback-user' }, SECRET, {
+        issuer: process.env.APP_API_JWT_ISSUER,
+        audience: process.env.APP_API_JWT_AUDIENCE,
+        algorithm: 'HS256'
+    });
+    const req = createMockReq({ token });
+    const res = createMockRes();
+    let calledNext = false;
+
+    await authenticateToken(req, res, () => {
+        calledNext = true;
+    });
+
+    assert.equal(req.user.id, 'fallback-user');
+    assert.equal(req.user.username, 'fallback-user');
+    assert.ok(calledNext);
+});
+
+test('authenticateToken returns 403 when token has no usable identity claims', async () => {
+    const token = jwt.sign({ email: 'test@example.com' }, SECRET, {
+        issuer: process.env.APP_API_JWT_ISSUER,
+        audience: process.env.APP_API_JWT_AUDIENCE,
+        algorithm: 'HS256'
+    });
+    const req = createMockReq({ token });
+    const res = createMockRes();
+    let calledNext = false;
+
+    await authenticateToken(req, res, () => {
+        calledNext = true;
+    });
+
+    assert.equal(res.statusCode, 403);
+    assert.ok(res.jsonBody);
+    assert.equal(
+        res.jsonBody.errors[0].detail,
+        'Authentication token is missing required identity claims'
+    );
+    assert.equal(calledNext, false);
+});

--- a/api/middleware/rateLimiter/index.js
+++ b/api/middleware/rateLimiter/index.js
@@ -14,8 +14,6 @@
  * @type {import('express').RequestHandler}
  */
 import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
-import jwt from 'jsonwebtoken';
-import { getApiJwtAudience, getApiJwtIssuer } from '../../auth/apiJwtClaims/index.js';
 import normalizeApiJwtUser from '../utils/normalizeApiJwtUser.js';
 
 /**
@@ -24,74 +22,6 @@ import normalizeApiJwtUser from '../utils/normalizeApiJwtUser.js';
  * @type {number}
  */
 const WINDOW_MS = Number(process.env.API_RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000;
-
-/**
- * Returns the Bearer token from the Authorization header if present and well-formed.
- *
- * @param {*} req - Express request object
- * @returns {*} - The Bearer token string if present and valid, or null if not found or malformed
- */
-function getBearerToken(req) {
-    const authHeader = req.headers?.authorization;
-    if (!authHeader) {
-        return null;
-    }
-
-    const [scheme, token] = authHeader.split(' ');
-    if (scheme !== 'Bearer' || !token) {
-        return null;
-    }
-
-    return token;
-}
-
-/**
- * Checks if the request has a valid API JWT token.
- *
- * @param {*} req - Express request object
- * @returns {boolean} - True if the request has a valid API JWT token, false otherwise
- */
-function hasValidApiJwt(req) {
-    const token = getBearerToken(req);
-    if (!token || !process.env.APP_JWT_SECRET) {
-        return false;
-    }
-
-    try {
-        const user = jwt.verify(token, process.env.APP_JWT_SECRET, {
-            algorithms: ['HS256'],
-            issuer: getApiJwtIssuer(),
-            audience: getApiJwtAudience()
-        });
-
-        req.user = normalizeApiJwtUser(user);
-        if (req.user?.id == null || req.user.id === '') {
-            return false;
-        }
-        req.apiJwtVerified = true; // marker for auth middleware short-circuit
-        return true;
-    } catch {
-        return false;
-    }
-}
-
-/**
- * Rate limiter for unauthenticated API requests.
- *
- * @type {*} - Express middleware that applies a stricter rate limit to unauthenticated requests.
- * Authenticated requests (with a valid API JWT) are not subject to this limiter.
- * The limit and window duration are configurable via environment variables.
- * Responds with HTTP 429 and a JSON error message when the limit is exceeded.
- */
-const unauthenticatedApiRateLimiter = rateLimit({
-    windowMs: WINDOW_MS,
-    limit: () => Number(process.env.API_RATE_LIMIT_MAX_UNAUTH) || 50,
-    keyGenerator: (req) => ipKeyGenerator(req.ip),
-    skip: (req) => process.env.NODE_ENV !== 'production' || hasValidApiJwt(req),
-    handler: (req, res) => {
-        res.status(429).json({ error: 'Too many requests, please try again later' });
-    }
-});
 
 /**
  * Dynamic rate limiter for API requests based on authentication status.
@@ -119,5 +49,4 @@ const dynamicRateLimiter = rateLimit({
     }
 });
 
-export { unauthenticatedApiRateLimiter };
 export default dynamicRateLimiter;

--- a/api/middleware/rateLimiter/index.js
+++ b/api/middleware/rateLimiter/index.js
@@ -14,9 +14,93 @@
  * @type {import('express').RequestHandler}
  */
 import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
+import jwt from 'jsonwebtoken';
+import { getApiJwtAudience, getApiJwtIssuer } from '../../auth/apiJwtClaims/index.js';
+import normalizeApiJwtUser from '../utils/normalizeApiJwtUser.js';
 
+/**
+ * Default rate limit window duration in milliseconds (15 minutes).
+ *
+ * @type {number}
+ */
 const WINDOW_MS = Number(process.env.API_RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000;
 
+/**
+ * Returns the Bearer token from the Authorization header if present and well-formed.
+ *
+ * @param {*} req - Express request object
+ * @returns {*} - The Bearer token string if present and valid, or null if not found or malformed
+ */
+function getBearerToken(req) {
+    const authHeader = req.headers?.authorization;
+    if (!authHeader) {
+        return null;
+    }
+
+    const [scheme, token] = authHeader.split(' ');
+    if (scheme !== 'Bearer' || !token) {
+        return null;
+    }
+
+    return token;
+}
+
+/**
+ * Checks if the request has a valid API JWT token.
+ *
+ * @param {*} req - Express request object
+ * @returns {boolean} - True if the request has a valid API JWT token, false otherwise
+ */
+function hasValidApiJwt(req) {
+    const token = getBearerToken(req);
+    if (!token || !process.env.APP_JWT_SECRET) {
+        return false;
+    }
+
+    try {
+        const user = jwt.verify(token, process.env.APP_JWT_SECRET, {
+            algorithms: ['HS256'],
+            issuer: getApiJwtIssuer(),
+            audience: getApiJwtAudience()
+        });
+
+        req.user = normalizeApiJwtUser(user);
+        if (req.user?.id == null || req.user.id === '') {
+            return false;
+        }
+        req.apiJwtVerified = true; // marker for auth middleware short-circuit
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Rate limiter for unauthenticated API requests.
+ *
+ * @type {*} - Express middleware that applies a stricter rate limit to unauthenticated requests.
+ * Authenticated requests (with a valid API JWT) are not subject to this limiter.
+ * The limit and window duration are configurable via environment variables.
+ * Responds with HTTP 429 and a JSON error message when the limit is exceeded.
+ */
+const unauthenticatedApiRateLimiter = rateLimit({
+    windowMs: WINDOW_MS,
+    limit: () => Number(process.env.API_RATE_LIMIT_MAX_UNAUTH) || 50,
+    keyGenerator: (req) => ipKeyGenerator(req.ip),
+    skip: (req) => process.env.NODE_ENV !== 'production' || hasValidApiJwt(req),
+    handler: (req, res) => {
+        res.status(429).json({ error: 'Too many requests, please try again later' });
+    }
+});
+
+/**
+ * Dynamic rate limiter for API requests based on authentication status.
+ *
+ * @type {*} - Express middleware that applies different rate limits for authenticated and unauthenticated requests.
+ * Authenticated requests (with a valid API JWT) have a higher limit than unauthenticated requests.
+ * The limits and window duration are configurable via environment variables.
+ * Responds with HTTP 429 and a JSON error message when the limit is exceeded.
+ */
 const dynamicRateLimiter = rateLimit({
     windowMs: WINDOW_MS,
     // Evaluate limits at request time to allow test changes
@@ -25,11 +109,15 @@ const dynamicRateLimiter = rateLimit({
         const unauthenticatedLimit = Number(process.env.API_RATE_LIMIT_MAX_UNAUTH) || 50;
         return req.user ? authenticatedLimit : unauthenticatedLimit;
     },
-    keyGenerator: (req) => (req.user?.id ? req.user.id : ipKeyGenerator(req.ip)),
+    keyGenerator: (req) => {
+        const user = normalizeApiJwtUser(req.user);
+        return user?.id != null && user.id !== '' ? String(user.id) : ipKeyGenerator(req.ip);
+    },
     skip: (req) => process.env.NODE_ENV !== 'production', // Evaluate at request time
     handler: (req, res) => {
         res.status(429).json({ error: 'Too many requests, please try again later' });
     }
 });
 
+export { unauthenticatedApiRateLimiter };
 export default dynamicRateLimiter;

--- a/api/middleware/utils/normalizeApiJwtUser.js
+++ b/api/middleware/utils/normalizeApiJwtUser.js
@@ -1,0 +1,23 @@
+/**
+ * Normalizes API JWT claims so downstream middleware can rely on req.user.id.
+ * Supports payloads where identity is provided as id, userId, or username.
+ *
+ * @param {*} user - Decoded JWT payload.
+ * @returns {*} Normalized user payload.
+ */
+export default function normalizeApiJwtUser(user) {
+    if (!user || typeof user !== 'object') {
+        return user;
+    }
+
+    const rawId = user.id ?? user.userId ?? user.username;
+    const normalizedId = typeof rawId === 'string' ? rawId.trim() : rawId;
+    if (normalizedId == null || normalizedId === '') {
+        return user;
+    }
+
+    return {
+        ...user,
+        id: normalizedId
+    };
+}

--- a/api/middleware/utils/normalizeApiJwtUser.test.js
+++ b/api/middleware/utils/normalizeApiJwtUser.test.js
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import normalizeApiJwtUser from './normalizeApiJwtUser.js';
+
+test('normalizes using precedence order id > userId > username', () => {
+    const user = {
+        id: 'id-value',
+        userId: 'user-id-value',
+        username: 'username-value'
+    };
+
+    const normalized = normalizeApiJwtUser(user);
+
+    assert.equal(normalized.id, 'id-value');
+});
+
+test('treats 0 as a valid identifier (does not drop falsy numeric id)', () => {
+    const user = {
+        userId: 0,
+        username: 'fallback-username'
+    };
+
+    const normalized = normalizeApiJwtUser(user);
+
+    assert.equal(normalized.id, 0);
+});

--- a/api/search/constants/searchTypes.js
+++ b/api/search/constants/searchTypes.js
@@ -70,8 +70,11 @@ export function resolveSearchType(searchType, session = {}) {
     // Direct session lookup rather than getFeatureFlagValue() to avoid a circular
     // dependency: featureFlags/index.js imports DEFAULT_SEARCH_TYPE from this module,
     // so importing getFeatureFlagValue back here would create a cycle.
-    // Validate the session value before using it — an unrecognised value should not
-    // be propagated into URLs or downstream query building.
     const sessionType = session?.featureFlags?.type;
-    return Object.values(SEARCH_TYPES).includes(sessionType) ? sessionType : DEFAULT_SEARCH_TYPE;
+    const normalisedSessionType =
+        typeof sessionType === 'string' ? sessionType.trim().toLowerCase() : undefined;
+    if (Object.values(SEARCH_TYPES).includes(normalisedSessionType)) {
+        return normalisedSessionType;
+    }
+    return DEFAULT_SEARCH_TYPE;
 }

--- a/api/search/constants/searchTypes.test.js
+++ b/api/search/constants/searchTypes.test.js
@@ -63,15 +63,28 @@ describe('resolveSearchType', () => {
             assert.strictEqual(resolveSearchType('foo,bar'), DEFAULT_SEARCH_TYPE);
         });
 
-        it('returns the session feature-flag value when the type is not recognised and a session override is set', () => {
+        it('returns the normalised session feature-flag value when the type is not recognised and a session override is set', () => {
             const session = { featureFlags: { type: 'semantic' } };
             assert.strictEqual(resolveSearchType('unknown', session), 'semantic');
         });
 
-        it('returns DEFAULT_SEARCH_TYPE when the session feature-flag value is falsy', () => {
+        it('normalises session feature-flag fallback values before validation', () => {
+            const session = { featureFlags: { type: ' KEYWORD-DATES ' } };
+            assert.strictEqual(resolveSearchType('unknown', session), 'keyword-dates');
+        });
+
+        it('returns DEFAULT_SEARCH_TYPE when the session feature-flag value is missing or invalid', () => {
             assert.strictEqual(resolveSearchType('unknown', {}), DEFAULT_SEARCH_TYPE);
             assert.strictEqual(
                 resolveSearchType('unknown', { featureFlags: {} }),
+                DEFAULT_SEARCH_TYPE
+            );
+            assert.strictEqual(
+                resolveSearchType('unknown', { featureFlags: { type: 'not-a-type' } }),
+                DEFAULT_SEARCH_TYPE
+            );
+            assert.strictEqual(
+                resolveSearchType('unknown', { featureFlags: { type: '   ' } }),
                 DEFAULT_SEARCH_TYPE
             );
         });

--- a/app.js
+++ b/app.js
@@ -169,16 +169,16 @@ async function createApp({ createLogger = defaultCreateLogger } = {}) {
         next();
     });
 
-    // Apply General Rate Limiter GLOBALLY (Fixes CodeQL)
-    // Note: auth login exclusion is handled within the limiter configuration
+    app.use('/api', await createApi());
+
+    // Apply General Rate Limiter to web app routes.
+    // API routes are mounted before this and use their own API-specific limiter.
     app.use(generalRateLimiter);
 
     app.use('/', indexRouter);
 
     // Auth routes (login, etc.)
     app.use('/auth', authRouter);
-
-    app.use('/api', await createApi());
     // Security: enforceCrnInQuery uses an explicit allowlist of redirect-eligible paths (see middleware).
     // If you add a new route that should support internal redirects, update the allowlist and its test.
     app.use(enforceCrnInQuery);
@@ -188,7 +188,6 @@ async function createApp({ createLogger = defaultCreateLogger } = {}) {
     app.use(
         '/document',
         isAuthenticated,
-        generalRateLimiter,
         getCaseReferenceNumberFromQueryString,
         caseSelected,
         featureFlags,
@@ -197,7 +196,6 @@ async function createApp({ createLogger = defaultCreateLogger } = {}) {
     app.use(
         '/search',
         isAuthenticated,
-        generalRateLimiter,
         getCaseReferenceNumberFromQueryString,
         caseSelected,
         featureFlags,

--- a/db/index.js
+++ b/db/index.js
@@ -1,5 +1,68 @@
+import crypto from 'node:crypto';
 import { Client as defaultClient } from '@opensearch-project/opensearch';
 import VError from 'verror';
+
+/**
+ *  Module-scoped client cache so OpenSearch TCP connections are reused across requests.
+ *
+ * @type {WeakMap<Function, Map<string, OpenSearchClient>>}
+ */
+const clientByConstructorAndNode = new WeakMap();
+/**
+ * Default threshold for slow query warnings in milliseconds.
+ *
+ * @type {number}
+ */
+const DEFAULT_SLOW_QUERY_WARN_MS = 2000;
+
+/**
+ * Hashes node URL for safe logging without exposing credentials.
+ *
+ * @param {string} node - OpenSearch node URL to hash for log-safe metadata.
+ * @returns {string}
+ */
+function nodeHash(node) {
+    return crypto.createHash('sha256').update(node).digest('hex').slice(0, 8);
+}
+
+/**
+ * Returns a shared OpenSearch client instance for the provided constructor+node pair.
+ *
+ * @param {new (...args: any[]) => OpenSearchClient} Client - OpenSearch client constructor to instantiate when no cached client exists.
+ * @param {string} node - OpenSearch node URL used as the cache key and client connection target.
+ * @param {Logger} [logger] - Optional logger used to record client creation/reuse events.
+ * @returns {OpenSearchClient}
+ */
+function getOrCreateSharedClient(Client, node, logger) {
+    let clientsByNode = clientByConstructorAndNode.get(Client);
+    if (!clientsByNode) {
+        clientsByNode = new Map();
+        clientByConstructorAndNode.set(Client, clientsByNode);
+    }
+
+    let client = clientsByNode.get(node);
+    if (!client) {
+        client = new Client({ node });
+        clientsByNode.set(node, client);
+        logger?.debug?.(
+            {
+                clientType: Client.name || 'anonymous-client',
+                nodeHash: nodeHash(node)
+            },
+            'OpenSearch client created'
+        );
+    } else {
+        logger?.debug?.(
+            {
+                clientType: Client.name || 'anonymous-client',
+                nodeHash: nodeHash(node)
+            },
+            'OpenSearch client reused'
+        );
+    }
+
+    return client;
+}
 
 /**
  * @typedef {object} OpenSearchQuery
@@ -25,6 +88,8 @@ import VError from 'verror';
  * @typedef {object} Logger
  * @property {(data: object, message?: string) => void} info - Logs informational messages with structured data.
  * @property {(data: object, message?: string) => void} error - Logs errors with structured data.
+ * @property {(data: object, message?: string) => void} [warn] - Logs warning messages with structured data.
+ * @property {(data: object, message?: string) => void} [debug] - Logs debug messages with structured data.
  */
 
 /**
@@ -53,9 +118,11 @@ function createDBQuery({ Client = defaultClient, logger }) {
         );
     }
 
-    const client = new Client({
-        node: process.env.APP_DATABASE_URL
-    });
+    const client = getOrCreateSharedClient(Client, process.env.APP_DATABASE_URL, logger);
+    const slowQueryWarnMs = Number.parseInt(
+        process.env.DB_SLOW_QUERY_WARN_MS ?? `${DEFAULT_SLOW_QUERY_WARN_MS}`,
+        10
+    );
 
     /**
      * Executes a query against the OpenSearch database and logs its execution time.
@@ -73,21 +140,39 @@ function createDBQuery({ Client = defaultClient, logger }) {
         const processExecutionStart = process.hrtime();
         const results = await client.search(query);
         const processExecutionTime = process.hrtime(processExecutionStart);
+        const seconds = processExecutionTime[0];
+        const nanoseconds = processExecutionTime[1];
+        const executionTimeMs = seconds * 1e3 + nanoseconds / 1e6;
+        const rows = results?.body?.hits?.hits?.length ?? results?.hits?.hits?.length ?? 0;
 
         if (logger?.info) {
-            const seconds = processExecutionTime[0];
-            const nanoseconds = processExecutionTime[1];
-            const milliseconds = nanoseconds / 1e6;
             logger.info(
                 {
                     data: {
                         query,
-                        rows: results.hits?.hits?.length ?? 0
+                        rows
                     },
-                    executionTime: `${seconds}s ${milliseconds.toFixed(3)}ms`,
+                    executionTime: `${seconds}s ${(nanoseconds / 1e6).toFixed(3)}ms`,
+                    executionTimeMs,
                     executionTimeNs: seconds * 1e9 + nanoseconds
                 },
                 'DB QUERY'
+            );
+        }
+
+        if (
+            logger?.warn &&
+            Number.isFinite(slowQueryWarnMs) &&
+            executionTimeMs >= slowQueryWarnMs
+        ) {
+            logger.warn(
+                {
+                    index: query?.index,
+                    executionTimeMs,
+                    slowQueryWarnMs,
+                    rows
+                },
+                'DB QUERY SLOW'
             );
         }
 

--- a/db/index.test.js
+++ b/db/index.test.js
@@ -89,7 +89,9 @@ describe('DB Service', () => {
                 }
             );
         } finally {
-            if (originalUrl) {
+            if (originalUrl === undefined) {
+                delete process.env.APP_DATABASE_URL;
+            } else {
                 process.env.APP_DATABASE_URL = originalUrl;
             }
         }
@@ -116,17 +118,20 @@ describe('DB Service', () => {
         const queryObj = { index: 'test', query: { match_all: {} } };
         await db.query(queryObj);
 
-        assert.equal(logInfoSpy.mock.callCount(), 1);
-        const [logData, logMessage] = logInfoSpy.mock.calls[0].arguments;
+        const dbQueryLog = logInfoSpy.mock.calls.find((call) => call.arguments[1] === 'DB QUERY');
+        assert.ok(dbQueryLog);
+        const [logData, logMessage] = dbQueryLog.arguments;
         assert.equal(logMessage, 'DB QUERY');
         assert.deepEqual(logData.data.query, queryObj);
         assert.equal(logData.data.rows, 2);
         assert.ok(logData.executionTime);
+        assert.equal(typeof logData.executionTimeMs, 'number');
+        assert.ok(logData.executionTimeMs >= 0);
         assert.ok(logData.executionTimeNs);
     });
 
     it('Should handle queries with no hits gracefully in logging', async () => {
-        const fakeResults = { hits: {} };
+        const fakeResults = { body: { hits: { hits: [] } } };
         const searchSpy = mock.fn(async () => fakeResults);
 
         class FakeClient {
@@ -145,7 +150,75 @@ describe('DB Service', () => {
 
         await db.query({ index: 'test', query: {} });
 
-        const [logData] = logInfoSpy.mock.calls[0].arguments;
+        const dbQueryLog = logInfoSpy.mock.calls.find((call) => call.arguments[1] === 'DB QUERY');
+        assert.ok(dbQueryLog);
+        const [logData] = dbQueryLog.arguments;
         assert.equal(logData.data.rows, 0);
+    });
+
+    it('Should reuse the same client instance for same Client and APP_DATABASE_URL', async () => {
+        const originalUrl = process.env.APP_DATABASE_URL;
+        process.env.APP_DATABASE_URL = 'http://reused-client-node';
+
+        try {
+            let constructorCallCount = 0;
+            class FakeClient {
+                constructor() {
+                    constructorCallCount += 1;
+                }
+
+                search = async () => ({ body: { hits: { hits: [] } } });
+            }
+
+            const dbA = createDBQuery({ Client: FakeClient, logger: {} });
+            const dbB = createDBQuery({ Client: FakeClient, logger: {} });
+
+            await dbA.query({ index: 'test', query: { match_all: {} } });
+            await dbB.query({ index: 'test', query: { match_all: {} } });
+
+            assert.equal(constructorCallCount, 1);
+        } finally {
+            if (originalUrl === undefined) {
+                delete process.env.APP_DATABASE_URL;
+            } else {
+                process.env.APP_DATABASE_URL = originalUrl;
+            }
+        }
+    });
+
+    it('Should emit slow query warning when execution exceeds threshold', async () => {
+        const originalThreshold = process.env.DB_SLOW_QUERY_WARN_MS;
+        process.env.DB_SLOW_QUERY_WARN_MS = '0';
+
+        try {
+            class FakeClient {
+                search = async () => ({ body: { hits: { hits: [{ _id: 1 }] } } });
+            }
+
+            const warnSpy = mock.fn();
+            const db = createDBQuery({
+                Client: FakeClient,
+                logger: {
+                    info: mock.fn(),
+                    warn: warnSpy
+                }
+            });
+
+            await db.query({ index: 'test-index', query: { match_all: {} } });
+
+            assert.equal(warnSpy.mock.callCount(), 1);
+            const [warnData, warnMessage] = warnSpy.mock.calls[0].arguments;
+            assert.equal(warnMessage, 'DB QUERY SLOW');
+            assert.equal(warnData.index, 'test-index');
+            assert.equal(warnData.slowQueryWarnMs, 0);
+            assert.equal(typeof warnData.executionTimeMs, 'number');
+            assert.ok(warnData.executionTimeMs >= 0);
+        } finally {
+            if (originalThreshold === undefined) {
+                delete process.env.DB_SLOW_QUERY_WARN_MS;
+            } else {
+                process.env.DB_SLOW_QUERY_WARN_MS = originalThreshold;
+            }
+        }
     });
 });

--- a/middleware/enforceSearchTypeInQuery/index.test.js
+++ b/middleware/enforceSearchTypeInQuery/index.test.js
@@ -38,7 +38,7 @@ function createMockRes() {
 }
 
 describe('enforceSearchTypeInQuery', () => {
-    it('redirects with default type when type is absent from query', () => {
+    it('redirects with default type when type is missing from query', () => {
         const req = createMockReq({ query: { query: 'acute', crn: '26-711111' } });
         const res = createMockRes();
         let nextCalled = false;
@@ -54,7 +54,20 @@ describe('enforceSearchTypeInQuery', () => {
         assert.strictEqual(nextCalled, false);
     });
 
-    it('redirects with session type when set and type absent from query', () => {
+    it('redirects to canonical type when type is valid but not canonical (e.g., uppercase)', () => {
+        const req = createMockReq({ query: { query: 'acute', type: 'KEYWORD' } });
+        const res = createMockRes();
+        let nextCalled = false;
+
+        enforceSearchTypeInQuery(req, res, () => {
+            nextCalled = true;
+        });
+
+        assert.strictEqual(res.redirectedUrl, '/search?query=acute&type=keyword');
+        assert.strictEqual(nextCalled, false);
+    });
+
+    it('redirects with session type when set and type is missing from query', () => {
         const req = createMockReq({
             query: { query: 'acute' },
             session: { featureFlags: { type: 'keyword' } }
@@ -188,7 +201,7 @@ describe('enforceSearchTypeInQuery', () => {
 
     it('redirects with session/default type when type is present but invalid', () => {
         const req = createMockReq({
-            query: { query: 'acute', type: 'keyword,semantic' },
+            query: { query: 'acute', type: 'not-a-real-type' },
             session: { featureFlags: { type: 'keyword' } }
         });
         const res = createMockRes();

--- a/middleware/rateLimiter/index.test.js
+++ b/middleware/rateLimiter/index.test.js
@@ -62,6 +62,32 @@ test('skip function returns true in non-production mode', async () => {
     }
 });
 
+test('skip function does not bypass limiter in production for /api paths', async () => {
+    const originalEnv = process.env.NODE_ENV;
+    const originalUnauth = process.env.APP_RATE_LIMIT_MAX_UNAUTH;
+    process.env.NODE_ENV = 'production';
+    process.env.APP_RATE_LIMIT_MAX_UNAUTH = '1';
+
+    try {
+        const { default: limiter } = await import(`./index.js?t=${Date.now()}`);
+
+        const app = express();
+        app.use(session({ secret: 'test', resave: false, saveUninitialized: true }));
+        app.use(limiter);
+        app.get('/api/test', (req, res) => res.send('OK'));
+
+        const res1 = await request(app).get('/api/test');
+        const res2 = await request(app).get('/api/test');
+
+        assert.strictEqual(res1.status, 200);
+        assert.strictEqual(res2.status, 429);
+    } finally {
+        process.env.NODE_ENV = originalEnv;
+        if (originalUnauth) process.env.APP_RATE_LIMIT_MAX_UNAUTH = originalUnauth;
+        else delete process.env.APP_RATE_LIMIT_MAX_UNAUTH;
+    }
+});
+
 test('limit function returns AUTHENTICATED_LIMIT when session.loggedIn is true', async () => {
     const originalEnv = process.env.NODE_ENV;
     const originalAuth = process.env.APP_RATE_LIMIT_MAX_AUTH;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "lint": "biome check --write",
         "format": "biome format --write",
         "precommit:secrets": "command -v gitleaks >/dev/null 2>&1 || { echo 'gitleaks not found on PATH; skipping secrets scan. Install gitleaks from https://github.com/gitleaks/gitleaks or disable the precommit:secrets hook if this is intentional.'; exit 1; }; gitleaks protect --staged --redact --verbose --config .gitleaks.toml",
-        "precommit": "npm run format && npm run lint && npm run sass && npm run precommit:secrets",
+        "precommit": "npm run format && npm run lint && npm run sass && npm run precommit:secrets && npm run test && npm run jsdoc:check && npm run openapi:build",
         "prepush": "npm run test && npm run jsdoc:check",
         "jsdoc:check": "eslint .",
         "prepare": "husky"

--- a/search/routes.js
+++ b/search/routes.js
@@ -73,7 +73,7 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
                 searchType
             };
 
-            req.log.info({ query, pageNumber, itemsPerPage }, 'Creating search service');
+            req.log?.debug?.({ query, pageNumber, itemsPerPage }, 'Creating search service');
             const searchService = createSearchService({
                 caseReferenceNumber: req.session?.caseReferenceNumber,
                 logger: req.log

--- a/search/search-service.js
+++ b/search/search-service.js
@@ -36,7 +36,7 @@ function createSearchService({
         token,
         { searchType = DEFAULT_SEARCH_TYPE } = {}
     ) {
-        logger.info({ query, pageNumber, itemsPerPage }, 'Fetching search results');
+        logger?.debug?.({ query, pageNumber, itemsPerPage }, 'Fetching search results');
         const opts = {
             url:
                 `${process.env.APP_API_URL}/search/?query=${query}` +


### PR DESCRIPTION
This PR cherry-picks a set of changes related to “hybrid search” support and associated operational improvements, spanning query-building/tuning, OpenSearch client reuse/metrics, logging level adjustments, and rate-limiter behaviour for both the UI and API.

Changes:

- Updates hybrid/semantic query DSL tuning and introduces separate thresholds for hybrid vs pure semantic scoring.
- Reworks DB query handling to reuse OpenSearch clients across calls and emits slow-query warnings + richer timing metrics in logs.
- Adjusts rate-limiting and logging behaviour (including API unauthenticated rate limiting and several info→debug changes),
-  expands test coverage and precommit checks.