### PR TITLE
Pinning Actions via SHA

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,12 +45,12 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
               with:
                   ref: ${{ inputs.ref || github.sha }}
 
             - name: Set up Node.js
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
               with:
                   node-version: "24.15.0"
 
@@ -71,7 +71,7 @@ jobs:
                   audience: sts.amazonaws.com
 
             - name: Login to Amazon ECR
-              uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
+              uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 #v2.1.5
 
               id: login-ecr
 
@@ -133,7 +133,7 @@ jobs:
 
             - name: Upload dependency SARIF to GitHub
               if: ${{ inputs.skip_security_scan != true  && hashFiles('snyk-test-results.sarif') != '' }}
-              uses: github/codeql-action/upload-sarif@v4
+              uses: github/codeql-action/upload-sarif@f0489abddd4e5e9dff53ed28a45b1d6f88978a1b #v4.36.0
               with:
                   sarif_file: snyk-test-results.sarif
 
@@ -230,7 +230,7 @@ jobs:
 
             - name: Upload container SARIF to GitHub
               if: ${{ inputs.skip_security_scan != true  && hashFiles('snyk-container-test-results.sarif') != '' }}
-              uses: github/codeql-action/upload-sarif@v4
+              uses: github/codeql-action/upload-sarif@f0489abddd4e5e9dff53ed28a45b1d6f88978a1b #v4.36.0
               with:
                   sarif_file: snyk-container-test-results.sarif
 
@@ -393,7 +393,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
               with:
                   ref: ${{ inputs.ref || github.sha }}
 
@@ -405,7 +405,7 @@ jobs:
                   audience: sts.amazonaws.com
 
             - name: Login to Amazon ECR
-              uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
+              uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 #v2.1.5
               id: login-ecr
 
             - name: Template Kubernetes manifests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
         with:
           node-version: "24.15.0"
           cache: "npm"


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow files to use specific commit hashes and newer versions for several key actions. These changes improve security and reliability by pinning dependencies to exact versions and updating to the latest stable releases.

**GitHub Actions dependency updates:**

* Updated `actions/checkout` to use commit hash `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (`v6.0.2`) in both `.github/workflows/deploy.yml` and `.github/workflows/tests.yml` for improved security and reliability. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L48-R53) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L396-R396) [[3]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL17-R20)
* Updated `actions/setup-node` to use commit hash `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` (`v6.4.0`) in both workflow files. (Ff73df62L49R49, Fd560a1fL17R17)
* Updated `aws-actions/amazon-ecr-login` to use the latest version (`v2.1.5`) with commit hash `fa648b43de3d4d023bcb3f89ed6940096949c419` in `.github/workflows/deploy.yml`. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L74-R74) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L408-R408)
* Updated `github/codeql-action/upload-sarif` to use commit hash `f0489abddd4e5e9dff53ed28a45b1d6f88978a1b` (`v4.36.0`) for both dependency and container SARIF uploads in `.github/workflows/deploy.yml`. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L136-R136) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L233-R233)