### PR TITLE
Security: migrate search URLs to shareable saved-search IDs and remove query-term exposure

### DIFF
--- a/api/app.test.js
+++ b/api/app.test.js
@@ -269,6 +269,26 @@ describe('API Application', () => {
             assert.ok(res.body.data.attributes.results.hits, 'Search results should have hits');
         });
 
+        test('returns 200 and search results for a valid POST search body', async () => {
+            const res = await request(app)
+                .post('/search')
+                .set('Authorization', `Bearer ${validToken}`)
+                .set('On-Behalf-Of', '25-711111')
+                .set('Content-Type', 'application/vnd.api+json')
+                .send({
+                    query: 'validsearch',
+                    pageNumber: 1,
+                    itemsPerPage: 5,
+                    type: 'semantic'
+                });
+
+            assert.strictEqual(res.statusCode, 200);
+            assert.ok(res.body.data, 'Response should have a data property');
+            assert.strictEqual(res.body.data.type, 'search-results');
+            assert.strictEqual(res.body.data.attributes.query, 'validsearch');
+            assert.ok(res.body.data.attributes.results.hits, 'Search results should have hits');
+        });
+
         test('sets correct content type and version headers', async () => {
             const res = await request(app)
                 .get('/search?query=test')

--- a/api/middleware/validator/index.test.js
+++ b/api/middleware/validator/index.test.js
@@ -125,6 +125,19 @@ describe('OpenAPI Validator Middleware', () => {
         assert.match(res.body.errors[0].message, /must have required property 'query'/);
     });
 
+    it('responds with 400 for missing required "query" property in POST body', async () => {
+        const res = await request(app)
+            .post('/api/search')
+            .set('Authorization', `Bearer ${validToken}`)
+            .set('On-Behalf-Of', '25-711111')
+            .set('Content-Type', 'application/vnd.api+json')
+            .send({ pageNumber: 1, itemsPerPage: 10, type: 'semantic' });
+
+        assert.strictEqual(res.statusCode, 400);
+        assert.ok(res.body.errors, 'Response should have errors');
+        assert.match(res.body.errors[0].message, /must have required property 'query'/);
+    });
+
     it('responds with 400 for invalid "query" parameter (too short)', async () => {
         const res = await request(app)
             .get('/api/search?query=a')
@@ -156,6 +169,22 @@ describe('OpenAPI Validator Middleware', () => {
             )
             .set('Authorization', `Bearer ${validToken}`)
             .set('On-Behalf-Of', '25-711111');
+
+        assert.strictEqual(res.statusCode, 200);
+    });
+
+    it('accepts POST search body with valid query', async () => {
+        const res = await request(app)
+            .post('/api/search')
+            .set('Authorization', `Bearer ${validToken}`)
+            .set('On-Behalf-Of', '25-711111')
+            .set('Content-Type', 'application/vnd.api+json')
+            .send({
+                query: 'acute november 2022',
+                pageNumber: 1,
+                itemsPerPage: 10,
+                type: 'hybrid'
+            });
 
         assert.strictEqual(res.statusCode, 200);
     });

--- a/api/openapi/openapi-dist.json
+++ b/api/openapi/openapi-dist.json
@@ -467,6 +467,430 @@
                         }
                     }
                 }
