### PR TITLE
security: fix deploy job to fail on unfixable high and critical vulne…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,11 +92,13 @@ jobs:
 
                   # Allow command to fail without killing step
                   set +e
+                  # Capture stdout (JSON) and stderr (diagnostics) separately so downstream steps
+                  # can parse clean JSON via jq and access error context from the log file
                   snyk test \
                       --policy-path=.snyk \
                       --all-projects \
                       --severity-threshold=high \
-                      --json > snyk-test-results.json
+                      --json > snyk-test-results.json 2> snyk-test-results.log
 
                   EXIT_CODE=$?
                   set -e
@@ -111,11 +113,12 @@ jobs:
                   fi
 
                   # Convert to SARIF (always succeeds)
+                  # Append stderr from SARIF conversion to the same log for complete diagnostics
                   snyk test \
                       --policy-path=.snyk \
                       --all-projects \
                       --severity-threshold=high \
-                      --sarif > snyk-test-results.sarif || true
+                      --sarif > snyk-test-results.sarif 2>> snyk-test-results.log || true
 
                   # Ensure SARIF exists
                   if [ ! -s snyk-test-results.sarif ]; then
@@ -193,11 +196,13 @@ jobs:
                   echo "Scanning image: $IMAGE"
 
                   set +e
+                  # Capture stdout (JSON) and stderr (diagnostics) separately so downstream steps
+                  # can parse clean JSON via jq and access error context from the log file
                   snyk container test "$IMAGE" \
                       --policy-path=.snyk \
                       --file=Dockerfile \
                       --severity-threshold=high \
-                      --json > snyk-container-test-results.json
+                      --json > snyk-container-test-results.json 2> snyk-container-test-results.log
 
                   EXIT_CODE=$?
                   set -e
@@ -211,11 +216,12 @@ jobs:
                       printf '{"ok":false,"error":"snyk container test --json produced no valid JSON","exitCode":%s,"vulnerabilities":[],"applications":[]}\n' "$EXIT_CODE" > snyk-container-test-results.json
                   fi
 
+                  # Append stderr from SARIF conversion to the same log for complete diagnostics
                   snyk container test "$IMAGE" \
                       --policy-path=.snyk \
                       --file=Dockerfile \
                       --severity-threshold=high \
-                      --sarif > snyk-container-test-results.sarif || true
+                      --sarif > snyk-container-test-results.sarif 2>> snyk-container-test-results.log || true
 
                   if [ ! -s snyk-container-test-results.sarif ]; then
                       echo '{"version":"2.1.0","runs":[]}' > snyk-container-test-results.sarif

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,6 +83,7 @@ jobs:
               run: npm ci
 
             - name: Scan application (SARIF + policy evaluation)
+              id: scan_application
               if: ${{ inputs.skip_security_scan != true }}
               run: |
                   set -euo pipefail
@@ -116,20 +117,26 @@ jobs:
 
                   echo "=== APPLICATION VULN SUMMARY ==="
 
-                  cat snyk-test-results.json | jq '
-                    def all_vulns:
-                        [
-                            (.vulnerabilities[]?),
-                            (.applications[]?.vulnerabilities[]?)
-                        ];
-                    {
-                        total: (all_vulns | length),
-                        high: (all_vulns | map(select(.severity=="high")) | length),
-                        critical: (all_vulns | map(select(.severity=="critical")) | length),
-                        fixable: (all_vulns | map(select(.isUpgradable==true or .isPatchable==true)) | length)
-                    }'
+                  if [ -s snyk-test-results.json ]; then
+                      if ! jq '
+                        def all_vulns:
+                            [
+                                (.vulnerabilities[]?),
+                                (.applications[]?.vulnerabilities[]?)
+                            ];
+                        {
+                            total: (all_vulns | length),
+                            high: (all_vulns | map(select(.severity=="high")) | length),
+                            critical: (all_vulns | map(select(.severity=="critical")) | length),
+                            fixable: (all_vulns | map(select(.isUpgradable==true or .isPatchable==true)) | length)
+                        }' snyk-test-results.json; then
+                          echo "::warning::Unable to parse snyk-test-results.json; scan exit code was $EXIT_CODE"
+                      fi
+                  else
+                      echo "::warning::No snyk-test-results.json produced; scan exit code was $EXIT_CODE"
+                  fi
 