+            },
+            "post": {
+                "tags": [
+                    "Search"
+                ],
+                "summary": "Search documents for a given case",
+                "description": "Gets all matching occurrences of text from case documents",
+                "operationId": "postSearchResults",
+                "parameters": [
+                    {
+                        "name": "On-Behalf-Of",
+                        "in": "header",
+                        "required": true,
+                        "description": "Specify the owner of the resource.",
+                        "schema": {
+                            "$schema": "http://json-schema.org/draft-07/schema#",
+                            "title": "Case Reference Number",
+                            "type": "string",
+                            "maxLength": 9,
+                            "pattern": "^\\d{2}-[78]\\d{5}$"
+                        },
+                        "example": "25-711111"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/vnd.api+json": {
+                            "schema": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "required": [
+                                    "query"
+                                ],
+                                "properties": {
+                                    "query": {
+                                        "type": "string",
+                                        "minLength": 2,
+                                        "maxLength": 200,
+                                        "errorMessage": {
+                                            "minLength": "Search terms must be 2 characters or more",
+                                            "maxLength": "Search terms must be 200 characters or less"
+                                        }
+                                    },
+                                    "pageNumber": {
+                                        "type": "integer",
+                                        "min": 1
+                                    },
+                                    "itemsPerPage": {
+                                        "type": "integer",
+                                        "min": 1,
+                                        "max": 100
+                                    },
+                                    "type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "keyword",
+                                            "keyword-dates",
+                                            "semantic",
+                                            "hybrid",
+                                            "hybrid-dates"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/vnd.api+json": {
+                                "schema": {
+                                    "$schema": "http://json-schema.org/draft-07/schema#",
+                                    "title": "Search query document",
+                                    "allOf": [
+                                        {
+                                            "$schema": "http://json-schema.org/draft-07/schema#",
+                                            "title": "Loosely describes the JSON:API document format",
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "required": [
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "data": {
+                                                    "anyOf": [
+                                                        {
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "type": "array"
+                                                        }
+                                                    ]
+                                                },
+                                                "included": {
+                                                    "type": "array"
+                                                },
+                                                "links": {
+                                                    "type": "object"
+                                                },
+                                                "meta": {
+                                                    "type": "object"
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "properties": {
+                                                "data": {
+                                                    "$schema": "http://json-schema.org/draft-07/schema#",
+                                                    "title": "Metadata resource",
+                                                    "allOf": [
+                                                        {
+                                                            "$schema": "http://json-schema.org/draft-07/schema#",
+                                                            "title": "Loosely describes the JSON:API resource format",
+                                                            "type": "object",
+                                                            "additionalProperties": false,
+                                                            "required": [
+                                                                "type",
+                                                                "id",
+                                                                "attributes"
+                                                            ],
+                                                            "properties": {
+                                                                "type": {
+                                                                    "type": "string"
+                                                                },
+                                                                "id": {
+                                                                    "type": "string",
+                                                                    "anyOf": [
+                                                                        {
+                                                                            "$schema": "http://json-schema.org/draft-07/schema#",
+                                                                            "title": "UUID v4",
+                                                                            "type": "string",
+                                                                            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "attributes": {
+                                                                    "type": "object",
+                                                                    "title": "Any valid resource"
+                                                                },
+                                                                "relationships": {
+                                                                    "type": "object"
+                                                                }
+                                                            }
+                                                        },
+                                                        {
+                                                            "properties": {
+                                                                "type": {
+                                                                    "const": "search-results"
+                                                                },
+                                                                "id": {
+                                                                    "$schema": "http://json-schema.org/draft-07/schema#",
+                                                                    "title": "UUID v4",
+                                                                    "type": "string",
+                                                                    "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+                                                                },
+                                                                "attributes": {
+                                                                    "allOf": [
+                                                                        {
+                                                                            "required": [
+                                                                                "query"
+                                                                            ],
+                                                                            "properties": {
+                                                                                "query": {
+                                                                                    "type": "string",
+                                                                                    "minLength": 2,
+                                                                                    "maxLength": 200
+                                                                                },
+                                                                                "results": {
+                                                                                    "type": "object"
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "example": {
+                                    "data": {
+                                        "type": "search-results",
+                                        "id": "08dbd0d2-6cee-49e5-a55f-35b31ac4aa9e",
+                                        "attributes": {
+                                            "query": "gabapentin",
+                                            "results": {
+                                                "total": {
+                                                    "value": 1,
+                                                    "relation": "eq"
+                                                },
+                                                "max_score": 10.590174,
+                                                "hits": [
+                                                    {
+                                                        "_index": "page_chunks",
+                                                        "_id": "38de7490-785c-5eaa-b49d-ffbfe5afb99c_p6_c4",
+                                                        "_score": 10.590174,
+                                                        "_source": {
+                                                            "chunk_id": "38de7490-785c-5eaa-b49d-ffbfe5afb99c_p6_c4",
+                                                            "ingested_doc_id": "38de7490-785c-5eaa-b49d-ffbfe5afb99c",
+                                                            "chunk_text": "28-Nov-2022 Gabapentin 600mg tablets Acute Medication (Past) 56 tablet - Take ONE tablet at NIGHT 26-Sept-2022 Gabapentin 600mg tablets Acute Medication (Past) 56 tablet - Take ONE tablet at NIGHT 05-Aug-2022 Gabapentin 600mg tablets Acute Medication (Past) 56 tablet - Take ONE tablet at NIGHT 28-Nov-2022 Gabapentin 600mg tablets Repeat Medication (Past) 56 tablet - Take ONE tablet at NIGHT 08-Jun-2022 Gabapentin 600mg tablets Acute Medication (Past) 56 tablet - Take ONE tablet at NIGHT",
+                                                            "source_file_name": "Case1_TC19_50_pages_brain_injury.pdf",
+                                                            "page_count": 50,
+                                                            "page_number": 6,
+                                                            "chunk_index": 4,
+                                                            "chunk_type": "LAYOUT_TEXT",
+                                                            "confidence": 0.0067822265625,
+                                                            "bounding_box": {
+                                                                "width": 0.4132622182369232,
+                                                                "height": 0.12280497141182423,
+                                                                "left": 0.0894956961274147,
+                                                                "top": 0.7214852571487427,
+                                                                "right": 0.5027579143643379,
+                                                                "bottom": 0.8442902285605669
+                                                            },
+                                                            "embedding": null,
+                                                            "case_ref": "25-711111",
+                                                            "received_date": "2025-10-06",
+                                                            "correspondence_type": "TC19",
+                                                            "character_count": 491,
+                                                            "word_count": 75
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "There is an issue with the request",
+                        "content": {
+                            "application/vnd.api+json": {
+                                "schema": {
+                                    "$schema": "http://json-schema.org/draft-07/schema#",
+                                    "type": "object",
+                                    "required": [
+                                        "errors"
+                                    ],
+                                    "properties": {
+                                        "errors": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "required": [
+                                                    "status",
+                                                    "title",
+                                                    "detail"
+                                                ],
+                                                "properties": {
+                                                    "status": {
+                                                        "const": 400
+                                                    },
+                                                    "title": {
+                                                        "const": "400 Bad Request"
+                                                    },
+                                                    "detail": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "example": {
+                                    "errors": [
+                                        {
+                                            "status": 400,
+                                            "title": "400 Bad Request",
+                                            "detail": "Request JSON is malformed"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Access token is missing or invalid",
+                        "content": {
+                            "application/vnd.api+json": {
+                                "schema": {
+                                    "$schema": "http://json-schema.org/draft-07/schema#",
+                                    "type": "object",
+                                    "required": [
+                                        "errors"
+                                    ],
+                                    "properties": {
+                                        "errors": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "required": [
+                                                    "status",
+                                                    "title",
+                                                    "detail"
+                                                ],
+                                                "properties": {
+                                                    "status": {
+                                                        "const": 401
+                                                    },
+                                                    "title": {
+                                                        "const": "401 Unauthorized"
+                                                    },
+                                                    "detail": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "example": {
+                                    "errors": [
+                                        {
+                                            "status": 401,
+                                            "detail": "No authorization token was found"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "The JWT doesn't permit access to this endpoint",
+                        "content": {
+                            "application/vnd.api+json": {
+                                "schema": {
+                                    "$schema": "http://json-schema.org/draft-07/schema#",
+                                    "type": "object",
+                                    "required": [
+                                        "errors"
+                                    ],
+                                    "properties": {
+                                        "errors": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "required": [
+                                                    "status",
+                                                    "title",
+                                                    "detail"
+                                                ],
+                                                "properties": {
+                                                    "status": {
+                                                        "const": 403
+                                                    },
+                                                    "title": {
+                                                        "const": "403 Forbidden"
+                                                    },
+                                                    "detail": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "example": {
+                                    "errors": [
+                                        {
+                                            "status": 403,
+                                            "title": "403 Forbidden",
+                                            "detail": "Insufficient scope"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The specified resource was not found",
+                        "content": {
+                            "application/vnd.api+json": {
+                                "schema": {
+                                    "$schema": "http://json-schema.org/draft-07/schema#",
+                                    "type": "object",
+                                    "required": [
+                                        "errors"
+                                    ],
+                                    "properties": {
+                                        "errors": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "required": [
+                                                    "status",
+                                                    "title",
+                                                    "detail"
+                                                ],
+                                                "properties": {
+                                                    "status": {
+                                                        "const": 404
+                                                    },
+                                                    "title": {
+                                                        "const": "404 Not Found"
+                                                    },
+                                                    "detail": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "example": {
+                                    "errors": [
+                                        {
+                                            "status": 404,
+                                            "title": "404 Not Found",
+                                            "detail": "Resource /api/v1/questionnaires/2d7caf89-2c72-469f-b19d-17f2a22270b6/sections/answers does not exist"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
             }
         },
         "/document/{documentId}/page/{pageNumber}/metadata": {

--- a/api/openapi/openapi.json
+++ b/api/openapi/openapi.json
@@ -126,6 +126,115 @@
                         "$ref": "#/components/responses/NotFound"
                     }
                 }
+            },
+            "post": {
+                "tags": ["Search"],
+                "summary": "Search documents for a given case",
+                "description": "Gets all matching occurrences of text from case documents",
+                "operationId": "postSearchResults",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/onBehalfOf"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/vnd.api+json": {
+                            "schema": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "required": ["query"],
+                                "properties": {
+                                    "query": {
+                                        "$ref": "#/components/parameters/query/schema"
+                                    },
+                                    "pageNumber": {
+                                        "$ref": "#/components/parameters/pageNumber/schema"
+                                    },
+                                    "itemsPerPage": {
+                                        "$ref": "#/components/parameters/itemsPerPage/schema"
+                                    },
+                                    "type": {
+                                        "$ref": "#/components/parameters/type/schema"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/vnd.api+json": {
+                                "schema": {
+                                    "$ref": "json-schemas/api/_search_{query}_{pageNumber}_{itemsPerPage}/get/res/200.json"
+                                },
+                                "example": {
+                                    "data": {
+                                        "type": "search-results",
+                                        "id": "08dbd0d2-6cee-49e5-a55f-35b31ac4aa9e",
+                                        "attributes": {
+                                            "query": "gabapentin",
+                                            "results": {
+                                                "total": {
+                                                    "value": 1,
+                                                    "relation": "eq"
+                                                },
+                                                "max_score": 10.590174,
+                                                "hits": [
+                                                    {
+                                                        "_index": "page_chunks",
+                                                        "_id": "38de7490-785c-5eaa-b49d-ffbfe5afb99c_p6_c4",
+                                                        "_score": 10.590174,
+                                                        "_source": {
+                                                            "chunk_id": "38de7490-785c-5eaa-b49d-ffbfe5afb99c_p6_c4",
+                                                            "ingested_doc_id": "38de7490-785c-5eaa-b49d-ffbfe5afb99c",
+                                                            "chunk_text": "28-Nov-2022 Gabapentin 600mg tablets Acute Medication (Past) 56 tablet - Take ONE tablet at NIGHT 26-Sept-2022 Gabapentin 600mg tablets Acute Medication (Past) 56 tablet - Take ONE tablet at NIGHT 05-Aug-2022 Gabapentin 600mg tablets Acute Medication (Past) 56 tablet - Take ONE tablet at NIGHT 28-Nov-2022 Gabapentin 600mg tablets Repeat Medication (Past) 56 tablet - Take ONE tablet at NIGHT 08-Jun-2022 Gabapentin 600mg tablets Acute Medication (Past) 56 tablet - Take ONE tablet at NIGHT",
+                                                            "source_file_name": "Case1_TC19_50_pages_brain_injury.pdf",
+                                                            "page_count": 50,
+                                                            "page_number": 6,
+                                                            "chunk_index": 4,
+                                                            "chunk_type": "LAYOUT_TEXT",
+                                                            "confidence": 0.0067822265625,
+                                                            "bounding_box": {
+                                                                "width": 0.4132622182369232,
+                                                                "height": 0.12280497141182423,
+                                                                "left": 0.0894956961274147,
+                                                                "top": 0.7214852571487427,
+                                                                "right": 0.5027579143643379,
+                                                                "bottom": 0.8442902285605669
+                                                            },
+                                                            "embedding": null,
+                                                            "case_ref": "25-711111",
+                                                            "received_date": "2025-10-06",
+                                                            "correspondence_type": "TC19",
+                                                            "character_count": 491,
+                                                            "word_count": 75
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/Forbidden"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/NotFound"
+                    }
+                }
             }
         },
         "/document/{documentId}/page/{pageNumber}/metadata": {

--- a/api/search/routes.js
+++ b/api/search/routes.js
@@ -55,9 +55,19 @@ import { resolveSearchType } from './constants/searchTypes.js';
 export default function searchRouter({ searchService }) {
     const router = express.Router();
 
-    router.get('/', async (req, res, next) => {
+    /**
+     * Handles GET and POST search requests and returns a JSON:API search resource.
+     *
+     * @param {express.Request} req - Express request containing query/body search fields.
+     * @param {express.Response} res - Express response used to send JSON output.
+     * @param {express.NextFunction} next - Express next middleware callback.
+     * @returns {Promise<void>} A promise that resolves once the response is sent.
+     */
+    async function handleSearch(req, res, next) {
         try {
-            const { query, pageNumber, itemsPerPage, type: rawSearchType } = req.query;
+            const isPost = req.method === 'POST';
+            const source = isPost ? req.body || {} : req.query || {};
+            const { query, pageNumber, itemsPerPage, type: rawSearchType } = source;
 
             // Resolve and validate the search type, falling back to DEFAULT_SEARCH_TYPE
             // when absent or invalid. This ensures downstream consumers always receive
@@ -99,7 +109,10 @@ export default function searchRouter({ searchService }) {
         } catch (err) {
             next(err);
         }
-    });
+    }
+
+    router.get('/', handleSearch);
+    router.post('/', handleSearch);
 
     return router;
 }

--- a/app.js
+++ b/app.js
@@ -30,6 +30,7 @@ import isAuthenticated from './middleware/isAuthenticated/index.js';
 import defaultCreateLogger from './middleware/logger/index.js';
 import generalRateLimiter from './middleware/rateLimiter/index.js';
 import searchRouter from './search/routes.js';
+import createSavedSearchStore from './search/saved-search-store.js';
 import createSearchService from './search/search-service.js';
 import createTemplateEngineService from './templateEngine/index.js';
 
@@ -213,7 +214,11 @@ async function createApp({ createLogger = defaultCreateLogger } = {}) {
         caseSelected,
         debugMiddleware,
         enforceSearchTypeInQuery,
-        searchRouter({ createTemplateEngineService, createSearchService })
+        searchRouter({
+            createTemplateEngineService,
+            createSearchService,
+            createSavedSearchStore
+        })
     );
 
     app.use(notFoundHandler);

--- a/document/handlers/page-viewer.js
+++ b/document/handlers/page-viewer.js
@@ -18,13 +18,17 @@ import { paginationDataFromMetadata } from '../utils/pagination/index.js';
  * @param {Function} createMetadataServiceFactory - Factory function to create metadata service
  * @param {Function} createPageChunksServiceFactory - Factory function to create document page chunks service
  * @param {Function} [createTemplateEngineServiceFactory=createTemplateEngineService] - Factory that returns a template engine service with a render method
+ * @param {object} [options] - Optional dependencies.
+ * @param {(searchId: string) => Promise<object|null>} [options.findSavedSearchById] - Optional lookup for saved searches by opaque ID.
  * @returns {Function} Express route handler
  */
 export function createPageViewerHandler(
     createMetadataServiceFactory,
     createPageChunksServiceFactory,
-    createTemplateEngineServiceFactory = createTemplateEngineService
+    createTemplateEngineServiceFactory = createTemplateEngineService,
+    options = {}
 ) {
+    const { findSavedSearchById } = options;
     return async (req, res, next) => {
         try {
             const templateEngineService = createTemplateEngineServiceFactory();
@@ -32,12 +36,23 @@ export function createPageViewerHandler(
 
             // Use pre-validated parameters from middleware
             const { documentId, pageNumber, crn } = req.validatedParams;
-            const { searchTerm = '' } = req.query;
+            const { searchTerm = '', searchId = '' } = req.query;
             const searchType = getFeatureFlagValue(req.session, 'type');
             const alignFlag = getFeatureFlagValue(req.session, 'align');
             const userName = req.session?.username;
             const apiJwtToken = createApiJwtToken(userName);
             const debugQueryDslOverrides = res.locals.debugQueryDslOverrides || {};
+            let resolvedSearchTerm = typeof searchTerm === 'string' ? searchTerm : '';
+
+            if (typeof searchId === 'string' && searchId !== '' && typeof findSavedSearchById === 'function') {
+                const savedSearch = await findSavedSearchById(searchId);
+                if (
+                    savedSearch?.query &&
+                    savedSearch.caseReferenceNumber === req.session?.caseReferenceNumber
+                ) {
+                    resolvedSearchTerm = savedSearch.query;
+                }
+            }
 
             // Fetch document page metadata from API (which queries OpenSearch)
             let pageMetadata;
@@ -72,9 +87,10 @@ export function createPageViewerHandler(
                 documentId,
                 pageNumber,
                 crn,
-                searchTerm,
+                resolvedSearchTerm,
                 searchType,
-                req.session
+                req.session,
+                searchId
             );
 
             const pageTitle = formatPageTitle(pageMetadata.correspondence_type);
@@ -86,7 +102,7 @@ export function createPageViewerHandler(
                     documentId,
                     pageNumber,
                     crn,
-                    searchTerm,
+                    searchTerm: resolvedSearchTerm,
                     searchType,
                     jwtToken: apiJwtToken,
                     queryDslConfig: debugQueryDslOverrides,
@@ -96,7 +112,7 @@ export function createPageViewerHandler(
             } catch (error) {
                 // Chunks are core functionality - capture error to display to user
                 req.log?.error(
-                    { error: error.message, documentId, pageNumber, searchTerm },
+                    { error: error.message, documentId, pageNumber, searchTerm: resolvedSearchTerm },
                     'Failed to retrieve document page chunks'
                 );
                 return next(error);
@@ -124,7 +140,7 @@ export function createPageViewerHandler(
                     opensearch: {
                         ...(debugInfo.search?.opensearch || {}),
                         index: process.env.OPENSEARCH_INDEX_CHUNKS_NAME || 'unknown',
-                        preference: buildSearchSessionPreference(String(searchTerm))
+                        preference: buildSearchSessionPreference(String(resolvedSearchTerm))
                     }
                 };
             });

--- a/document/handlers/page-viewer.js
+++ b/document/handlers/page-viewer.js
@@ -36,15 +36,19 @@ export function createPageViewerHandler(
 
             // Use pre-validated parameters from middleware
             const { documentId, pageNumber, crn } = req.validatedParams;
-            const { searchTerm = '', searchId = '' } = req.query;
+            const { searchId = '' } = req.query;
             const searchType = getFeatureFlagValue(req.session, 'type');
             const alignFlag = getFeatureFlagValue(req.session, 'align');
             const userName = req.session?.username;
             const apiJwtToken = createApiJwtToken(userName);
             const debugQueryDslOverrides = res.locals.debugQueryDslOverrides || {};
-            let resolvedSearchTerm = typeof searchTerm === 'string' ? searchTerm : '';
+            let resolvedSearchTerm = '';
 
-            if (typeof searchId === 'string' && searchId !== '' && typeof findSavedSearchById === 'function') {
+            if (
+                typeof searchId === 'string' &&
+                searchId !== '' &&
+                typeof findSavedSearchById === 'function'
+            ) {
                 const savedSearch = await findSavedSearchById(searchId);
                 if (
                     savedSearch?.query &&
@@ -74,7 +78,7 @@ export function createPageViewerHandler(
             // work out the pagination data from the metadata and values needed to construct the URLs for the pagination links
             const paginationData = paginationDataFromMetadata(
                 pageMetadata,
-                req.query,
+                { searchId },
                 req.validatedParams,
                 viewMode,
                 searchType
@@ -87,35 +91,41 @@ export function createPageViewerHandler(
                 documentId,
                 pageNumber,
                 crn,
-                resolvedSearchTerm,
+                searchId,
                 searchType,
-                req.session,
-                searchId
+                req.session
             );
 
             const pageTitle = formatPageTitle(pageMetadata.correspondence_type);
 
             // Fetch document page chunks with bounding boxes for overlay rendering
             let pageChunks = [];
-            try {
-                const pageChunksServiceInstance = createPageChunksServiceFactory({
-                    documentId,
-                    pageNumber,
-                    crn,
-                    searchTerm: resolvedSearchTerm,
-                    searchType,
-                    jwtToken: apiJwtToken,
-                    queryDslConfig: debugQueryDslOverrides,
-                    logger: req.log
-                });
-                pageChunks = await pageChunksServiceInstance.getPageChunks();
-            } catch (error) {
-                // Chunks are core functionality - capture error to display to user
-                req.log?.error(
-                    { error: error.message, documentId, pageNumber, searchTerm: resolvedSearchTerm },
-                    'Failed to retrieve document page chunks'
-                );
-                return next(error);
+            if (resolvedSearchTerm !== '') {
+                try {
+                    const pageChunksServiceInstance = createPageChunksServiceFactory({
+                        documentId,
+                        pageNumber,
+                        crn,
+                        searchTerm: resolvedSearchTerm,
+                        searchType,
+                        jwtToken: apiJwtToken,
+                        queryDslConfig: debugQueryDslOverrides,
+                        logger: req.log
+                    });
+                    pageChunks = await pageChunksServiceInstance.getPageChunks();
+                } catch (error) {
+                    // Chunks are core functionality - capture error to display to user
+                    req.log?.error(
+                        {
+                            error: error.message,
+                            documentId,
+                            pageNumber,
+                            searchTerm: resolvedSearchTerm
+                        },
+                        'Failed to retrieve document page chunks'
+                    );
+                    return next(error);
+                }
             }
 
             const alignedPageHighlights = determineHighlightAlignmentStrategy(

--- a/document/handlers/page-viewer.test.js
+++ b/document/handlers/page-viewer.test.js
@@ -205,7 +205,13 @@ describe('Page Viewer Handler', () => {
                         renderParams = params;
                         return 'render-output-valid-metadata';
                     }
-                })
+                }),
+                {
+                    findSavedSearchById: async () => ({
+                        query: 'test',
+                        caseReferenceNumber: 'CASE-2024-001'
+                    })
+                }
             );
 
             const req = {
@@ -215,10 +221,11 @@ describe('Page Viewer Handler', () => {
                     crn: 'CASE-2024-001'
                 },
                 query: {
-                    searchTerm: 'test'
+                    searchId: 'srch_abc123'
                 },
                 session: {
                     caseSelected: 'CASE-2024-001',
+                    caseReferenceNumber: 'CASE-2024-001',
                     username: 'viewer@example.com'
                 },
                 log: { info: () => {}, error: () => {}, warn: () => {} }
@@ -281,7 +288,13 @@ describe('Page Viewer Handler', () => {
                         renderedPageChunks = params.pageChunks;
                         return 'render-output-session-align';
                     }
-                })
+                }),
+                {
+                    findSavedSearchById: async () => ({
+                        query: 'test',
+                        caseReferenceNumber: 'CASE-2024-003'
+                    })
+                }
             );
 
             const req = {
@@ -291,9 +304,10 @@ describe('Page Viewer Handler', () => {
                     crn: 'CASE-2024-003'
                 },
                 query: {
-                    searchTerm: 'test'
+                    searchId: 'srch_abc123'
                 },
                 session: {
+                    caseReferenceNumber: 'CASE-2024-003',
                     featureFlags: {
                         align: false
                     }

--- a/document/handlers/text-viewer.js
+++ b/document/handlers/text-viewer.js
@@ -18,13 +18,17 @@ import { paginationDataFromMetadata } from '../utils/pagination/index.js';
  * @param {Function} createMetadataServiceFactory -  Factory that returns a metadata service, that throws an error on invalid or malformed data.
  * @param {Function} createPageChunksServiceFactory - Factory that returns a page chunks service used for text highlights.
  * @param {Function} [createTemplateEngineServiceFactory=createTemplateEngineService] - Factory that returns a template engine service with a render method
+ * @param {object} [options] - Optional dependencies.
+ * @param {(searchId: string) => Promise<object|null>} [options.findSavedSearchById] - Optional lookup for saved searches by opaque ID.
  * @returns {Function} Express route handler
  */
 export function createTextViewerHandler(
     createMetadataServiceFactory,
     createPageChunksServiceFactory,
-    createTemplateEngineServiceFactory = createTemplateEngineService
+    createTemplateEngineServiceFactory = createTemplateEngineService,
+    options = {}
 ) {
+    const { findSavedSearchById } = options;
     return async (req, res, next) => {
         try {
             const templateEngineService = createTemplateEngineServiceFactory();
@@ -32,10 +36,21 @@ export function createTextViewerHandler(
 
             // Use pre-validated parameters from middleware
             const { documentId, pageNumber, crn } = req.validatedParams;
-            const { searchTerm = '' } = req.query;
+            const { searchTerm = '', searchId = '' } = req.query;
             const searchType = getFeatureFlagValue(req.session, 'type');
             const apiJwtToken = createApiJwtToken(req.session?.username);
             const debugQueryDslOverrides = res.locals.debugQueryDslOverrides || {};
+            let resolvedSearchTerm = typeof searchTerm === 'string' ? searchTerm : '';
+
+            if (typeof searchId === 'string' && searchId !== '' && typeof findSavedSearchById === 'function') {
+                const savedSearch = await findSavedSearchById(searchId);
+                if (
+                    savedSearch?.query &&
+                    savedSearch.caseReferenceNumber === req.session?.caseReferenceNumber
+                ) {
+                    resolvedSearchTerm = savedSearch.query;
+                }
+            }
 
             // Fetch document page metadata from OpenSearch via API
             let pageMetadata;
@@ -71,16 +86,18 @@ export function createTextViewerHandler(
                 documentId,
                 pageNumber,
                 crn,
-                searchTerm,
+                resolvedSearchTerm,
                 searchType,
-                req.session
+                req.session,
+                searchId
             );
 
             const { text } = pageMetadata;
 
             const pageText = text || 'No text content available for this page.'; // TODO: confirm with content team whether this is the desired fallback text when no OCR text is available
 
-            const safeSearchTerm = typeof searchTerm === 'string' ? searchTerm.trim() : '';
+            const safeSearchTerm =
+                typeof resolvedSearchTerm === 'string' ? resolvedSearchTerm.trim() : '';
             let pageChunks = [];
 
             if (safeSearchTerm !== '') {

--- a/document/handlers/text-viewer.js
+++ b/document/handlers/text-viewer.js
@@ -36,13 +36,17 @@ export function createTextViewerHandler(
 
             // Use pre-validated parameters from middleware
             const { documentId, pageNumber, crn } = req.validatedParams;
-            const { searchTerm = '', searchId = '' } = req.query;
+            const { searchId = '' } = req.query;
             const searchType = getFeatureFlagValue(req.session, 'type');
             const apiJwtToken = createApiJwtToken(req.session?.username);
             const debugQueryDslOverrides = res.locals.debugQueryDslOverrides || {};
-            let resolvedSearchTerm = typeof searchTerm === 'string' ? searchTerm : '';
+            let resolvedSearchTerm = '';
 
-            if (typeof searchId === 'string' && searchId !== '' && typeof findSavedSearchById === 'function') {
+            if (
+                typeof searchId === 'string' &&
+                searchId !== '' &&
+                typeof findSavedSearchById === 'function'
+            ) {
                 const savedSearch = await findSavedSearchById(searchId);
                 if (
                     savedSearch?.query &&
@@ -73,7 +77,7 @@ export function createTextViewerHandler(
             // construct the URLs for the pagination links.
             const paginationData = paginationDataFromMetadata(
                 pageMetadata,
-                req.query,
+                { searchId },
                 req.validatedParams,
                 viewMode,
                 searchType
@@ -86,10 +90,9 @@ export function createTextViewerHandler(
                 documentId,
                 pageNumber,
                 crn,
-                resolvedSearchTerm,
+                searchId,
                 searchType,
-                req.session,
-                searchId
+                req.session
             );
 
             const { text } = pageMetadata;

--- a/document/handlers/text-viewer.test.js
+++ b/document/handlers/text-viewer.test.js
@@ -224,7 +224,7 @@ describe('Text Viewer Handler', () => {
         assert.equal(result, sendResult);
     });
 
-    it('provides highlighted text segments when searchTerm is present', async () => {
+    it('provides highlighted text segments when searchId resolves to a query', async () => {
         let renderParams;
         let capturedChunkServiceArgs;
 
@@ -251,7 +251,13 @@ describe('Text Viewer Handler', () => {
                     renderParams = params;
                     return 'render-output-highlight';
                 }
-            })
+            }),
+            {
+                findSavedSearchById: async () => ({
+                    query: '12/12/1995',
+                    caseReferenceNumber: '26-745678'
+                })
+            }
         );
 
         const req = {
@@ -261,9 +267,9 @@ describe('Text Viewer Handler', () => {
                 crn: '26-745678'
             },
             query: {
-                searchTerm: '12/12/1995'
+                searchId: 'srch_abc123'
             },
-            session: { caseSelected: true },
+            session: { caseSelected: true, caseReferenceNumber: '26-745678' },
             cookies: { jwtToken: 'test-jwt' },
             log: { error: () => {} }
         };
@@ -320,28 +326,6 @@ describe('Text Viewer Handler', () => {
         let renderCalled = false;
         let sendCalled = false;
 
-        const handler = createTextViewerHandler(
-            () => ({
-                getPageMetadata: async () =>
-                    buildPageMetadataFixture({
-                        overrides: {
-                            text: 'Some text'
-                        }
-                    })
-            }),
-            () => ({
-                getPageChunks: async () => {
-                    throw pageChunksError;
-                }
-            }),
-            () => ({
-                render: () => {
-                    renderCalled = true;
-                    return 'render-output-page-chunks-failure';
-                }
-            })
-        );
-
         const req = {
             validatedParams: {
                 documentId: '123e4567-e89b-12d3-a456-426614174000',
@@ -349,9 +333,9 @@ describe('Text Viewer Handler', () => {
                 crn: '26-745678'
             },
             query: {
-                searchTerm: '  gabapentin  '
+                searchId: 'srch_abc123'
             },
-            session: { caseSelected: true },
+            session: { caseSelected: true, caseReferenceNumber: '26-745678' },
             cookies: { jwtToken: 'test-jwt' },
             log: {
                 error: (context, message) => {
@@ -374,7 +358,35 @@ describe('Text Viewer Handler', () => {
             return nextResult;
         };
 
-        const result = await handler(req, res, next);
+        const handlerWithSavedLookup = createTextViewerHandler(
+            () => ({
+                getPageMetadata: async () =>
+                    buildPageMetadataFixture({
+                        overrides: {
+                            text: 'Some text'
+                        }
+                    })
+            }),
+            () => ({
+                getPageChunks: async () => {
+                    throw pageChunksError;
+                }
+            }),
+            () => ({
+                render: () => {
+                    renderCalled = true;
+                    return 'render-output-metadata-failure';
+                }
+            }),
+            {
+                findSavedSearchById: async () => ({
+                    query: 'gabapentin',
+                    caseReferenceNumber: '26-745678'
+                })
+            }
+        );
+
+        const result = await handlerWithSavedLookup(req, res, next);
 
         assert.equal(nextError, pageChunksError);
         assert.deepEqual(loggedContext, {
@@ -389,7 +401,7 @@ describe('Text Viewer Handler', () => {
         assert.equal(result, nextResult);
     });
 
-    it('does not request chunks when searchTerm is blank', async () => {
+    it('does not request chunks when searchId cannot be resolved', async () => {
         let getPageChunksCalls = 0;
 
         const handler = createTextViewerHandler(
@@ -409,7 +421,10 @@ describe('Text Viewer Handler', () => {
             }),
             () => ({
                 render: () => 'render-output-no-search-term'
-            })
+            }),
+            {
+                findSavedSearchById: async () => null
+            }
         );
 
         const req = {
@@ -419,7 +434,7 @@ describe('Text Viewer Handler', () => {
                 crn: '26-745678'
             },
             query: {
-                searchTerm: '   '
+                searchId: 'srch_missing'
             },
             session: { caseSelected: true },
             cookies: { jwtToken: 'test-jwt' },

--- a/document/routes.js
+++ b/document/routes.js
@@ -1,12 +1,12 @@
 import express from 'express';
 import { validateDocumentParams } from '../middleware/validateDocumentParams/index.js';
+import createSavedSearchStoreDefault from '../search/saved-search-store.js';
 import { createImageStreamingHandler } from './handlers/image-streaming.js';
 import { createPageViewerHandler } from './handlers/page-viewer.js';
 import { createTextViewerHandler } from './handlers/text-viewer.js';
 import createPageChunksService from './services/document-chunks-service.js';
 import createDocumentMetadataService from './services/document-metadata-service.js';
 import { createS3Client } from './services/s3-service.js';
-import createSavedSearchStoreDefault from '../search/saved-search-store.js';
 
 /**
  * Creates an Express router for handling document viewing functionality.
@@ -25,7 +25,7 @@ function createDocumentRouter(options = {}) {
     const {
         createDocumentMetadataService: createMetadataServiceFactory = createDocumentMetadataService,
         createPageChunksService: createPageChunksServiceFactory = createPageChunksService,
-        createSavedSearchStore: createSavedSearchStore = createSavedSearchStoreDefault
+        createSavedSearchStore = createSavedSearchStoreDefault
     } = options;
     const router = express.Router();
     let savedSearchStore = null;
@@ -43,7 +43,11 @@ function createDocumentRouter(options = {}) {
         if (!savedSearchStore?.getById) {
             return null;
         }
-        return savedSearchStore.getById(searchId);
+        try {
+            return await savedSearchStore.getById(searchId);
+        } catch {
+            return null;
+        }
     };
 
     // Create S3 client
@@ -62,9 +66,14 @@ function createDocumentRouter(options = {}) {
     router.get(
         '/:documentId/view/page/:pageNumber',
         validateDocumentParams(),
-        createPageViewerHandler(createMetadataServiceFactory, createPageChunksServiceFactory, undefined, {
-            findSavedSearchById
-        })
+        createPageViewerHandler(
+            createMetadataServiceFactory,
+            createPageChunksServiceFactory,
+            undefined,
+            {
+                findSavedSearchById
+            }
+        )
     );
 
     // TEXT VIEWER ENDPOINT
@@ -72,9 +81,14 @@ function createDocumentRouter(options = {}) {
     router.get(
         '/:documentId/view/text/page/:pageNumber',
         validateDocumentParams(),
-        createTextViewerHandler(createMetadataServiceFactory, createPageChunksServiceFactory, undefined, {
-            findSavedSearchById
-        })
+        createTextViewerHandler(
+            createMetadataServiceFactory,
+            createPageChunksServiceFactory,
+            undefined,
+            {
+                findSavedSearchById
+            }
+        )
     );
 
     return router;

--- a/document/routes.js
+++ b/document/routes.js
@@ -6,6 +6,7 @@ import { createTextViewerHandler } from './handlers/text-viewer.js';
 import createPageChunksService from './services/document-chunks-service.js';
 import createDocumentMetadataService from './services/document-metadata-service.js';
 import { createS3Client } from './services/s3-service.js';
+import createSavedSearchStoreDefault from '../search/saved-search-store.js';
 
 /**
  * Creates an Express router for handling document viewing functionality.
@@ -13,6 +14,7 @@ import { createS3Client } from './services/s3-service.js';
  * @param {Object} [options] - Optional configuration object.
  * @param {Function} [options.createDocumentMetadataService] - Factory function to create the document metadata service (for testing).
  * @param {Function} [options.createPageChunksService] - Factory function to create the page chunks service (for testing).
+ * @param {Function} [options.createSavedSearchStore] - Factory function to create saved-search store (for testing).
  * @returns {express.Router} The configured Express router for document routes.
  *
  * @route GET /document/:documentId/page/:pageNumber - Image streaming endpoint
@@ -22,9 +24,27 @@ import { createS3Client } from './services/s3-service.js';
 function createDocumentRouter(options = {}) {
     const {
         createDocumentMetadataService: createMetadataServiceFactory = createDocumentMetadataService,
-        createPageChunksService: createPageChunksServiceFactory = createPageChunksService
+        createPageChunksService: createPageChunksServiceFactory = createPageChunksService,
+        createSavedSearchStore: createSavedSearchStore = createSavedSearchStoreDefault
     } = options;
     const router = express.Router();
+    let savedSearchStore = null;
+
+    if (typeof createSavedSearchStore === 'function') {
+        try {
+            savedSearchStore = createSavedSearchStore();
+        } catch {
+            // Keep legacy searchTerm flow when persistence is not configured.
+            savedSearchStore = null;
+        }
+    }
+
+    const findSavedSearchById = async (searchId) => {
+        if (!savedSearchStore?.getById) {
+            return null;
+        }
+        return savedSearchStore.getById(searchId);
+    };
 
     // Create S3 client
     const s3Client = createS3Client();
@@ -42,7 +62,9 @@ function createDocumentRouter(options = {}) {
     router.get(
         '/:documentId/view/page/:pageNumber',
         validateDocumentParams(),
-        createPageViewerHandler(createMetadataServiceFactory, createPageChunksServiceFactory)
+        createPageViewerHandler(createMetadataServiceFactory, createPageChunksServiceFactory, undefined, {
+            findSavedSearchById
+        })
     );
 
     // TEXT VIEWER ENDPOINT
@@ -50,7 +72,9 @@ function createDocumentRouter(options = {}) {
     router.get(
         '/:documentId/view/text/page/:pageNumber',
         validateDocumentParams(),
-        createTextViewerHandler(createMetadataServiceFactory, createPageChunksServiceFactory)
+        createTextViewerHandler(createMetadataServiceFactory, createPageChunksServiceFactory, undefined, {
+            findSavedSearchById
+        })
     );
 
     return router;

--- a/document/routes.test.js
+++ b/document/routes.test.js
@@ -10,7 +10,11 @@ import createDocumentRouter from './routes.js';
 /**
  * Helper function to set up a test express app with required middleware
  */
-function createTestApp(mockCreateDocumentMetadataService, stubCreatePageChunksServiceFactory) {
+function createTestApp(
+    mockCreateDocumentMetadataService,
+    stubCreatePageChunksServiceFactory,
+    stubCreateSavedSearchStore
+) {
     const stubPageChunksServiceFactory =
         stubCreatePageChunksServiceFactory ||
         (() => ({
@@ -34,18 +38,26 @@ function createTestApp(mockCreateDocumentMetadataService, stubCreatePageChunksSe
     // Setup minimal middleware
     testApp.use((req, res, next) => {
         req.session.caseSelected = true;
+        req.session.caseReferenceNumber = '12-745678';
         req.log = { info: () => {}, error: () => {}, warn: () => {}, debug: () => {} };
         res.locals.csrfToken = 'test-csrf-token';
         res.locals.cspNonce = 'test-csp-nonce';
         next();
     });
 
+    const savedSearchStoreFactory =
+        stubCreateSavedSearchStore ||
+        (() => ({
+            getById: async () => null
+        }));
+
     // Inject mock service into routes
     testApp.use(
         '/document',
         createDocumentRouter({
             createDocumentMetadataService: mockCreateDocumentMetadataService,
-            createPageChunksService: stubPageChunksServiceFactory
+            createPageChunksService: stubPageChunksServiceFactory,
+            createSavedSearchStore: savedSearchStoreFactory
         })
     );
 
@@ -139,7 +151,7 @@ describe('Document Routes', () => {
             );
 
             const res = await request(appWithPassingServices).get(
-                `/document/${docId}/view/page/1?crn=12-745678&searchTerm=test%20query`
+                `/document/${docId}/view/page/1?crn=12-745678&searchId=srch_abc123`
             );
             assert.equal(res.statusCode, 200);
             // Ensure mock correspondence_type influences title rendering indirectly
@@ -162,7 +174,7 @@ describe('Document Routes', () => {
 
             const docId = '123e4567-e89b-12d3-a456-426614174000';
             const res = await request(appWithFailingService).get(
-                `/document/${docId}/view/page/1?crn=12-745678`
+                `/document/${docId}/view/page/1?crn=12-745678&searchId=srch_abc123`
             );
 
             assert.equal(res.statusCode, 500);
@@ -179,12 +191,18 @@ describe('Document Routes', () => {
 
             const appWithFailingService = createTestApp(
                 passingMetadataService,
-                failingPageChunksService
+                failingPageChunksService,
+                () => ({
+                    getById: async () => ({
+                        query: 'test query',
+                        caseReferenceNumber: '12-745678'
+                    })
+                })
             );
 
             const docId = '123e4567-e89b-12d3-a456-426614174000';
             const res = await request(appWithFailingService).get(
-                `/document/${docId}/view/page/1?crn=12-745678`
+                `/document/${docId}/view/page/1?crn=12-745678&searchId=srch_abc123`
             );
 
             assert.equal(res.statusCode, 500);
@@ -195,7 +213,7 @@ describe('Document Routes', () => {
         it('renders text view with valid parameters', async () => {
             const docId = '123e4567-e89b-12d3-a456-426614174000';
             const res = await request(app).get(
-                `/document/${docId}/view/text/page/1?crn=12-745678&searchTerm=test`
+                `/document/${docId}/view/text/page/1?crn=12-745678&searchId=srch_abc123`
             );
 
             assert.equal(res.statusCode, 200);

--- a/document/utils/link-builders/index.js
+++ b/document/utils/link-builders/index.js
@@ -34,26 +34,22 @@ export function buildImageUrl(
  * @param {string} documentId - The document UUID
  * @param {number} pageNumber - The page number
  * @param {string} crn - The case reference number
- * @param {string} [searchTerm=''] - The search term
+ * @param {string} [searchId=''] - Opaque saved-search identifier
  * @param {string} [searchType=DEFAULT_SEARCH_TYPE] - The active search type value
  * @param {Object} [session={}] - The session object
- * @param {string} [searchId=''] - Optional opaque saved-search identifier
  * @returns {string} The text view URL
  */
 export function buildTextPageLink(
     documentId,
     pageNumber,
     crn,
-    searchTerm = '',
+    searchId = '',
     searchType = DEFAULT_SEARCH_TYPE,
-    session = {},
-    searchId = ''
+    session = {}
 ) {
-    const searchContext = searchId
-        ? `searchId=${encodeURIComponent(searchId)}`
-        : `searchTerm=${encodeURIComponent(searchTerm)}`;
-    const base = `/document/${documentId}/view/text/page/${pageNumber}?crn=${encodeURIComponent(crn)}&${searchContext}`;
-    return `${base}&type=${encodeURIComponent(resolveSearchType(searchType, session))}`;
+    const base = `/document/${documentId}/view/text/page/${pageNumber}?crn=${encodeURIComponent(crn)}`;
+    const searchContext = searchId ? `&searchId=${encodeURIComponent(searchId)}` : '';
+    return `${base}${searchContext}&type=${encodeURIComponent(resolveSearchType(searchType, session))}`;
 }
 
 /**
@@ -62,24 +58,20 @@ export function buildTextPageLink(
  * @param {string} documentId - The document UUID
  * @param {number} pageNumber - The page number
  * @param {string} crn - The case reference number
- * @param {string} [searchTerm=''] - The search term
+ * @param {string} [searchId=''] - Opaque saved-search identifier
  * @param {string} [searchType=DEFAULT_SEARCH_TYPE] - The active search type value
  * @param {Object} [session={}] - The session object
- * @param {string} [searchId=''] - Optional opaque saved-search identifier
  * @returns {string} The image view URL
  */
 export function buildImagePageLink(
     documentId,
     pageNumber,
     crn,
-    searchTerm = '',
+    searchId = '',
     searchType = DEFAULT_SEARCH_TYPE,
-    session = {},
-    searchId = ''
+    session = {}
 ) {
-    const searchContext = searchId
-        ? `searchId=${encodeURIComponent(searchId)}`
-        : `searchTerm=${encodeURIComponent(searchTerm)}`;
-    const base = `/document/${documentId}/view/page/${pageNumber}?crn=${encodeURIComponent(crn)}&${searchContext}`;
-    return `${base}&type=${encodeURIComponent(resolveSearchType(searchType, session))}`;
+    const base = `/document/${documentId}/view/page/${pageNumber}?crn=${encodeURIComponent(crn)}`;
+    const searchContext = searchId ? `&searchId=${encodeURIComponent(searchId)}` : '';
+    return `${base}${searchContext}&type=${encodeURIComponent(resolveSearchType(searchType, session))}`;
 }

--- a/document/utils/link-builders/index.js
+++ b/document/utils/link-builders/index.js
@@ -37,6 +37,7 @@ export function buildImageUrl(
  * @param {string} [searchTerm=''] - The search term
  * @param {string} [searchType=DEFAULT_SEARCH_TYPE] - The active search type value
  * @param {Object} [session={}] - The session object
+ * @param {string} [searchId=''] - Optional opaque saved-search identifier
  * @returns {string} The text view URL
  */
 export function buildTextPageLink(
@@ -45,9 +46,13 @@ export function buildTextPageLink(
     crn,
     searchTerm = '',
     searchType = DEFAULT_SEARCH_TYPE,
-    session = {}
+    session = {},
+    searchId = ''
 ) {
-    const base = `/document/${documentId}/view/text/page/${pageNumber}?crn=${encodeURIComponent(crn)}&searchTerm=${encodeURIComponent(searchTerm)}`;
+    const searchContext = searchId
+        ? `searchId=${encodeURIComponent(searchId)}`
+        : `searchTerm=${encodeURIComponent(searchTerm)}`;
+    const base = `/document/${documentId}/view/text/page/${pageNumber}?crn=${encodeURIComponent(crn)}&${searchContext}`;
     return `${base}&type=${encodeURIComponent(resolveSearchType(searchType, session))}`;
 }
 
@@ -60,6 +65,7 @@ export function buildTextPageLink(
  * @param {string} [searchTerm=''] - The search term
  * @param {string} [searchType=DEFAULT_SEARCH_TYPE] - The active search type value
  * @param {Object} [session={}] - The session object
+ * @param {string} [searchId=''] - Optional opaque saved-search identifier
  * @returns {string} The image view URL
  */
 export function buildImagePageLink(
@@ -68,8 +74,12 @@ export function buildImagePageLink(
     crn,
     searchTerm = '',
     searchType = DEFAULT_SEARCH_TYPE,
-    session = {}
+    session = {},
+    searchId = ''
 ) {
-    const base = `/document/${documentId}/view/page/${pageNumber}?crn=${encodeURIComponent(crn)}&searchTerm=${encodeURIComponent(searchTerm)}`;
+    const searchContext = searchId
+        ? `searchId=${encodeURIComponent(searchId)}`
+        : `searchTerm=${encodeURIComponent(searchTerm)}`;
+    const base = `/document/${documentId}/view/page/${pageNumber}?crn=${encodeURIComponent(crn)}&${searchContext}`;
     return `${base}&type=${encodeURIComponent(resolveSearchType(searchType, session))}`;
 }

--- a/document/utils/link-builders/index.test.js
+++ b/document/utils/link-builders/index.test.js
@@ -72,21 +72,21 @@ describe('Link Builders', () => {
 
     describe('buildTextPageLink', () => {
         it('builds text page link with search context', () => {
-            const result = buildTextPageLink(docId, 1, crn, 'search term');
+            const result = buildTextPageLink(docId, 1, crn, 'srch_abc123');
             assert.ok(result.includes(`/document/${docId}/view/text/page/1`));
             assert.ok(result.includes(`crn=${encodeURIComponent(crn)}`));
-            assert.ok(result.includes(`searchTerm=${encodeURIComponent('search term')}`));
+            assert.ok(result.includes('searchId=srch_abc123'));
         });
 
-        it('handles empty search parameters', () => {
+        it('omits searchId when not provided', () => {
             const result = buildTextPageLink(docId, 1, crn);
             assert.ok(result.includes(`/document/${docId}/view/text/page/1`));
-            assert.ok(result.includes('searchTerm='));
+            assert.ok(!result.includes('searchId='));
         });
 
-        it('encodes special characters in search term', () => {
-            const result = buildTextPageLink(docId, 1, crn, 'test & special');
-            assert.ok(result.includes(encodeURIComponent('test & special')));
+        it('encodes special characters in searchId', () => {
+            const result = buildTextPageLink(docId, 1, crn, 'srch/with spaces');
+            assert.ok(result.includes(`searchId=${encodeURIComponent('srch/with spaces')}`));
         });
 
         it('defaults to DEFAULT_SEARCH_TYPE when searchType is not provided', () => {
@@ -126,16 +126,16 @@ describe('Link Builders', () => {
 
     describe('buildImagePageLink', () => {
         it('builds image page link with search context', () => {
-            const result = buildImagePageLink(docId, 1, crn, 'search term');
+            const result = buildImagePageLink(docId, 1, crn, 'srch_abc123');
             assert.ok(result.includes(`/document/${docId}/view/page/1`));
             assert.ok(result.includes(`crn=${encodeURIComponent(crn)}`));
-            assert.ok(result.includes(`searchTerm=${encodeURIComponent('search term')}`));
+            assert.ok(result.includes('searchId=srch_abc123'));
         });
 
-        it('handles empty search parameters', () => {
+        it('omits searchId when not provided', () => {
             const result = buildImagePageLink(docId, 1, crn);
             assert.ok(result.includes(`/document/${docId}/view/page/1`));
-            assert.ok(result.includes('searchTerm='));
+            assert.ok(!result.includes('searchId='));
         });
 
         it('defaults to DEFAULT_SEARCH_TYPE when searchType is not provided', () => {

--- a/document/utils/pagination/index.js
+++ b/document/utils/pagination/index.js
@@ -89,20 +89,23 @@ const buildPaginationItems = ({ visiblePages, currentPageIndex, buildPageUrl }) 
  * @param {object} options - Query options.
  * @param {object} [options.query] - Optional request query object.
  * @param {string} [options.query.searchTerm] - Search term to preserve in links.
+ * @param {string} [options.query.searchId] - Opaque saved-search ID to preserve in links.
  * @param {object} [options.params] - Optional route params object.
  * @param {string} [options.params.crn] - Case reference number.
  * @param {string} [options.resolvedSearchType] - The canonical resolved search type (from session/default). Used instead of raw query.type to ensure pagination links are always canonical.
  * @returns {string} Encoded query string.
  */
 const buildQueryString = ({ query, params, resolvedSearchType }) => {
-    const { searchTerm = '' } = query || {};
+    const { searchTerm = '', searchId = '' } = query || {};
     const { crn } = params || {};
     const queryParams = new URLSearchParams();
 
     if (crn) {
         queryParams.append('crn', crn);
     }
-    if (searchTerm) {
+    if (searchId) {
+        queryParams.append('searchId', searchId);
+    } else if (searchTerm) {
         queryParams.append('searchTerm', searchTerm);
     }
     if (resolvedSearchType) {

--- a/document/utils/pagination/index.js
+++ b/document/utils/pagination/index.js
@@ -88,7 +88,6 @@ const buildPaginationItems = ({ visiblePages, currentPageIndex, buildPageUrl }) 
  *
  * @param {object} options - Query options.
  * @param {object} [options.query] - Optional request query object.
- * @param {string} [options.query.searchTerm] - Search term to preserve in links.
  * @param {string} [options.query.searchId] - Opaque saved-search ID to preserve in links.
  * @param {object} [options.params] - Optional route params object.
  * @param {string} [options.params.crn] - Case reference number.
@@ -96,7 +95,7 @@ const buildPaginationItems = ({ visiblePages, currentPageIndex, buildPageUrl }) 
  * @returns {string} Encoded query string.
  */
 const buildQueryString = ({ query, params, resolvedSearchType }) => {
-    const { searchTerm = '', searchId = '' } = query || {};
+    const { searchId = '' } = query || {};
     const { crn } = params || {};
     const queryParams = new URLSearchParams();
 
@@ -105,8 +104,6 @@ const buildQueryString = ({ query, params, resolvedSearchType }) => {
     }
     if (searchId) {
         queryParams.append('searchId', searchId);
-    } else if (searchTerm) {
-        queryParams.append('searchTerm', searchTerm);
     }
     if (resolvedSearchType) {
         queryParams.append('type', resolvedSearchType);

--- a/document/utils/pagination/index.test.js
+++ b/document/utils/pagination/index.test.js
@@ -23,10 +23,10 @@ describe('paginationDataFromMetadata', () => {
         assert.strictEqual(result.next, null);
     });
 
-    it('includes search query parameters in generated page URLs', () => {
+    it('includes searchId in generated page URLs', () => {
         const result = paginationDataFromMetadata(
             { page_num: 2, page_count: 3 },
-            { searchTerm: 'acute pain' },
+            { searchId: 'srch_abc123' },
             params
         );
 
@@ -34,7 +34,8 @@ describe('paginationDataFromMetadata', () => {
         const parsed = new URL(firstHref, 'http://localhost');
 
         assert.strictEqual(parsed.searchParams.get('crn'), '12-745678');
-        assert.strictEqual(parsed.searchParams.get('searchTerm'), 'acute pain');
+        assert.strictEqual(parsed.searchParams.get('searchId'), 'srch_abc123');
+        assert.strictEqual(parsed.searchParams.get('searchTerm'), null);
         assert.strictEqual(result.previous?.text, 'Previous');
         assert.strictEqual(result.next?.text, 'Next');
     });

--- a/middleware/enforceCrnInQuery/allowList.test.js
+++ b/middleware/enforceCrnInQuery/allowList.test.js
@@ -11,6 +11,7 @@ assert.deepStrictEqual(
 
 // --- Pattern-based allowlist test ---
 const validPaths = [
+    '/search/s/srch_abc123',
     '/document/123e4567-e89b-12d3-a456-426614174000/view/page/1',
     '/document/abcdefab-1234-5678-abcd-abcdefabcdef/view/page/42',
     '/document/123e4567-e89b-12d3-a456-426614174000/view/text/page/1',

--- a/middleware/enforceCrnInQuery/index.js
+++ b/middleware/enforceCrnInQuery/index.js
@@ -18,6 +18,7 @@ const ALLOWED_PATHS = ['/search'];
  * if (ALLOWED_PATH_PATTERNS.some(pattern => pattern.test(request.path))) { ... }
  */
 const ALLOWED_PATH_PATTERNS = [
+    /^\/search\/s\/[^/]+$/,
     /^\/document\/[0-9a-fA-F-]{36}\/view\/page\/\d+$/,
     /^\/document\/[0-9a-fA-F-]{36}\/view\/text\/page\/\d+$/, // Text viewer endpoint
     /^\/document\/[0-9a-fA-F-]{36}\/page\/\d+$/ // Image streaming endpoint

--- a/middleware/enforceCrnInQuery/index.test.js
+++ b/middleware/enforceCrnInQuery/index.test.js
@@ -224,6 +224,25 @@ test('allows redirect for path matching allowed patterns', () => {
     assert.strictEqual(nextCalled, false);
 });
 
+test('allows redirect for saved search route pattern', () => {
+    const req = createMockReq({
+        method: 'GET',
+        query: { pageNumber: '2' },
+        session: { caseSelected: true, caseReferenceNumber: '12-745678' }
+    });
+    req.path = '/search/s/srch_abc123';
+    const res = createMockRes();
+    let nextCalled = false;
+    const next = () => {
+        nextCalled = true;
+    };
+
+    enforceCrnInQuery(req, res, next);
+
+    assert.strictEqual(res.redirectedUrl, '/search/s/srch_abc123?pageNumber=2&crn=12-745678');
+    assert.strictEqual(nextCalled, false);
+});
+
 test('allows redirect for image streaming endpoint pattern', () => {
     const req = createMockReq({
         method: 'GET',

--- a/middleware/enforceFeatureFlagsInQuery/allowList.test.js
+++ b/middleware/enforceFeatureFlagsInQuery/allowList.test.js
@@ -11,6 +11,7 @@ assert.deepStrictEqual(
 
 // --- Pattern-based allowlist test ---
 const validPaths = [
+    '/search/s/srch_abc123',
     '/document/123e4567-e89b-12d3-a456-426614174000/view/page/1',
     '/document/abcdefab-1234-5678-abcd-abcdefabcdef/view/page/42',
     '/document/123e4567-e89b-12d3-a456-426614174000/view/text/page/1',

--- a/middleware/enforceFeatureFlagsInQuery/index.js
+++ b/middleware/enforceFeatureFlagsInQuery/index.js
@@ -11,6 +11,7 @@ const DOCUMENT_VIEW_PAGE_PATH_PATTERN = /^\/document\/([0-9a-fA-F-]{36})\/view\/
 const DOCUMENT_VIEW_TEXT_PAGE_PATH_PATTERN =
     /^\/document\/([0-9a-fA-F-]{36})\/view\/text\/page\/(\d+)$/;
 const DOCUMENT_IMAGE_PAGE_PATH_PATTERN = /^\/document\/([0-9a-fA-F-]{36})\/page\/(\d+)$/;
+const SEARCH_SAVED_PATH_PATTERN = /^\/search\/s\/([^/]+)$/;
 
 /**
  * An array of allowed URL patterns for which feature-flag enforcement applies.
@@ -18,6 +19,7 @@ const DOCUMENT_IMAGE_PAGE_PATH_PATTERN = /^\/document\/([0-9a-fA-F-]{36})\/page\
  * @constant
  */
 const ALLOWED_PATH_PATTERNS = [
+    SEARCH_SAVED_PATH_PATTERN,
     DOCUMENT_VIEW_PAGE_PATH_PATTERN,
     DOCUMENT_VIEW_TEXT_PAGE_PATH_PATTERN,
     DOCUMENT_IMAGE_PAGE_PATH_PATTERN // Image streaming endpoint
@@ -67,6 +69,12 @@ function resolveSafeRedirectPath(path) {
 
     if (ALLOWED_PATHS.includes(normalizedPath)) {
         return normalizedPath;
+    }
+
+    const savedSearchMatch = normalizedPath.match(SEARCH_SAVED_PATH_PATTERN);
+    if (savedSearchMatch) {
+        const [, searchId] = savedSearchMatch;
+        return `/search/s/${searchId}`;
     }
 
     const viewPageMatch = normalizedPath.match(DOCUMENT_VIEW_PAGE_PATH_PATTERN);

--- a/middleware/enforceFeatureFlagsInQuery/index.test.js
+++ b/middleware/enforceFeatureFlagsInQuery/index.test.js
@@ -272,7 +272,10 @@ test('redirects for saved search page path', () => {
 
     enforceFeatureFlagsInQuery(req, res, () => {});
 
-    assert.strictEqual(res.redirectedUrl, '/search/s/srch_abc123?pageNumber=2&crn=12-745678&align=off');
+    assert.strictEqual(
+        res.redirectedUrl,
+        '/search/s/srch_abc123?pageNumber=2&crn=12-745678&align=off'
+    );
 });
 
 test('normalises trailing slash before checking allowed path', () => {

--- a/middleware/enforceFeatureFlagsInQuery/index.test.js
+++ b/middleware/enforceFeatureFlagsInQuery/index.test.js
@@ -262,6 +262,19 @@ test('redirects for document image streaming endpoint', () => {
     );
 });
 
+test('redirects for saved search page path', () => {
+    const req = createMockReq({
+        path: '/search/s/srch_abc123',
+        query: { pageNumber: '2', crn: '12-745678' },
+        session: { featureFlags: { align: false, type: DEFAULT_SEARCH_TYPE, debug: false } }
+    });
+    const res = createMockRes();
+
+    enforceFeatureFlagsInQuery(req, res, () => {});
+
+    assert.strictEqual(res.redirectedUrl, '/search/s/srch_abc123?pageNumber=2&crn=12-745678&align=off');
+});
+
 test('normalises trailing slash before checking allowed path', () => {
     const req = createMockReq({
         path: '/search/',

--- a/search/macro/search-result-item/template.njk
+++ b/search/macro/search-result-item/template.njk
@@ -2,7 +2,7 @@
 <p class="govuk-hint govuk-visually-hidden">Received on {{ params._source.received_date | formatDate}}</p>
 <p class="govuk-body">{{ params._source.chunk_text | safe }}</p>
 
-<p class="govuk-body"><strong>Found on:</strong> <a href="/document/{{ params.docUuid }}/view/page/{{ params._source.page_number or '0' }}?crn={{ params.caseReferenceNumber | urlencode }}&searchTerm={{ params.searchTerm | urlencode }}&type={{ params.searchType | urlencode }}" class="govuk-link">Page {{ params._source.page_number }}</a></p>
+<p class="govuk-body"><strong>Found on:</strong> <a href="/document/{{ params.docUuid }}/view/page/{{ params._source.page_number or '0' }}?crn={{ params.caseReferenceNumber | urlencode }}{% if params.searchId %}&searchId={{ params.searchId | urlencode }}{% else %}&searchTerm={{ params.searchTerm | urlencode }}{% endif %}&type={{ params.searchType | urlencode }}" class="govuk-link">Page {{ params._source.page_number }}</a></p>
 
 {% if params.isDebugMode %}
   <div class="search-result-debug">

--- a/search/macro/search-result-item/template.njk
+++ b/search/macro/search-result-item/template.njk
@@ -2,7 +2,7 @@
 <p class="govuk-hint govuk-visually-hidden">Received on {{ params._source.received_date | formatDate}}</p>
 <p class="govuk-body">{{ params._source.chunk_text | safe }}</p>
 
-<p class="govuk-body"><strong>Found on:</strong> <a href="/document/{{ params.docUuid }}/view/page/{{ params._source.page_number or '0' }}?crn={{ params.caseReferenceNumber | urlencode }}{% if params.searchId %}&searchId={{ params.searchId | urlencode }}{% else %}&searchTerm={{ params.searchTerm | urlencode }}{% endif %}&type={{ params.searchType | urlencode }}" class="govuk-link">Page {{ params._source.page_number }}</a></p>
+<p class="govuk-body"><strong>Found on:</strong> <a href="/document/{{ params.docUuid }}/view/page/{{ params._source.page_number or '0' }}?crn={{ params.caseReferenceNumber | urlencode }}{% if params.searchId %}&searchId={{ params.searchId | urlencode }}{% endif %}&type={{ params.searchType | urlencode }}" class="govuk-link">Page {{ params._source.page_number }}</a></p>
 
 {% if params.isDebugMode %}
   <div class="search-result-debug">

--- a/search/page/results.njk
+++ b/search/page/results.njk
@@ -81,11 +81,11 @@
     {% if searchId %}
         {% set paginationPrevious = {
             text: "Previous",
-            href: ["/search/s/", searchId | urlencode, "?pageNumber=", pagination.currentPageIndex - 1] | join
+            href: ["/search/s/", searchId | urlencode, "?pageNumber=", pagination.currentPageIndex - 1, "&crn=", caseReferenceNumber | urlencode] | join
         } %}
         {% set paginationNext = {
             text: "Next",
-            href: ["/search/s/", searchId | urlencode, "?pageNumber=", pagination.currentPageIndex + 1] | join
+            href: ["/search/s/", searchId | urlencode, "?pageNumber=", pagination.currentPageIndex + 1, "&crn=", caseReferenceNumber | urlencode] | join
         } %}
     {% endif %}
     {# only show pagination item links if there is more than one page #}
@@ -94,7 +94,7 @@
             {%
                 set paginationItems = (paginationItems.push({
                     text: i,
-                    href: ["/search/s/", searchId | urlencode, "?pageNumber=", i] | join,
+                    href: ["/search/s/", searchId | urlencode, "?pageNumber=", i, "&crn=", caseReferenceNumber | urlencode] | join,
                     selected: i == pagination.currentPageIndex
                 }), paginationItems)
             %}

--- a/search/page/results.njk
+++ b/search/page/results.njk
@@ -86,6 +86,16 @@
             href: ["/search/?query=", query | urlencode, "&pageNumber=", pagination.currentPageIndex + 1, "&crn=", caseReferenceNumber | urlencode, "&type=", searchType | urlencode] | join
         }
     %}
+    {% if searchId %}
+        {% set paginationPrevious = {
+            text: "Previous",
+            href: ["/search/s/", searchId | urlencode, "?pageNumber=", pagination.currentPageIndex - 1] | join
+        } %}
+        {% set paginationNext = {
+            text: "Next",
+            href: ["/search/s/", searchId | urlencode, "?pageNumber=", pagination.currentPageIndex + 1] | join
+        } %}
+    {% endif %}
     {# only show pagination item links if there is more than one page #}
     {% if showPaginationItems %}
         {% for i in range(1, pagination.totalPageCount + 1) %}
@@ -93,6 +103,18 @@
                 set paginationItems = (paginationItems.push({
                     text: i,
                     href: ["/search/?query=", query | urlencode, "&pageNumber=", i, "&crn=", caseReferenceNumber | urlencode, "&type=", searchType | urlencode] | join,
+                    selected: i == pagination.currentPageIndex
+                }), paginationItems)
+            %}
+        {% endfor %}
+    {% endif %}
+    {% if showPaginationItems and searchId %}
+        {% set paginationItems = [] %}
+        {% for i in range(1, pagination.totalPageCount + 1) %}
+            {%
+                set paginationItems = (paginationItems.push({
+                    text: i,
+                    href: ["/search/s/", searchId | urlencode, "?pageNumber=", i] | join,
                     selected: i == pagination.currentPageIndex
                 }), paginationItems)
             %}

--- a/search/page/results.njk
+++ b/search/page/results.njk
@@ -76,16 +76,8 @@
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
     {% set paginationItems = [] %}
-    {% set paginationPrevious = {
-            text: "Previous",
-            href: ["/search/?query=", query | urlencode, "&pageNumber=", pagination.currentPageIndex - 1, "&crn=", caseReferenceNumber | urlencode, "&type=", searchType | urlencode] | join
-        }
-    %}
-    {% set paginationNext = {
-            text: "Next",
-            href: ["/search/?query=", query | urlencode, "&pageNumber=", pagination.currentPageIndex + 1, "&crn=", caseReferenceNumber | urlencode, "&type=", searchType | urlencode] | join
-        }
-    %}
+    {% set paginationPrevious = null %}
+    {% set paginationNext = null %}
     {% if searchId %}
         {% set paginationPrevious = {
             text: "Previous",
@@ -97,19 +89,7 @@
         } %}
     {% endif %}
     {# only show pagination item links if there is more than one page #}
-    {% if showPaginationItems %}
-        {% for i in range(1, pagination.totalPageCount + 1) %}
-            {%
-                set paginationItems = (paginationItems.push({
-                    text: i,
-                    href: ["/search/?query=", query | urlencode, "&pageNumber=", i, "&crn=", caseReferenceNumber | urlencode, "&type=", searchType | urlencode] | join,
-                    selected: i == pagination.currentPageIndex
-                }), paginationItems)
-            %}
-        {% endfor %}
-    {% endif %}
     {% if showPaginationItems and searchId %}
-        {% set paginationItems = [] %}
         {% for i in range(1, pagination.totalPageCount + 1) %}
             {%
                 set paginationItems = (paginationItems.push({

--- a/search/page/templates.test.js
+++ b/search/page/templates.test.js
@@ -172,4 +172,33 @@ describe('search page templates', () => {
         assert.doesNotMatch(html, /search-result-debug/);
         assert.doesNotMatch(html, /Relevance score:/);
     });
+
+    it('renders document links with searchId when provided', () => {
+        const html = createRenderer().render('search/page/results.njk', {
+            ...baseResultsContext,
+            searchId: 'srch_abc123',
+            searchResults: [
+                {
+                    docUuid: 'doc-123',
+                    searchId: 'srch_abc123',
+                    searchTerm: 'jaw fracture',
+                    searchType: 'semantic',
+                    caseReferenceNumber: '12-745678',
+                    _source: {
+                        correspondence_type: 'Medical report',
+                        source_file_name: 'report.pdf',
+                        chunk_text: 'Result snippet',
+                        page_number: 3,
+                        received_date: '2026-01-12T00:00:00Z'
+                    }
+                }
+            ]
+        });
+
+        assert.match(
+            html,
+            /\/document\/doc-123\/view\/page\/3\?crn=12-745678&searchId=srch_abc123&type=semantic/
+        );
+        assert.doesNotMatch(html, /searchTerm=jaw%20fracture/);
+    });
 });

--- a/search/page/templates.test.js
+++ b/search/page/templates.test.js
@@ -71,8 +71,8 @@ describe('search page templates', () => {
         });
 
         assert.match(html, /name="type" value="semantic"/);
-        assert.match(html, /\/search\/s\/srch_abc123\?pageNumber=1/);
-        assert.match(html, /\/search\/s\/srch_abc123\?pageNumber=3/);
+        assert.match(html, /\/search\/s\/srch_abc123\?pageNumber=1&amp;crn=12-745678/);
+        assert.match(html, /\/search\/s\/srch_abc123\?pageNumber=3&amp;crn=12-745678/);
         assert.match(
             html,
             /\/document\/doc-123\/view\/page\/3\?crn=12-745678&searchId=srch_abc123&type=semantic/
@@ -136,8 +136,8 @@ describe('search page templates', () => {
             ]
         });
 
-        assert.match(html, /\/search\/s\/srch_abc123\?pageNumber=1/);
-        assert.match(html, /\/search\/s\/srch_abc123\?pageNumber=3/);
+        assert.match(html, /\/search\/s\/srch_abc123\?pageNumber=1&amp;crn=12-745678/);
+        assert.match(html, /\/search\/s\/srch_abc123\?pageNumber=3&amp;crn=12-745678/);
         assert.doesNotMatch(html, /\/search\/\?query=jaw%20fracture/);
     });
 

--- a/search/page/templates.test.js
+++ b/search/page/templates.test.js
@@ -18,6 +18,7 @@ describe('search page templates', () => {
         csrfToken: 'csrf-token',
         cspNonce: 'nonce',
         userName: 'search.user@example.com',
+        searchId: 'srch_abc123',
         query: 'jaw fracture',
         searchType: 'semantic',
         searchTerm: 'jaw fracture',
@@ -54,6 +55,7 @@ describe('search page templates', () => {
             searchResults: [
                 {
                     docUuid: 'doc-123',
+                    searchId: 'srch_abc123',
                     searchTerm: 'jaw fracture',
                     searchType: 'semantic',
                     caseReferenceNumber: '12-745678',
@@ -69,18 +71,14 @@ describe('search page templates', () => {
         });
 
         assert.match(html, /name="type" value="semantic"/);
+        assert.match(html, /\/search\/s\/srch_abc123\?pageNumber=1/);
+        assert.match(html, /\/search\/s\/srch_abc123\?pageNumber=3/);
         assert.match(
             html,
-            /\/search\/\?query=jaw%20fracture&amp;pageNumber=1&amp;crn=12-745678&amp;type=semantic/
+            /\/document\/doc-123\/view\/page\/3\?crn=12-745678&searchId=srch_abc123&type=semantic/
         );
-        assert.match(
-            html,
-            /\/search\/\?query=jaw%20fracture&amp;pageNumber=3&amp;crn=12-745678&amp;type=semantic/
-        );
-        assert.match(
-            html,
-            /\/document\/doc-123\/view\/page\/3\?crn=12-745678&searchTerm=jaw%20fracture&type=semantic/
-        );
+        assert.doesNotMatch(html, /\/search\/\?query=jaw%20fracture/);
+        assert.doesNotMatch(html, /searchTerm=jaw%20fracture/);
     });
 
     it('renders result-level debug tags and relevance score when debug feature flag is enabled', () => {

--- a/search/page/templates.test.js
+++ b/search/page/templates.test.js
@@ -117,6 +117,32 @@ describe('search page templates', () => {
         assert.match(html, /Relevance score:\s*9\.42/);
     });
 
+    it('renders pagination links using shareable searchId when present', () => {
+        const html = createRenderer().render('search/page/results.njk', {
+            ...baseResultsContext,
+            searchId: 'srch_abc123',
+            searchResults: [
+                {
+                    docUuid: 'doc-123',
+                    searchTerm: 'jaw fracture',
+                    searchType: 'semantic',
+                    caseReferenceNumber: '12-745678',
+                    _source: {
+                        correspondence_type: 'Medical report',
+                        source_file_name: 'report.pdf',
+                        chunk_text: 'Result snippet',
+                        page_number: 3,
+                        received_date: '2026-01-12T00:00:00Z'
+                    }
+                }
+            ]
+        });
+
+        assert.match(html, /\/search\/s\/srch_abc123\?pageNumber=1/);
+        assert.match(html, /\/search\/s\/srch_abc123\?pageNumber=3/);
+        assert.doesNotMatch(html, /\/search\/\?query=jaw%20fracture/);
+    });
+
     it('does not render result-level debug metadata when debug feature flag is disabled', () => {
         const html = createRenderer().render('search/page/results.njk', {
             ...baseResultsContext,

--- a/search/routes.js
+++ b/search/routes.js
@@ -6,7 +6,7 @@ import { finalizeDebugInfo, hasDebugContext, ifDebugContext } from '../middlewar
 import { getFeatureFlagValue } from '../middleware/featureFlags/index.js';
 import createApiJwtToken from '../service/request/create-api-jwt-token.js';
 import buildViewModel from '../templateEngine/buildViewModel.js';
-import buildSearchSessionPreference from '../utils/buildSearchSessionPreference.js';
+import buildSearchSessionPreference from '../utils/buildSearchSessionPreference/index.js';
 import createSavedSearchStoreDefault from './saved-search-store.js';
 
 /**

--- a/search/routes.js
+++ b/search/routes.js
@@ -220,6 +220,16 @@ function createSearchRouter({
             const { pageNumber = 1 } = req.query;
             const searchType = resolveSearchType(req.body?.type, req.session);
 
+            const redirectToLegacySearch = () => {
+                const redirectParams = new URLSearchParams({
+                    query: query.trim(),
+                    pageNumber: String(pageNumber),
+                    type: searchType
+                });
+
+                return res.redirect(`/search?${redirectParams.toString()}`);
+            };
+
             if (savedSearchStore?.create) {
                 return savedSearchStore
                     .create({
@@ -238,16 +248,19 @@ function createSearchRouter({
                             `/search/s/${encodeURIComponent(id)}?${redirectParams.toString()}`
                         );
                     })
-                    .catch(next);
+                    .catch((error) => {
+                        req.log?.warn?.(
+                            {
+                                error: error?.message,
+                                caseReferenceNumber: req.session?.caseReferenceNumber
+                            },
+                            'Saved search store unavailable, falling back to legacy search redirect'
+                        );
+                        return redirectToLegacySearch();
+                    });
             }
 
-            const redirectParams = new URLSearchParams({
-                query: query.trim(),
-                pageNumber: String(pageNumber),
-                type: searchType
-            });
-
-            return res.redirect(`/search?${redirectParams.toString()}`);
+            return redirectToLegacySearch();
         } catch (err) {
             next(err);
         }

--- a/search/routes.js
+++ b/search/routes.js
@@ -6,7 +6,8 @@ import { finalizeDebugInfo, hasDebugContext, ifDebugContext } from '../middlewar
 import { getFeatureFlagValue } from '../middleware/featureFlags/index.js';
 import createApiJwtToken from '../service/request/create-api-jwt-token.js';
 import buildViewModel from '../templateEngine/buildViewModel.js';
-import buildSearchSessionPreference from '../utils/buildSearchSessionPreference/index.js';
+import buildSearchSessionPreference from '../utils/buildSearchSessionPreference.js';
+import createSavedSearchStoreDefault from './saved-search-store.js';
 
 /**
  * Creates an Express router for handling search functionality.
@@ -14,74 +15,49 @@ import buildSearchSessionPreference from '../utils/buildSearchSessionPreference/
  * @param {Object} services - The services required to create the router.
  * @param {Function} services.createTemplateEngineService - Factory function to create the template engine service.
  * @param {Function} services.createSearchService - Factory function to create the search service.
+ * @param {Function} [services.createSavedSearchStore] - Optional factory function to create the saved search store.
  * @returns {express.Router} The configured Express router for search routes.
  *
  * @route POST /search
  * @route GET /search
+ * @route GET /search/s/:searchId
  */
-function createSearchRouter({ createTemplateEngineService, createSearchService }) {
+function createSearchRouter({
+    createTemplateEngineService,
+    createSearchService,
+    createSavedSearchStore = createSavedSearchStoreDefault
+}) {
     const router = express.Router();
-
-    /**
-     * Handles search form submissions and normalizes input into query-string based navigation.
-     *
-     * @param {express.Request} req - Express request containing body fields.
-     * @param {express.Response} res - Express response used for redirects.
-     * @param {express.NextFunction} next - Express next middleware callback.
-     * @returns {void}
-     */
-    router.post('/', (req, res, next) => {
+    let savedSearchStore = null;
+    if (typeof createSavedSearchStore === 'function') {
         try {
-            const { query } = req.body;
-            const { pageNumber = 1 } = req.query;
-            const searchType = resolveSearchType(req.body?.type, req.session);
-
-            const redirectParams = new URLSearchParams({
-                query: query.trim(),
-                pageNumber: String(pageNumber),
-                type: searchType
-            });
-
-            return res.redirect(`/search?${redirectParams.toString()}`);
-        } catch (err) {
-            next(err);
+            savedSearchStore = createSavedSearchStore();
+        } catch {
+            // Keep legacy behavior when saved-search persistence is not configured.
+            savedSearchStore = null;
         }
-    });
+    }
 
     /**
-     * Renders search index/results pages and coordinates API-backed search execution.
+     * Renders search results using either raw query input or a saved search definition.
      *
-     * @param {express.Request} req - Express request with query parameters and session context.
-     * @param {express.Response} res - Express response used to send rendered HTML.
+     * @param {express.Request} req - Express request object.
+     * @param {express.Response} res - Express response object.
      * @param {express.NextFunction} next - Express next middleware callback.
-     * @returns {Promise<void>}
+     * @param {{query: string, searchType: string, searchId?: string}} options - Search rendering options.
+     * @returns {Promise<void>} Resolves when the response is sent.
      */
-    router.get('/', async (req, res, next) => {
+    async function renderSearchResults(req, res, next, { query, searchType, searchId }) {
         try {
             const templateEngineService = createTemplateEngineService();
             const { render } = templateEngineService;
-
-            const { query, pageNumber: rawPageNumber, itemsPerPage: rawItemsPerPage } = req.query;
+            const { pageNumber: rawPageNumber, itemsPerPage: rawItemsPerPage } = req.query;
             const userName = req.session?.username;
-            const searchType = getFeatureFlagValue(req.session, 'type');
             const isDebugMode = Boolean(hasDebugContext(res));
             const debugQueryDslOverrides = isDebugMode
                 ? res.locals.debugQueryDslOverrides || {}
                 : {};
             const debugQueryDslConfig = res.locals.debugQueryDslConfig;
-
-            if (!query) {
-                finalizeDebugInfo(res, 200);
-                const html = render(
-                    'search/page/index.njk',
-                    buildViewModel(req, res, {
-                        pageType: 'search',
-                        searchType,
-                        isDebugMode
-                    })
-                );
-                return res.send(html);
-            }
 
             const pageNumber = Math.max(Number(rawPageNumber) || 1, 1);
             const itemsPerPage = Math.max(
@@ -93,10 +69,14 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
                 pageType: 'search',
                 query,
                 searchType,
+                searchId,
                 isDebugMode
             });
 
-            req.log?.debug?.({ query, pageNumber, itemsPerPage }, 'Creating search service');
+            req.log?.debug?.(
+                { query, pageNumber, itemsPerPage, searchId },
+                'Creating search service'
+            );
             const searchService = createSearchService({
                 caseReferenceNumber: req.session?.caseReferenceNumber,
                 logger: req.log
@@ -191,6 +171,7 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
                 ),
                 docUuid: hit._source?.source_doc_id || 0,
                 searchTerm: query,
+                searchId,
                 searchType,
                 isDebugMode,
                 caseReferenceNumber: req.session?.caseReferenceNumber,
@@ -221,6 +202,117 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
             return res.status(200).send(html);
         } catch (error) {
             req.log.error('Error occurred while processing search request:', error);
+            next(error);
+        }
+    }
+
+    /**
+     * Handles search form submissions and normalizes input into query-string based navigation.
+     *
+     * @param {express.Request} req - Express request containing body fields.
+     * @param {express.Response} res - Express response used for redirects.
+     * @param {express.NextFunction} next - Express next middleware callback.
+     * @returns {void}
+     */
+    router.post('/', (req, res, next) => {
+        try {
+            const { query } = req.body;
+            const { pageNumber = 1 } = req.query;
+            const searchType = resolveSearchType(req.body?.type, req.session);
+
+            if (savedSearchStore?.create) {
+                return savedSearchStore
+                    .create({
+                        query: query.trim(),
+                        searchType,
+                        caseReferenceNumber: req.session?.caseReferenceNumber,
+                        itemsPerPage: Number(process.env.APP_SEARCH_PAGINATION_ITEMS_PER_PAGE),
+                        ownerUserName: req.session?.username
+                    })
+                    .then(({ id }) => {
+                        return res.redirect(
+                            `/search/s/${encodeURIComponent(id)}?pageNumber=${pageNumber}`
+                        );
+                    })
+                    .catch(next);
+            }
+
+            const redirectParams = new URLSearchParams({
+                query: query.trim(),
+                pageNumber: String(pageNumber),
+                type: searchType
+            });
+
+            return res.redirect(`/search?${redirectParams.toString()}`);
+        } catch (err) {
+            next(err);
+        }
+    });
+
+    /**
+     * Renders search index/results pages and coordinates API-backed search execution.
+     *
+     * @param {express.Request} req - Express request with query parameters and session context.
+     * @param {express.Response} res - Express response used to send rendered HTML.
+     * @param {express.NextFunction} next - Express next middleware callback.
+     * @returns {Promise<void>}
+     */
+    router.get('/', async (req, res, next) => {
+        try {
+            const templateEngineService = createTemplateEngineService();
+            const { render } = templateEngineService;
+
+            const { query } = req.query;
+            const searchType = getFeatureFlagValue(req.session, 'type');
+            const isDebugMode = Boolean(hasDebugContext(res));
+
+            if (!query) {
+                finalizeDebugInfo(res, 200);
+                const html = render(
+                    'search/page/index.njk',
+                    buildViewModel(req, res, {
+                        pageType: 'search',
+                        searchType,
+                        isDebugMode
+                    })
+                );
+                return res.send(html);
+            }
+
+            return renderSearchResults(req, res, next, {
+                query: String(query),
+                searchType,
+                searchId: undefined
+            });
+        } catch (error) {
+            req.log.error('Error occurred while processing search request:', error);
+            next(error);
+        }
+    });
+
+    router.get('/s/:searchId', async (req, res, next) => {
+        try {
+            if (!savedSearchStore?.getById) {
+                return res.status(404).send('Not Found');
+            }
+
+            const { searchId } = req.params;
+            const savedSearch = await savedSearchStore.getById(searchId);
+            if (!savedSearch) {
+                return res.status(404).send('Not Found');
+            }
+
+            if (savedSearch.caseReferenceNumber !== req.session?.caseReferenceNumber) {
+                return res.status(403).send('Forbidden');
+            }
+
+            return renderSearchResults(req, res, next, {
+                query: savedSearch.query,
+                searchType: resolveSearchType(savedSearch.searchType, req.session),
+                searchId
+            });
+        } catch (error) {
+            req.log.error('Error occurred while processing saved search request:', error);
             next(error);
         }
     });

--- a/search/routes.js
+++ b/search/routes.js
@@ -230,8 +230,12 @@ function createSearchRouter({
                         ownerUserName: req.session?.username
                     })
                     .then(({ id }) => {
+                        const redirectParams = new URLSearchParams({
+                            pageNumber: String(pageNumber),
+                            crn: String(req.session?.caseReferenceNumber || '')
+                        });
                         return res.redirect(
-                            `/search/s/${encodeURIComponent(id)}?pageNumber=${pageNumber}`
+                            `/search/s/${encodeURIComponent(id)}?${redirectParams.toString()}`
                         );
                     })
                     .catch(next);

--- a/search/routes.test.js
+++ b/search/routes.test.js
@@ -648,6 +648,44 @@ describe('Search Routes', () => {
             );
         });
 
+        it('falls back to legacy search redirect when saved-search storage is unavailable', async () => {
+            const testApp = express();
+            const router = createSearchRouter({
+                createTemplateEngineService: mockCreateTemplateEngineService,
+                createSearchService: mockCreateSearchService,
+                createSavedSearchStore: () => ({
+                    create: async () => {
+                        throw new Error('connect ECONNREFUSED 127.0.0.1:9200');
+                    }
+                })
+            });
+
+            testApp.use(express.json());
+            testApp.use(express.urlencoded({ extended: true }));
+            testApp.use((req, res, next) => {
+                req.session = {
+                    caseSelected: true,
+                    caseReferenceNumber: '12345',
+                    username: 'search.user@example.com'
+                };
+                req.log = { info: () => {}, warn: () => {}, error: () => {} };
+                res.locals.csrfToken = 'test-csrf-token';
+                res.locals.cspNonce = 'test-csp-nonce';
+                next();
+            });
+            testApp.use('/search', router);
+
+            const res = await request(testApp)
+                .post('/search?pageNumber=3')
+                .send({ query: 'search term', type: 'semantic' });
+
+            assert.strictEqual(res.statusCode, 302);
+            assert.strictEqual(
+                res.headers.location,
+                '/search?query=search+term&pageNumber=3&type=semantic'
+            );
+        });
+
         it('should render search results for GET /search/s/:id when saved search exists', async () => {
             const testApp = express();
             const router = createSearchRouter({

--- a/search/routes.test.js
+++ b/search/routes.test.js
@@ -43,7 +43,8 @@ describe('Search Routes', () => {
 
         const searchRouter = createSearchRouter({
             createTemplateEngineService: mockCreateTemplateEngineService,
-            createSearchService: mockCreateSearchService
+            createSearchService: mockCreateSearchService,
+            createSavedSearchStore: () => null
         });
 
         app = express();
@@ -110,7 +111,8 @@ describe('Search Routes', () => {
 
             const searchRouter = createSearchRouter({
                 createTemplateEngineService: mockCreateTemplateEngineService,
-                createSearchService: mockCreateSearchService
+                createSearchService: mockCreateSearchService,
+                createSavedSearchStore: () => null
             });
 
             const testApp = express();
@@ -145,6 +147,7 @@ describe('Search Routes', () => {
 
             const searchRouter = createSearchRouter({
                 createTemplateEngineService: mockCreateTemplateEngineService,
+                createSavedSearchStore: () => null,
                 createSearchService: () => ({
                     getSearchResults: async (...args) => {
                         serviceCallArgs = args;
@@ -218,6 +221,7 @@ describe('Search Routes', () => {
 
             const router = createSearchRouter({
                 createTemplateEngineService: mockCreateTemplateEngineService,
+                createSavedSearchStore: () => null,
                 createSearchService: () => ({
                     getSearchResults: async (
                         _query,
@@ -279,7 +283,8 @@ describe('Search Routes', () => {
             });
             const routerWithFailingService = createSearchRouter({
                 createTemplateEngineService: mockCreateTemplateEngineService,
-                createSearchService: failingSearchService
+                createSearchService: failingSearchService,
+                createSavedSearchStore: () => null
             });
             testApp.use((req, res, next) => {
                 req.session = {
@@ -313,7 +318,8 @@ describe('Search Routes', () => {
             });
             const routerWithErrorService = createSearchRouter({
                 createTemplateEngineService: mockCreateTemplateEngineService,
-                createSearchService: errorSearchService
+                createSearchService: errorSearchService,
+                createSavedSearchStore: () => null
             });
             testApp.use((req, res, next) => {
                 req.session = {
@@ -343,7 +349,8 @@ describe('Search Routes', () => {
             });
             const routerWithErrorService = createSearchRouter({
                 createTemplateEngineService: mockCreateTemplateEngineService,
-                createSearchService: errorSearchService
+                createSearchService: errorSearchService,
+                createSavedSearchStore: () => null
             });
             testApp.use((req, res, next) => {
                 req.session = {
@@ -373,7 +380,8 @@ describe('Search Routes', () => {
             });
             const routerWithErrorService = createSearchRouter({
                 createTemplateEngineService: mockCreateTemplateEngineService,
-                createSearchService: errorSearchService
+                createSearchService: errorSearchService,
+                createSavedSearchStore: () => null
             });
             testApp.use((req, res, next) => {
                 req.session = {
@@ -408,7 +416,8 @@ describe('Search Routes', () => {
             });
             const routerWithErrorService = createSearchRouter({
                 createTemplateEngineService: mockCreateTemplateEngineService,
-                createSearchService: errorSearchService
+                createSearchService: errorSearchService,
+                createSavedSearchStore: () => null
             });
             testApp.use((req, res, next) => {
                 req.session = {
@@ -455,7 +464,8 @@ describe('Search Routes', () => {
 
             const routerWithResults = createSearchRouter({
                 createTemplateEngineService: mockCreateTemplateEngineService,
-                createSearchService: searchService
+                createSearchService: searchService,
+                createSavedSearchStore: () => null
             });
 
             testApp.use((req, res, next) => {
@@ -512,7 +522,8 @@ describe('Search Routes', () => {
 
             const routerWithResults = createSearchRouter({
                 createTemplateEngineService: mockCreateTemplateEngineService,
-                createSearchService: searchService
+                createSearchService: searchService,
+                createSavedSearchStore: () => null
             });
 
             testApp.use((req, res, next) => {
@@ -571,7 +582,8 @@ describe('Search Routes', () => {
 
             const routerWithResults = createSearchRouter({
                 createTemplateEngineService: mockCreateTemplateEngineService,
-                createSearchService: searchService
+                createSearchService: searchService,
+                createSavedSearchStore: () => null
             });
 
             testApp.use((req, res, next) => {
@@ -600,6 +612,79 @@ describe('Search Routes', () => {
     });
 
     describe('POST /', () => {
+        it('should create a saved search and redirect to a shareable searchId URL when store is configured', async () => {
+            const testApp = express();
+            const router = createSearchRouter({
+                createTemplateEngineService: mockCreateTemplateEngineService,
+                createSearchService: mockCreateSearchService,
+                createSavedSearchStore: () => ({
+                    create: async () => ({ id: 'srch_abc123' })
+                })
+            });
+
+            testApp.use(express.json());
+            testApp.use(express.urlencoded({ extended: true }));
+            testApp.use((req, res, next) => {
+                req.session = {
+                    caseSelected: true,
+                    caseReferenceNumber: '12345',
+                    username: 'search.user@example.com'
+                };
+                req.log = { info: () => {}, error: () => {} };
+                res.locals.csrfToken = 'test-csrf-token';
+                res.locals.cspNonce = 'test-csp-nonce';
+                next();
+            });
+            testApp.use('/search', router);
+
+            const res = await request(testApp)
+                .post('/search?pageNumber=3')
+                .send({ query: 'search term', type: 'semantic' });
+
+            assert.strictEqual(res.statusCode, 302);
+            assert.strictEqual(res.headers.location, '/search/s/srch_abc123?pageNumber=3');
+        });
+
+        it('should render search results for GET /search/s/:id when saved search exists', async () => {
+            const testApp = express();
+            const router = createSearchRouter({
+                createTemplateEngineService: mockCreateTemplateEngineService,
+                createSearchService: mockCreateSearchService,
+                createSavedSearchStore: () => ({
+                    getById: async () => ({
+                        id: 'srch_abc123',
+                        query: 'test',
+                        searchType: 'semantic',
+                        caseReferenceNumber: '12345'
+                    })
+                })
+            });
+
+            testApp.use(express.json());
+            testApp.use(express.urlencoded({ extended: true }));
+            testApp.use((req, res, next) => {
+                req.session = {
+                    caseSelected: true,
+                    caseReferenceNumber: '12345',
+                    username: 'search.user@example.com',
+                    featureFlags: {
+                        type: 'semantic'
+                    }
+                };
+                req.log = { info: () => {}, error: () => {}, debug: () => {} };
+                res.locals.csrfToken = 'test-csrf-token';
+                res.locals.cspNonce = 'test-csp-nonce';
+                next();
+            });
+            testApp.use('/search', router);
+
+            const res = await request(testApp).get('/search/s/srch_abc123?pageNumber=2');
+
+            assert.strictEqual(res.statusCode, 200);
+            assert.match(res.text, /search\/page\/results.njk/);
+            assert.strictEqual(lastRenderParams.searchId, 'srch_abc123');
+        });
+
         it('should redirect to the GET route with the query parameter and default type', async () => {
             const res = await request(app).post('/search').send({ query: ' search term ' });
             assert.strictEqual(res.statusCode, 302);
@@ -668,7 +753,8 @@ describe('Search Routes', () => {
 
             const router = createSearchRouter({
                 createTemplateEngineService: mockCreateTemplateEngineService,
-                createSearchService: mockCreateSearchService
+                createSearchService: mockCreateSearchService,
+                createSavedSearchStore: () => null
             });
             errorApp.use('/search', router);
 

--- a/search/routes.test.js
+++ b/search/routes.test.js
@@ -642,7 +642,10 @@ describe('Search Routes', () => {
                 .send({ query: 'search term', type: 'semantic' });
 
             assert.strictEqual(res.statusCode, 302);
-            assert.strictEqual(res.headers.location, '/search/s/srch_abc123?pageNumber=3');
+            assert.strictEqual(
+                res.headers.location,
+                '/search/s/srch_abc123?pageNumber=3&crn=12345'
+            );
         });
 
         it('should render search results for GET /search/s/:id when saved search exists', async () => {
@@ -678,7 +681,7 @@ describe('Search Routes', () => {
             });
             testApp.use('/search', router);
 
-            const res = await request(testApp).get('/search/s/srch_abc123?pageNumber=2');
+            const res = await request(testApp).get('/search/s/srch_abc123?pageNumber=2&crn=12345');
 
             assert.strictEqual(res.statusCode, 200);
             assert.match(res.text, /search\/page\/results.njk/);

--- a/search/saved-search-store.js
+++ b/search/saved-search-store.js
@@ -1,0 +1,170 @@
+import crypto from 'node:crypto';
+import { Client as defaultClient } from '@opensearch-project/opensearch';
+import { nanoid } from 'nanoid';
+import VError from 'verror';
+
+const DEFAULT_TTL_DAYS = 30;
+const DEFAULT_INDEX_NAME = 'saved_searches';
+
+/**
+ * Computes an ISO expiry timestamp from now + TTL days.
+ *
+ * @param {Date} now - Current date value used as the reference point.
+ * @param {number} ttlDays - Number of days before the saved search expires.
+ * @returns {string} ISO-8601 timestamp.
+ */
+function computeExpiry(now, ttlDays) {
+    const ttlMs = Math.max(Number(ttlDays) || DEFAULT_TTL_DAYS, 1) * 24 * 60 * 60 * 1000;
+    return new Date(now.getTime() + ttlMs).toISOString();
+}
+
+/**
+ * Returns a masked ID for safer logs.
+ *
+ * @param {string} id - Saved search identifier.
+ * @returns {string} Short hash suffix.
+ */
+function idHash(id) {
+    return crypto.createHash('sha256').update(id).digest('hex').slice(0, 8);
+}
+
+/**
+ * Creates a persistent saved-search store backed by OpenSearch.
+ *
+ * Saved definitions can be referenced by opaque IDs to support shareable URLs
+ * without exposing sensitive query text in browser query strings.
+ *
+ * @param {object} [params] - Store configuration.
+ * @param {new (...args: any[]) => object} [params.Client=defaultClient] - OpenSearch client constructor.
+ * @param {object} [params.logger] - Optional structured logger.
+ * @param {() => Date} [params.now] - Test seam for deterministic time handling.
+ * @returns {{
+ *  create: (input: {query: string, searchType: string, caseReferenceNumber: string, itemsPerPage?: number, ownerUserName?: string, ttlDays?: number}) => Promise<{id: string, expiresAt: string}>,
+ *  getById: (id: string) => Promise<object|null>,
+ *  deleteById: (id: string) => Promise<void>
+ * }} Saved-search store API.
+ */
+export default function createSavedSearchStore({
+    Client = defaultClient,
+    logger,
+    now = () => new Date()
+} = {}) {
+    const node = process.env.APP_DATABASE_URL;
+    if (!node) {
+        throw new VError(
+            {
+                name: 'ConfigurationError'
+            },
+            'Environment variable "APP_DATABASE_URL" must be set'
+        );
+    }
+
+    const index = process.env.APP_SAVED_SEARCH_INDEX_NAME || DEFAULT_INDEX_NAME;
+    const client = new Client({ node });
+
+    /**
+     * Persists a saved search definition and returns its opaque ID.
+     *
+     * @param {object} input - Saved search payload.
+     * @param {string} input.query - Raw search query text.
+     * @param {string} input.searchType - Search mode used to execute this definition.
+     * @param {string} input.caseReferenceNumber - Case scope for authorization checks.
+     * @param {number} [input.itemsPerPage] - Optional pagination size.
+     * @param {string} [input.ownerUserName] - Optional creator identity.
+     * @param {number} [input.ttlDays=30] - Number of days before automatic expiry.
+     * @returns {Promise<{id: string, expiresAt: string}>} Opaque identifier and expiry timestamp.
+     */
+    async function create({
+        query,
+        searchType,
+        caseReferenceNumber,
+        itemsPerPage,
+        ownerUserName,
+        ttlDays = DEFAULT_TTL_DAYS
+    }) {
+        const createdAt = now();
+        const id = `srch_${nanoid(16)}`;
+        const expiresAt = computeExpiry(createdAt, ttlDays);
+
+        const doc = {
+            query,
+            searchType,
+            caseReferenceNumber,
+            itemsPerPage:
+                Number(itemsPerPage) || Number(process.env.APP_SEARCH_PAGINATION_ITEMS_PER_PAGE),
+            ownerUserName: ownerUserName || null,
+            createdAt: createdAt.toISOString(),
+            expiresAt,
+            lastAccessedAt: null
+        };
+
+        await client.index({
+            index,
+            id,
+            body: doc,
+            refresh: 'wait_for'
+        });
+
+        logger?.info?.(
+            {
+                idHash: idHash(id),
+                caseReferenceNumber,
+                expiresAt,
+                index
+            },
+            'Saved search created'
+        );
+
+        return { id, expiresAt };
+    }
+
+    /**
+     * Retrieves a saved search definition by opaque ID.
+     *
+     * @param {string} id - Saved search identifier.
+     * @returns {Promise<object|null>} Stored definition or null when not found.
+     */
+    async function getById(id) {
+        try {
+            const response = await client.get({ index, id });
+            const source = response?.body?._source || response?._source;
+            if (!source) {
+                return null;
+            }
+
+            return {
+                id,
+                ...source
+            };
+        } catch (error) {
+            const statusCode = error?.meta?.statusCode;
+            if (statusCode === 404) {
+                return null;
+            }
+            throw error;
+        }
+    }
+
+    /**
+     * Deletes a saved search definition by ID.
+     *
+     * @param {string} id - Saved search identifier.
+     * @returns {Promise<void>} Resolves when delete succeeds or record is already absent.
+     */
+    async function deleteById(id) {
+        try {
+            await client.delete({ index, id, refresh: 'wait_for' });
+        } catch (error) {
+            const statusCode = error?.meta?.statusCode;
+            if (statusCode !== 404) {
+                throw error;
+            }
+        }
+    }
+
+    return Object.freeze({
+        create,
+        getById,
+        deleteById
+    });
+}

--- a/search/saved-search-store.test.js
+++ b/search/saved-search-store.test.js
@@ -1,0 +1,110 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import createSavedSearchStore from './saved-search-store.js';
+
+describe('saved-search-store', () => {
+    const originalDbUrl = process.env.APP_DATABASE_URL;
+
+    beforeEach(() => {
+        process.env.APP_DATABASE_URL = 'http://localhost:9200';
+    });
+
+    afterEach(() => {
+        if (originalDbUrl === undefined) {
+            delete process.env.APP_DATABASE_URL;
+        } else {
+            process.env.APP_DATABASE_URL = originalDbUrl;
+        }
+    });
+
+    it('throws a configuration error when APP_DATABASE_URL is missing', () => {
+        delete process.env.APP_DATABASE_URL;
+
+        assert.throws(
+            () => createSavedSearchStore({}),
+            (error) => {
+                assert.equal(error.name, 'ConfigurationError');
+                assert.match(error.message, /APP_DATABASE_URL/);
+                return true;
+            }
+        );
+    });
+
+    it('creates a saved search and returns id + expiry', async () => {
+        let indexArgs;
+
+        class FakeClient {
+            index = async (args) => {
+                indexArgs = args;
+                return { body: { result: 'created' } };
+            };
+
+            get = async () => ({ body: { _source: {} } });
+            delete = async () => ({ body: { result: 'deleted' } });
+        }
+
+        const store = createSavedSearchStore({
+            Client: FakeClient,
+            now: () => new Date('2026-06-30T12:00:00.000Z')
+        });
+
+        const result = await store.create({
+            query: 'john smith',
+            searchType: 'semantic',
+            caseReferenceNumber: '25-711111',
+            itemsPerPage: 10,
+            ownerUserName: 'user@example.com',
+            ttlDays: 30
+        });
+
+        assert.match(result.id, /^srch_/);
+        assert.equal(result.expiresAt, '2026-07-30T12:00:00.000Z');
+        assert.equal(indexArgs.index, 'saved_searches');
+        assert.equal(indexArgs.body.query, 'john smith');
+        assert.equal(indexArgs.body.searchType, 'semantic');
+        assert.equal(indexArgs.body.caseReferenceNumber, '25-711111');
+    });
+
+    it('returns null when saved search is not found', async () => {
+        class FakeClient {
+            index = async () => ({ body: { result: 'created' } });
+
+            get = async () => {
+                const error = new Error('not found');
+                error.meta = { statusCode: 404 };
+                throw error;
+            };
+
+            delete = async () => ({ body: { result: 'deleted' } });
+        }
+
+        const store = createSavedSearchStore({ Client: FakeClient });
+        const result = await store.getById('srch_abc');
+        assert.equal(result, null);
+    });
+
+    it('deletes existing saved search and ignores 404 on delete', async () => {
+        let deleteCalls = 0;
+
+        class FakeClient {
+            index = async () => ({ body: { result: 'created' } });
+            get = async () => ({ body: { _source: {} } });
+            delete = async () => {
+                deleteCalls += 1;
+                if (deleteCalls === 2) {
+                    const error = new Error('not found');
+                    error.meta = { statusCode: 404 };
+                    throw error;
+                }
+                return { body: { result: 'deleted' } };
+            };
+        }
+
+        const store = createSavedSearchStore({ Client: FakeClient });
+
+        await store.deleteById('srch_abc');
+        await store.deleteById('srch_abc');
+
+        assert.equal(deleteCalls, 2);
+    });
+});

--- a/search/search-service.js
+++ b/search/search-service.js
@@ -15,7 +15,7 @@ function createSearchService({
     logger,
     createRequestService = createRequestServiceDefault
 } = {}) {
-    const { get } = createRequestService();
+    const { post } = createRequestService();
 
     /**
      * Fetches search results from the API.
@@ -39,17 +39,14 @@ function createSearchService({
         { searchType = DEFAULT_SEARCH_TYPE, includeNamedQueries = false, queryDslConfig } = {}
     ) {
         logger?.info?.({ query, pageNumber, itemsPerPage }, 'Fetching search results');
-        const searchParams = new URLSearchParams({
-            query: String(query),
-            pageNumber: String(pageNumber),
-            itemsPerPage: String(itemsPerPage),
-            type: searchType
-        });
-        const strictQueryString = Array.from(searchParams.entries())
-            .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
-            .join('&');
         const opts = {
-            url: `${process.env.APP_API_URL}/search/?${strictQueryString}`,
+            url: `${process.env.APP_API_URL}/search/`,
+            json: {
+                query: String(query),
+                pageNumber: Number(pageNumber),
+                itemsPerPage: Number(itemsPerPage),
+                type: searchType
+            },
             headers: {
                 'On-Behalf-Of': caseReferenceNumber
             }
@@ -68,7 +65,7 @@ function createSearchService({
         if (hasQueryDslConfig) {
             opts.headers['X-Query-DSL-Config'] = JSON.stringify(queryDslConfig);
         }
-        return get(opts);
+        return post(opts);
     }
 
     return Object.freeze({

--- a/search/search-service.test.js
+++ b/search/search-service.test.js
@@ -4,11 +4,11 @@ import { beforeEach, describe, it, mock } from 'node:test';
 import createSearchService from './search-service.js';
 
 describe('search-service', () => {
-    let mockGet;
+    let mockPost;
     let mockCreateRequestService;
 
     beforeEach(() => {
-        mockGet = mock.fn(() => {
+        mockPost = mock.fn(() => {
             return {
                 body: {
                     data: 'fake results'
@@ -18,12 +18,12 @@ describe('search-service', () => {
 
         mockCreateRequestService = mock.fn(() => {
             return {
-                get: mockGet
+                post: mockPost
             };
         });
     });
 
-    it('Should call get with correct URL and headers', async () => {
+    it('Should call post with correct URL, body and headers', async () => {
         const fakeLogger = { info: () => {}, error: () => {}, warn: () => {}, debug: () => {} };
         const service = createSearchService({
             caseReferenceNumber: '12-745678',
@@ -40,20 +40,18 @@ describe('search-service', () => {
 
         assert.deepEqual(result, { body: { data: 'fake results' } });
         assert.equal(mockCreateRequestService.mock.callCount(), 1);
-        const mockGetCallArguments = mockGet.mock.calls[0].arguments[0];
-        assert.equal(
-            mockGetCallArguments.url,
-            `${process.env.APP_API_URL}/search/?${new URLSearchParams({
-                query,
-                pageNumber: String(pageNumber),
-                itemsPerPage: String(itemsPerPage),
-                type: 'semantic'
-            }).toString()}`
-        );
-        assert.equal(mockGetCallArguments.headers['On-Behalf-Of'], '12-745678');
+        const mockPostCallArguments = mockPost.mock.calls[0].arguments[0];
+        assert.equal(mockPostCallArguments.url, `${process.env.APP_API_URL}/search/`);
+        assert.deepEqual(mockPostCallArguments.json, {
+            query,
+            pageNumber,
+            itemsPerPage,
+            type: 'semantic'
+        });
+        assert.equal(mockPostCallArguments.headers['On-Behalf-Of'], '12-745678');
     });
 
-    it('Should encode searchType in URL query string', async () => {
+    it('Should send searchType in request body as a plain value', async () => {
         const fakeLogger = { info: () => {}, error: () => {}, warn: () => {}, debug: () => {} };
         const service = createSearchService({
             caseReferenceNumber: '12-745678',
@@ -70,20 +68,12 @@ describe('search-service', () => {
             searchType: injectedSearchType
         });
 
-        const mockGetCallArguments = mockGet.mock.calls[0].arguments[0];
-        assert.equal(
-            mockGetCallArguments.url,
-            `${process.env.APP_API_URL}/search/?${new URLSearchParams({
-                query,
-                pageNumber: String(pageNumber),
-                itemsPerPage: String(itemsPerPage),
-                type: injectedSearchType
-            }).toString()}`
-        );
-        assert.equal(mockGetCallArguments.url.includes('&debug=on'), false);
+        const mockPostCallArguments = mockPost.mock.calls[0].arguments[0];
+        assert.equal(mockPostCallArguments.url, `${process.env.APP_API_URL}/search/`);
+        assert.equal(mockPostCallArguments.json.type, injectedSearchType);
     });
 
-    it('Should encode query to prevent query-string injection', async () => {
+    it('Should send query in request body', async () => {
         const fakeLogger = { info: () => {}, error: () => {}, warn: () => {}, debug: () => {} };
         const service = createSearchService({
             caseReferenceNumber: '12-745678',
@@ -97,20 +87,12 @@ describe('search-service', () => {
             searchType: 'semantic'
         });
 
-        const mockGetCallArguments = mockGet.mock.calls[0].arguments[0];
-        assert.equal(
-            mockGetCallArguments.url,
-            `${process.env.APP_API_URL}/search/?${new URLSearchParams({
-                query,
-                pageNumber: '1',
-                itemsPerPage: '10',
-                type: 'semantic'
-            }).toString()}`
-        );
-        assert.equal(mockGetCallArguments.url.includes('&debug=on'), false);
+        const mockPostCallArguments = mockPost.mock.calls[0].arguments[0];
+        assert.equal(mockPostCallArguments.url, `${process.env.APP_API_URL}/search/`);
+        assert.equal(mockPostCallArguments.json.query, query);
     });
 
-    it('Should encode spaces in query as %20 for API compatibility', async () => {
+    it('Should keep spaces in query payload value', async () => {
         const fakeLogger = { info: () => {}, error: () => {}, warn: () => {}, debug: () => {} };
         const service = createSearchService({
             caseReferenceNumber: '12-745678',
@@ -122,12 +104,8 @@ describe('search-service', () => {
             searchType: 'hybrid-dates'
         });
 
-        const mockGetCallArguments = mockGet.mock.calls[0].arguments[0];
-        assert.equal(
-            mockGetCallArguments.url,
-            `${process.env.APP_API_URL}/search/?query=acute%20november%202022&pageNumber=1&itemsPerPage=10&type=hybrid-dates`
-        );
-        assert.equal(mockGetCallArguments.url.includes('acute+november+2022'), false);
+        const mockPostCallArguments = mockPost.mock.calls[0].arguments[0];
+        assert.equal(mockPostCallArguments.json.query, 'acute november 2022');
     });
 
     it('Should include X-Debug-Context header when includeNamedQueries is true', async () => {
@@ -143,8 +121,8 @@ describe('search-service', () => {
             includeNamedQueries: true
         });
 
-        const mockGetCallArguments = mockGet.mock.calls[0].arguments[0];
-        assert.equal(mockGetCallArguments.headers['X-Debug-Context'], 'true');
+        const mockPostCallArguments = mockPost.mock.calls[0].arguments[0];
+        assert.equal(mockPostCallArguments.headers['X-Debug-Context'], 'true');
     });
 
     it('Should include X-Query-DSL-Config header when queryDslConfig is provided', async () => {
@@ -170,9 +148,9 @@ describe('search-service', () => {
             queryDslConfig
         });
 
-        const mockGetCallArguments = mockGet.mock.calls[0].arguments[0];
+        const mockPostCallArguments = mockPost.mock.calls[0].arguments[0];
         assert.equal(
-            mockGetCallArguments.headers['X-Query-DSL-Config'],
+            mockPostCallArguments.headers['X-Query-DSL-Config'],
             JSON.stringify(queryDslConfig)
         );
     });
@@ -188,6 +166,6 @@ describe('search-service', () => {
         });
 
         assert.deepEqual(result, { body: { data: 'fake results' } });
-        assert.equal(mockGet.mock.callCount(), 1);
+        assert.equal(mockPost.mock.callCount(), 1);
     });
 });


### PR DESCRIPTION
## Summary
This branch implements the security ticket to stop exposing sensitive search text in URLs while preserving shareable links.

It migrates the search flow to use POST for execution, introduces persistent saved-search IDs for sharing, updates document navigation to carry opaque IDs instead of raw search terms, and hardens redirect/middleware behaviour so the new routes remain stable.

## Why
Search terms in query strings can leak through browser history, referrers, proxies, and logs.  
The goal here is to keep search content server-side while still allowing users to share and revisit search results.

## What Changed
- Added API support for POST-based search execution and updated the web search service to use POST.
- Updated OpenAPI definitions and regenerated the built spec.
- Added a persistent saved-search store backed by OpenSearch with opaque search IDs.
- Wired the app and search routes to:
  - create saved searches on submit,
  - redirect to shareable saved-search URLs,
  - resolve saved searches securely on read.
- Migrated document page and text viewer flows to use search IDs in navigation/pagination URLs.
- Removed legacy search-term URL generation in search/document link building paths.
- Added case-scoped checks when resolving saved searches.
- Updated CRN and feature-flag query-enforcement middleware to allow saved-search routes.
- Added graceful degradation:
  - if saved-search persistence is unavailable, POST search falls back to legacy non-persistent redirect behaviour instead of returning 500.

## Key Behaviour Outcomes
- Shareable links now use opaque saved-search IDs.
- Raw search text is no longer propagated in search/document navigation URLs.
- Middleware redirects work correctly for saved-search routes.
- Search still functions when persistence is temporarily unavailable.

## Test and Validation
- Added/updated unit and route tests for:
  - search POST/GET/saved-search flows,
  - document handlers/routes/link builders/pagination,
  - CRN and feature-flag middleware allowlists and redirect behaviour,
  - saved-search store behaviour.
- Local runs included targeted suites and full test run, with all tests passing.
- Lint/JSDoc checks pass for modified areas.

## Risk Notes
- This is a cross-cutting change touching search, document navigation, middleware, and API contract docs.
- Compatibility fallback remains in place for persistence outages to reduce user-facing disruption.