-                  echo "SNYK_APPLICATION_SCAN_EXIT_CODE=$EXIT_CODE" >> $GITHUB_ENV
+                  echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
 
             - name: Upload dependency SARIF to GitHub
               if: ${{ inputs.skip_security_scan != true  && hashFiles('snyk-test-results.sarif') != '' }}
@@ -165,6 +172,7 @@ jobs:
                   echo "::warning::⚠️ SECURITY SCAN BYPASSED - This is an emergency deployment without vulnerability scanning"
 
             - name: Scan container (SARIF + policy evaluation)
+              id: scan_container
               if: ${{ inputs.skip_security_scan != true }}
               env:
                   REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -220,7 +228,7 @@ jobs:
                         fixable: (all_vulns | map(select(.isUpgradable==true or .isPatchable==true)) | length)
                     }'
 
-                  echo "SNYK_CONTAINER_SCAN_EXIT_CODE=$EXIT_CODE" >> $GITHUB_ENV
+                  echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
 
             - name: Dump full container Snyk JSON
               if: ${{ inputs.skip_security_scan != true }}
@@ -290,7 +298,35 @@ jobs:
                     fi
                   fi
 
-            - name: Warn on non-fixable container vulnerabilities
+            - name: ⚠️ Report policy-suppressed vulnerabilities
+              if: ${{ inputs.skip_security_scan != true }}
+              run: |
+                  echo "=== SNYK POLICY FILE (.snyk) - IGNORED VULNERABILITIES ==="
+                  echo ""
+                  if [ -f .snyk ]; then
+                      cat .snyk
+                      echo ""
+                      echo "=== POLICY SUMMARY ==="
+                      ACTIVE_IGNORES=$(awk '
+                        BEGIN { in_ignore = 0; count = 0 }
+                        /^ignore:[[:space:]]*$/ { in_ignore = 1; next }
+                        in_ignore && /^[^[:space:]]/ { in_ignore = 0 }
+                        in_ignore && /^[[:space:]]{2}[A-Za-z0-9._-]+:[[:space:]]*$/ { count++ }
+                        END { print count }
+                      ' .snyk)
+
+                      echo "Active ignore entries detected: $ACTIVE_IGNORES"
+
+                      if [ "$ACTIVE_IGNORES" -gt 0 ]; then
+                          echo "::warning::Policy file detected and applied via --policy-path=.snyk"
+                          echo "::warning::Active suppressions are present in .snyk"
+                          echo "::warning::Review the .snyk file above to verify suppressions have clear reason and expiry"
+                      else
+                          echo "No active suppressions found in .snyk"
+                      fi
+                  fi
+
+            - name: Fail on non-fixable container vulnerabilities
               if: ${{ inputs.skip_security_scan != true }}
               run: |
                   NON_FIXABLE=$(jq '
@@ -306,13 +342,35 @@ jobs:
                     ' snyk-container-test-results.json)
 
                   if [ "$NON_FIXABLE" -gt 0 ]; then
-                      echo "::warning::High/critical vulnerabilities found that are NOT fixable ($NON_FIXABLE)"
+                      echo "❌ Failing build: $NON_FIXABLE high/critical container vulnerabilities found that are NOT fixable"
+                      echo "These must be acknowledged via skip_security_scan for emergency deployments only."
+                      exit 1
                   fi
 
-            - name: Fail workflow on application vulnerabilities (fixable only)
-              if: ${{ inputs.skip_security_scan != true && env.SNYK_APPLICATION_SCAN_EXIT_CODE != '0' }}
+            - name: Fail workflow on application vulnerabilities
+              if: ${{ inputs.skip_security_scan != true && steps.scan_application.outputs.exit_code != '0' }}
               run: |
-                  echo "⚠️ Fixable high/critical application vulnerabilities found"
+                  EXIT_CODE="${{ steps.scan_application.outputs.exit_code }}"
+
+                  if [ "$EXIT_CODE" = "1" ]; then
+                      echo "❌ High/critical application vulnerabilities found"
+                      echo "These must be acknowledged via skip_security_scan for emergency deployments only."
+                  elif [ "$EXIT_CODE" = "2" ]; then
+                      echo "❌ Snyk application scan encountered an error (exit code 2)"
+                      echo "This could indicate authentication failure, network issues, or misconfiguration."
+                      echo "Please check the scan output above for details."
+                  else
+                      echo "❌ Snyk application scan failed with unexpected exit code: $EXIT_CODE"
+                  fi
+
+                  exit 1
+
+            - name: Fail workflow on container scan error
+              if: ${{ inputs.skip_security_scan != true && steps.scan_container.outputs.exit_code == '2' }}
+              run: |
+                  echo "❌ Snyk container scan encountered an error (exit code 2)"
+                  echo "This could indicate authentication failure, network issues, or misconfiguration."
+                  echo "Please check the scan output above for details."
                   exit 1
 
             - name: Fail on fixable container vulnerabilities (jq evaluation)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -209,24 +209,24 @@ jobs:
 
                   echo "=== CONTAINER VULN SUMMARY ==="
 
-
-                  ALL_VULNS='[
-                    (.vulnerabilities[]?),
-                    (.applications[]?.vulnerabilities[]?)
-                  ]'
-
-                  cat snyk-container-test-results.json | jq '
-                    def all_vulns:
-                        [
-                            (.vulnerabilities[]?),
-                            (.applications[]?.vulnerabilities[]?)
-                        ];
-                    {
-                        total: (all_vulns | length),
-                        high: (all_vulns | map(select(.severity=="high")) | length),
-                        critical: (all_vulns | map(select(.severity=="critical")) | length),
-                        fixable: (all_vulns | map(select(.isUpgradable==true or .isPatchable==true)) | length)
-                    }'
+                  if [ -s snyk-container-test-results.json ]; then
+                      if ! jq '
+                        def all_vulns:
+                            [
+                                (.vulnerabilities[]?),
+                                (.applications[]?.vulnerabilities[]?)
+                            ];
+                        {
+                            total: (all_vulns | length),
+                            high: (all_vulns | map(select(.severity=="high")) | length),
+                            critical: (all_vulns | map(select(.severity=="critical")) | length),
+                            fixable: (all_vulns | map(select(.isUpgradable==true or .isPatchable==true)) | length)
+                        }' snyk-container-test-results.json; then
+                          echo "::warning::Unable to parse snyk-container-test-results.json; scan exit code was $EXIT_CODE"
+                      fi
+                  else
+                      echo "::warning::No snyk-container-test-results.json produced; scan exit code was $EXIT_CODE"
+                  fi
 
                   echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
 
@@ -329,6 +329,11 @@ jobs:
             - name: Fail on non-fixable container vulnerabilities
               if: ${{ inputs.skip_security_scan != true }}
               run: |
+                  if [ ! -s snyk-container-test-results.json ]; then
+                      echo "::warning::No snyk-container-test-results.json found; skipping non-fixable check"
+                      exit 0
+                  fi
+
                   NON_FIXABLE=$(jq '
                     [
                     (.vulnerabilities[]?),

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,6 +103,13 @@ jobs:
 
                   echo "Snyk raw exit code: $EXIT_CODE"
 
+                  # Normalize JSON output so downstream cat/jq steps are deterministic.
+                  # Keep EXIT_CODE-based gating as the source of pass/fail truth.
+                  if [ ! -s snyk-test-results.json ] || ! jq -e . snyk-test-results.json >/dev/null 2>&1; then
+                      echo "::warning::snyk-test-results.json missing or invalid; writing fallback JSON"
+                      printf '{"ok":false,"error":"snyk test --json produced no valid JSON","exitCode":%s,"vulnerabilities":[],"applications":[]}\n' "$EXIT_CODE" > snyk-test-results.json
+                  fi
+
                   # Convert to SARIF (always succeeds)
                   snyk test \
                       --policy-path=.snyk \
@@ -196,6 +203,13 @@ jobs:
                   set -e
 
                   echo "Snyk raw exit code: $EXIT_CODE"
+
+                  # Normalize JSON output so downstream cat/jq steps are deterministic.
+                  # Keep EXIT_CODE-based gating as the source of pass/fail truth.
+                  if [ ! -s snyk-container-test-results.json ] || ! jq -e . snyk-container-test-results.json >/dev/null 2>&1; then
+                      echo "::warning::snyk-container-test-results.json missing or invalid; writing fallback JSON"
+                      printf '{"ok":false,"error":"snyk container test --json produced no valid JSON","exitCode":%s,"vulnerabilities":[],"applications":[]}\n' "$EXIT_CODE" > snyk-container-test-results.json
+                  fi
 
                   snyk container test "$IMAGE" \
                       --policy-path=.snyk \

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -5,7 +5,6 @@ on:
   schedule:
     - cron: "0 0 * * *"
   pull_request:
-    branches: ["main"]
   workflow_dispatch:
 
 permissions: {}

--- a/.snyk
+++ b/.snyk
@@ -2,4 +2,16 @@
 # For rule syntax and examples, see CONTRIBUTING.md and:
 # https://docs.snyk.io/manage-risk/policies/the-.snyk-file
 version: v1.25.0
-ignore: {}
+ignore:
+  SNYK-DEBIAN13-PERL-17037371:
+    - "*":
+        reason: "Accepted temporarily: non-fixable in current base image; tracked for remediation via base image updates"
+        expires: "2026-07-31T23:59:59.000Z"
+  SNYK-DEBIAN13-PERL-17037374:
+    - "*":
+        reason: "Accepted temporarily: non-fixable in current base image; tracked for remediation via base image updates"
+        expires: "2026-07-31T23:59:59.000Z"
+  SNYK-DEBIAN13-PERL-17037434:
+    - "*":
+        reason: "Accepted temporarily: non-fixable in current base image; tracked for remediation via base image updates"
+        expires: "2026-07-31T23:59:59.000Z"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,8 +102,7 @@ The project uses Husky for Git hooks:
 | Hook Name  | Action       | Description                          |
 | ---------- | ------------ | ------------------------------------ |
 | pre-commit | npm run precommit | Runs format, lint, sass, and gitleaks before commit |
-| pre-push   | npm run prepush | Runs tests and JSDoc linting before push |
-
+| pre-push   | npm run prepush | Runs npm audit --audit-level=high --omit=dev, tests and JSDoc linting before push |
 
 ### CI/CD Pipeline
 
@@ -117,14 +116,14 @@ The deployment process consists of two stages:
 
 ##### 1. Build and Scan
 - Builds Docker image with the commit SHA as the tag
-- Runs Trivy security scanning:
+- Runs Snyk security scanning:
   - **Breaking scan**: Fails on CRITICAL/HIGH vulnerabilities
   - **Informative scan**: Reports all vulnerabilities without failing
 - Pushes image to Amazon ECR
 
 ##### 2. Deploy
 - Templates Kubernetes manifests with the built image
-- Deploys to the specified environment (dev/prod)
+- Deploys to the specified environment (dev/uat)
 
 ##### Manual Deployment
 Deployments can be triggered manually via workflow dispatch:
@@ -132,19 +131,37 @@ Deployments can be triggered manually via workflow dispatch:
 - Specify branch/ref to deploy
 - Optional: Skip security scan for emergency deployments (not recommended)
 
-##### Security Scanning
-Uses Trivy to scan for vulnerabilities. See `.trivyignore` for suppressed CVEs.
+###### Security Scanning
 
-Snyk scans in deployment CI use `.snyk` via `--policy-path=.snyk`.
-Keep `.snyk` as a valid YAML policy file at all times, even when no ignores are active:
+The project includes automated security scanning during deployment via [Snyk](https://snyk.io/).
 
+###### Snyk Policy File (`.snyk`)
+
+The `.snyk` file contains Snyk policy rules to manage vulnerability suppressions in CI/CD. It must remain a valid YAML file at all times, even when no suppressions are active.
+
+When suppressing vulnerabilities, always include:
+- **reason**: Clear explanation for the suppression
+- **expires**: Expiry date (ISO 8601 format)
+
+Example:
 ```yaml
 version: v1.25.0
-ignore: {}
+ignore:
+  SNYK-ID-123:
+    - "*":
+        reason: "Non-fixable in current base image, tracked for remediation"
+        expires: "2026-12-31T23:59:59.000Z"
 ```
 
-When adding temporary ignores, include a clear reason and expiry date. For syntax and examples, see:
-https://docs.snyk.io/manage-risk/policies/the-.snyk-file
+For detailed syntax and policy options, see [Snyk policy documentation](https://docs.snyk.io/manage-risk/policies/the-.snyk-file).
+
+**Policy Reporting:**
+Suppressions are reported in deployment logs for transparency and audit purposes. During deployment, the workflow displays:
+- The full `.snyk` policy file content
+- Emits GitHub Actions warning annotations
+- Clear visibility into all suppressed vulnerabilities and their reasons
+
+This ensures reviewers can audit which vulnerabilities have been intentionally ignored and verify they have appropriate expiry dates.
 
 Environment variables are substituted during CI/CD deployment.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,7 @@ The deployment process consists of two stages:
 
 ##### Manual Deployment
 Deployments can be triggered manually via workflow dispatch:
-- Select environment (dev/prod)
+- Select environment (dev/uat)
 - Specify branch/ref to deploy
 - Optional: Skip security scan for emergency deployments (not recommended)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,7 @@ The deployment process consists of two stages:
 - Builds Docker image with the commit SHA as the tag
 - Runs Snyk security scanning:
   - **Breaking scan**: Fails on CRITICAL/HIGH vulnerabilities
-  - **Informative scan**: Reports all vulnerabilities without failing
+  - **Informational monitor**: Sends the container image snapshot to Snyk for ongoing monitoring (does not fail the workflow)
 - Pushes image to Amazon ECR
 
 ##### 2. Deploy

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ node --env-file=.env.test --test search/routes.test.js
 
 For detailed testing guidelines, see [CONTRIBUTING.md](./CONTRIBUTING.md#testing).
 
+
 This web app is intended to be accessed via Tempus. Tempus has specific links that a user can click on to get to specific areas of this web app.
 
 ## Usage

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@apidevtools/json-schema-ref-parser": "^15.3.5",
                 "@aws-sdk/client-s3": "^3.1050.0",
                 "@ministryofjustice/frontend": "^9.0.0",
-                "@opensearch-project/opensearch": "^3.6.0",
+                "@opensearch-project/opensearch": "3.6.0",
                 "ajv": "^8.20.0",
                 "ajv-errors": "^3.0.0",
                 "cookie-parser": "^1.4.7",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "format": "biome format --write",
         "precommit:secrets": "command -v gitleaks >/dev/null 2>&1 || { echo 'gitleaks not found on PATH; skipping secrets scan. Install gitleaks from https://github.com/gitleaks/gitleaks or disable the precommit:secrets hook if this is intentional.'; exit 1; }; gitleaks protect --staged --redact --verbose --config .gitleaks.toml",
         "precommit": "npm run format && npm run lint && npm run sass && npm run precommit:secrets",
-        "prepush": "npm run test && npm run jsdoc:check",
+        "prepush": "npm audit --audit-level=high --omit=dev && npm run test && npm run jsdoc:check",
         "jsdoc:check": "eslint .",
         "prepare": "husky"
     },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "@apidevtools/json-schema-ref-parser": "^15.3.5",
         "@aws-sdk/client-s3": "^3.1050.0",
         "@ministryofjustice/frontend": "^9.0.0",
-        "@opensearch-project/opensearch": "^3.6.0",
+        "@opensearch-project/opensearch": "3.6.0",
         "ajv": "^8.20.0",
         "ajv-errors": "^3.0.0",
         "cookie-parser": "^1.4.7",


### PR DESCRIPTION
Pull request overview
This PR tightens security gating in the deployment workflow by making high/critical vulnerability findings (including non-fixable container issues) fail the deploy rather than only warning, and documents/how-to’s for Snyk policy usage.

Changes:

- Update deploy.yml to surface Snyk policy suppressions and fail deployments on non-fixable high/critical container vulnerabilities, plus switch application scan exit handling to step outputs.
- Add/expand Snyk policy documentation and introduce concrete .snyk ignore entries with reasons/expiries.
- Adjust local and repo-level security scanning triggers (pre-push audit and SCA workflow PR trigger behavior).