### PR TITLE
feat(api): move _source projection into buildQueryJson

### DIFF
--- a/api/DAL/document-dal.js
+++ b/api/DAL/document-dal.js
@@ -4,6 +4,7 @@ import createDBQueryDefault from '../../db/index.js';
 import buildSearchSessionPreference from '../../utils/buildSearchSessionPreference/index.js';
 import { DEFAULT_SEARCH_TYPE } from '../search/constants/searchTypes.js';
 import buildQueryJson from './utils/buildQueryJson/index.js';
+import { QUERY_MODES } from './utils/buildQueryJson/queryStructureBuilders.js';
 
 /**
  * @typedef {object} Logger
@@ -51,9 +52,9 @@ import buildQueryJson from './utils/buildQueryJson/index.js';
  * @returns {{
  *   getDocuments: () => Promise<object[]>,
  *   getDocument: (documentId: string) => Promise<object>,
- *   getDocumentsChunksByKeyword: (keyword: string, pageNumber: number, itemsPerPage: number) => Promise<object[]>,
- *   getPageMetadataByDocumentIdAndPageNumber: (documentId: string, pageNumber: number|string) => Promise<object|null>,
- *   getPageChunksByDocumentIdAndPageNumber: (documentId: string, pageNumber: number|string, keyword?: string, searchType?: string) => Promise<object[]>
+ *   getDocumentsChunksByKeyword: (keyword: string, pageNumber: number, itemsPerPage: number, options?: {sourceFields?: string[]|boolean|{includes?: string[], excludes?: string[]}}) => Promise<object[]>,
+ *   getPageMetadataByDocumentIdAndPageNumber: (documentId: string, pageNumber: number|string, options?: {sourceFields?: string[]|boolean|{includes?: string[], excludes?: string[]}}) => Promise<object|null>,
+ *   getPageChunksByDocumentIdAndPageNumber: (documentId: string, pageNumber: number|string, keyword?: string, searchType?: string, options?: {sourceFields?: string[]|boolean|{includes?: string[], excludes?: string[]}}) => Promise<object[]>
  * }}
  *   A frozen object exposing document and chunk retrieval methods.
  */
@@ -101,13 +102,21 @@ function createDocumentDAL({
      * @param {string} keyword - Keyword to search in `chunk_text`.
      * @param {number} pageNumber - 1-based page number.
      * @param {number} itemsPerPage - Number of items per page.
+     * @param {{sourceFields?: string[]|boolean|{includes?: string[], excludes?: string[]}}} [options]
+     *   Optional OpenSearch `_source` projection.
+     *   Defaults to excluding the `embeddings` field while returning all other source fields.
      * @returns {Promise<Object[]>} Array of hit objects from OpenSearch.
      *
      * @throws {VError} If the OpenSearch query fails or throws an error.
      */
-    async function getDocumentsChunksByKeyword(keyword, pageNumber, itemsPerPage) {
+    async function getDocumentsChunksByKeyword(keyword, pageNumber, itemsPerPage, options = {}) {
         try {
             const buildStart = Date.now();
+            const {
+                sourceFields = {
+                    excludes: ['embeddings']
+                }
+            } = options;
             const queryBody = buildQueryJson({
                 keyword,
                 caseReferenceNumber,
@@ -120,6 +129,7 @@ function createDocumentDAL({
                     queryDslConfig
                 }
             });
+            queryBody._source = sourceFields;
             const buildEnd = Date.now();
 
             // safe query hash for correlation, not raw text.
@@ -182,29 +192,36 @@ function createDocumentDAL({
      * @returns {Promise<Object|null>} The page metadata object with all fields, or null if not found.
      * @throws {VError} If the database query fails.
      */
-    async function getPageMetadataByDocumentIdAndPageNumber(documentId, pageNumber) {
+    async function getPageMetadataByDocumentIdAndPageNumber(documentId, pageNumber, options = {}) {
         try {
+            const {
+                sourceFields = [
+                    'correspondence_type',
+                    'page_count',
+                    'page_num',
+                    's3_page_image_s3_uri',
+                    'text'
+                ]
+            } = options;
             logger?.info?.({ documentId, pageNumber }, 'Querying OpenSearch for page metadata');
+
+            const queryBody = buildQueryJson({
+                keyword: '',
+                caseReferenceNumber,
+                pageNumber,
+                options: {
+                    logger,
+                    queryMode: QUERY_MODES.PAGE_METADATA,
+                    includePagination: false,
+                    documentId,
+                    queryDslConfig
+                }
+            });
+            queryBody._source = sourceFields;
 
             const response = await db.query({
                 index: 'page_metadata',
-                body: {
-                    query: {
-                        bool: {
-                            must: [
-                                { match: { source_doc_id: documentId } },
-                                { match: { page_num: parseInt(pageNumber, 10) } }
-                            ]
-                        }
-                    },
-                    _source: [
-                        'correspondence_type',
-                        'page_count',
-                        'page_num',
-                        's3_page_image_s3_uri',
-                        'text'
-                    ]
-                }
+                body: queryBody
             });
 
             if (response.body?.hits?.hits && response.body.hits.hits.length > 0) {
@@ -240,9 +257,19 @@ function createDocumentDAL({
         documentId,
         pageNumber,
         keyword = '',
-        searchType = DEFAULT_SEARCH_TYPE
+        searchType = DEFAULT_SEARCH_TYPE,
+        options = {}
     ) {
         try {
+            const {
+                sourceFields = [
+                    'chunk_id',
+                    'bounding_box',
+                    'chunk_type',
+                    'chunk_index',
+                    'chunk_text'
+                ]
+            } = options;
             logger?.info?.(
                 { documentId, pageNumber, searchType },
                 'Querying OpenSearch for page chunks with bounding boxes'
@@ -262,13 +289,7 @@ function createDocumentDAL({
                 }
             });
 
-            queryBody._source = [
-                'chunk_id',
-                'bounding_box',
-                'chunk_type',
-                'chunk_index',
-                'chunk_text'
-            ];
+            queryBody._source = sourceFields;
             queryBody.sort = [{ chunk_index: { order: 'asc' } }];
 
             const dbStart = Date.now();

--- a/api/DAL/document-dal.js
+++ b/api/DAL/document-dal.js
@@ -126,10 +126,10 @@ function createDocumentDAL({
                     logger,
                     searchType,
                     includeNamedQueries: shouldIncludeNamedQueries,
+                    sourceFields,
                     queryDslConfig
                 }
             });
-            queryBody._source = sourceFields;
             const buildEnd = Date.now();
 
             // safe query hash for correlation, not raw text.
@@ -214,10 +214,10 @@ function createDocumentDAL({
                     queryMode: QUERY_MODES.PAGE_METADATA,
                     includePagination: false,
                     documentId,
+                    sourceFields,
                     queryDslConfig
                 }
             });
-            queryBody._source = sourceFields;
 
             const response = await db.query({
                 index: 'page_metadata',
@@ -285,11 +285,10 @@ function createDocumentDAL({
                     documentId,
                     logger,
                     includeNamedQueries: shouldIncludeNamedQueries,
+                    sourceFields,
                     queryDslConfig
                 }
             });
-
-            queryBody._source = sourceFields;
             queryBody.sort = [{ chunk_index: { order: 'asc' } }];
 
             const dbStart = Date.now();

--- a/api/DAL/document-dal.js
+++ b/api/DAL/document-dal.js
@@ -189,6 +189,9 @@ function createDocumentDAL({
      * @async
      * @param {string} documentId - The UUID of the document (source_doc_id in OpenSearch).
      * @param {number|string} pageNumber - The page number (page_num in OpenSearch).
+        * @param {{sourceFields?: string[]|boolean|{includes?: string[], excludes?: string[]}}} [options]
+        *   Optional OpenSearch `_source` projection.
+        *   Defaults to the page metadata fields used by the API response.
      * @returns {Promise<Object|null>} The page metadata object with all fields, or null if not found.
      * @throws {VError} If the database query fails.
      */

--- a/api/DAL/document-dal.js
+++ b/api/DAL/document-dal.js
@@ -189,9 +189,9 @@ function createDocumentDAL({
      * @async
      * @param {string} documentId - The UUID of the document (source_doc_id in OpenSearch).
      * @param {number|string} pageNumber - The page number (page_num in OpenSearch).
-        * @param {{sourceFields?: string[]|boolean|{includes?: string[], excludes?: string[]}}} [options]
-        *   Optional OpenSearch `_source` projection.
-        *   Defaults to the page metadata fields used by the API response.
+     * @param {{sourceFields?: string[]|boolean|{includes?: string[], excludes?: string[]}}} [options]
+     *   Optional OpenSearch `_source` projection.
+     *   Defaults to the page metadata fields used by the API response.
      * @returns {Promise<Object|null>} The page metadata object with all fields, or null if not found.
      * @throws {VError} If the database query fails.
      */

--- a/api/DAL/document-dal.test.js
+++ b/api/DAL/document-dal.test.js
@@ -148,6 +148,60 @@ describe('document-dal', () => {
         assert.ok(neuralClause.neural.embedding.boost > 0);
     });
 
+    it('Should exclude embeddings by default for keyword chunk searches', async () => {
+        let queryArgs;
+        const mockDB = {
+            query: async (args) => {
+                queryArgs = args;
+                return {
+                    body: {
+                        hits: {
+                            hits: []
+                        }
+                    }
+                };
+            }
+        };
+
+        const dal = createDocumentDAL({
+            caseReferenceNumber: '12-745678',
+            createDBQuery: () => mockDB,
+            logger: mockLogger
+        });
+
+        await dal.getDocumentsChunksByKeyword('keyword', 1, 10);
+
+        assert.deepStrictEqual(queryArgs.body._source, { excludes: ['embeddings'] });
+    });
+
+    it('Should allow overriding _source for keyword chunk searches', async () => {
+        let queryArgs;
+        const mockDB = {
+            query: async (args) => {
+                queryArgs = args;
+                return {
+                    body: {
+                        hits: {
+                            hits: []
+                        }
+                    }
+                };
+            }
+        };
+
+        const dal = createDocumentDAL({
+            caseReferenceNumber: '12-745678',
+            createDBQuery: () => mockDB,
+            logger: mockLogger
+        });
+
+        await dal.getDocumentsChunksByKeyword('keyword', 1, 10, {
+            sourceFields: ['chunk_text', 'source_doc_id']
+        });
+
+        assert.deepStrictEqual(queryArgs.body._source, ['chunk_text', 'source_doc_id']);
+    });
+
     it('Should include named query metadata when includeNamedQueries override is true', async () => {
         let queryArgs;
         const mockQuery = async (args) => {
@@ -348,6 +402,41 @@ describe('document-dal', () => {
 
             assert.strictEqual(queryArgs.index, 'page_metadata');
             assert.deepStrictEqual(queryArgs.body.query.bool.must[1], { match: { page_num: 5 } });
+            assert.deepStrictEqual(queryArgs.body._source, [
+                'correspondence_type',
+                'page_count',
+                'page_num',
+                's3_page_image_s3_uri',
+                'text'
+            ]);
+        });
+
+        it('should allow overriding _source fields for page metadata query', async () => {
+            let queryArgs;
+            const mockDB = {
+                query: async (args) => {
+                    queryArgs = args;
+                    return {
+                        body: {
+                            hits: {
+                                hits: []
+                            }
+                        }
+                    };
+                }
+            };
+
+            const dal = createDocumentDAL({
+                caseReferenceNumber: '12-745678',
+                createDBQuery: () => mockDB,
+                logger: mockLogger
+            });
+
+            await dal.getPageMetadataByDocumentIdAndPageNumber('doc-123', 5, {
+                sourceFields: ['text']
+            });
+
+            assert.deepStrictEqual(queryArgs.body._source, ['text']);
         });
     });
 
@@ -903,6 +992,28 @@ describe('document-dal', () => {
                 'chunk_index',
                 'chunk_text'
             ]);
+        });
+
+        it('should allow overriding _source fields for page chunks query', async () => {
+            let queryArgs;
+            const mockDB = {
+                query: async (args) => {
+                    queryArgs = args;
+                    return { body: { hits: { hits: [] } } };
+                }
+            };
+
+            const dal = createDocumentDAL({
+                caseReferenceNumber: '12-745678',
+                createDBQuery: () => mockDB,
+                logger: mockLogger
+            });
+
+            await dal.getPageChunksByDocumentIdAndPageNumber('doc-123', 1, '', 'hybrid', {
+                sourceFields: ['chunk_text']
+            });
+
+            assert.deepStrictEqual(queryArgs.body._source, ['chunk_text']);
         });
 
         it('should handle missing logger in getPageChunksByDocumentIdAndPageNumber', async () => {

--- a/api/DAL/utils/buildQueryJson/README.md
+++ b/api/DAL/utils/buildQueryJson/README.md
@@ -1,6 +1,31 @@
 # buildQueryJson
 
-Builds an OpenSearch query DSL object for a given `searchType`.
+Builds an OpenSearch query DSL object for a given query mode.
+
+- Search queries are assembled by `queryTypeBuilders.js` (driven by `searchType`).
+- Non-search structural queries are assembled by `queryStructureBuilders.js` (driven by `queryMode`).
+
+## `queryMode` values
+
+| `queryMode` | Default | Description |
+|---|:---:|---|
+| `search` | ✅ | Uses `searchType` and `queryTypeBuilders` to build chunk search DSL. |
+| `page-metadata` | | Uses `queryStructureBuilders` to build page metadata lookup DSL. |
+
+## Structure Builders
+
+`queryStructureBuilders.js` defines non-search query shapes.
+
+- `QUERY_MODES.SEARCH`: canonical default mode value.
+- `QUERY_MODES.PAGE_METADATA`: page metadata lookup mode.
+- `DEFAULT_QUERY_MODE`: currently `QUERY_MODES.SEARCH`.
+
+When `queryMode` is `page-metadata`, `buildQueryJson` builds:
+
+- `bool.must` with `source_doc_id` match
+- `bool.must` with `page_num` match
+
+`_source` projection is still caller-controlled (for example in DAL methods).
 
 ## `searchType` values
 
@@ -82,6 +107,19 @@ const keywordQuery = buildQueryJson({
     pageNumber: 1,
     itemsPerPage: 10,
     options: { searchType: 'keyword', logger }
+});
+
+// Page metadata lookup (non-search structure mode)
+const pageMetadataQuery = buildQueryJson({
+    keyword: '',
+    caseReferenceNumber: '26-711111',
+    pageNumber: '5',
+    options: {
+        queryMode: 'page-metadata',
+        includePagination: false,
+        documentId: 'doc-123',
+        logger
+    }
 });
 ```
 

--- a/api/DAL/utils/buildQueryJson/README.md
+++ b/api/DAL/utils/buildQueryJson/README.md
@@ -25,7 +25,7 @@ When `queryMode` is `page-metadata`, `buildQueryJson` builds:
 - `bool.must` with `source_doc_id` match
 - `bool.must` with `page_num` match
 
-`_source` projection is still caller-controlled (for example in DAL methods).
+`_source` projection is set in `buildQueryJson` when `options.sourceFields` is provided.
 
 ## `searchType` values
 
@@ -79,7 +79,11 @@ const hybridDatesQuery = buildQueryJson({
     caseReferenceNumber: '26-711111',
     pageNumber: 1,
     itemsPerPage: 10,
-    options: { searchType: 'hybrid-dates', logger }
+    options: {
+        searchType: 'hybrid-dates',
+        sourceFields: { excludes: ['embeddings'] },
+        logger
+    }
 });
 
 // Keyword + dates (BM25 match + date phrase expansion)

--- a/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
+++ b/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
@@ -451,6 +451,25 @@ describe('buildQueryJson', () => {
         });
     });
 
+    it('Should throw when documentId is missing in page-metadata mode', () => {
+        assert.throws(
+            () =>
+                buildQueryJson({
+                    keyword: '',
+                    caseReferenceNumber: '26-711111',
+                    pageNumber: 1,
+                    itemsPerPage: 10,
+                    options: {
+                        queryMode: 'page-metadata',
+                        includePagination: false
+                    }
+                }),
+            {
+                message: 'documentId is required when queryMode is page-metadata'
+            }
+        );
+    });
+
     it('Should include pagination fields in page-metadata mode when enabled', () => {
         const result = buildQueryJson({
             keyword: '',

--- a/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
+++ b/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
@@ -401,6 +401,67 @@ describe('buildQueryJson', () => {
         );
     });
 
+    it('Should build page metadata query when queryMode is page-metadata', () => {
+        const result = buildQueryJson({
+            keyword: '',
+            caseReferenceNumber: '26-711111',
+            pageNumber: '5',
+            options: {
+                queryMode: 'page-metadata',
+                includePagination: false,
+                documentId: 'doc-123'
+            }
+        });
+
+        assert.deepStrictEqual(result, {
+            query: {
+                bool: {
+                    must: [{ match: { source_doc_id: 'doc-123' } }, { match: { page_num: 5 } }]
+                }
+            }
+        });
+    });
+
+    it('Should include pagination fields in page-metadata mode when enabled', () => {
+        const result = buildQueryJson({
+            keyword: '',
+            caseReferenceNumber: '26-711111',
+            pageNumber: 2,
+            itemsPerPage: 3,
+            options: {
+                queryMode: 'page-metadata',
+                includePagination: true,
+                documentId: 'doc-123'
+            }
+        });
+
+        assert.strictEqual(result.from, 3);
+        assert.strictEqual(result.size, 3);
+        assert.deepStrictEqual(result.query.bool.must, [
+            { match: { source_doc_id: 'doc-123' } },
+            { match: { page_num: 2 } }
+        ]);
+    });
+
+    it('Should throw when an invalid queryMode is provided', () => {
+        assert.throws(
+            () =>
+                buildQueryJson({
+                    keyword: '',
+                    caseReferenceNumber: '26-711111',
+                    pageNumber: 1,
+                    options: {
+                        queryMode: 'invalid-mode',
+                        includePagination: false,
+                        documentId: 'doc-123'
+                    }
+                }),
+            {
+                message: 'Invalid queryMode "invalid-mode". Must be one of: search, page-metadata'
+            }
+        );
+    });
+
     it('Should build a hybrid query when searchType is hybrid', () => {
         // Test owns its tuning via explicit overrides so it is decoupled from
         // production defaults in DEFAULT_QUERY_DSL_CONFIG.

--- a/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
+++ b/api/DAL/utils/buildQueryJson/buildQueryJson.test.js
@@ -96,6 +96,35 @@ describe('buildQueryJson', () => {
         }
     });
 
+    it('Should include _source when sourceFields option is provided', () => {
+        const result = buildQueryJson({
+            keyword: 'Important meeting',
+            caseReferenceNumber: '26-711111',
+            pageNumber: 1,
+            itemsPerPage: 5,
+            options: {
+                searchType: SEARCH_TYPES.KEYWORD,
+                sourceFields: { excludes: ['embeddings'] }
+            }
+        });
+
+        assert.deepStrictEqual(result._source, { excludes: ['embeddings'] });
+    });
+
+    it('Should not include _source when sourceFields option is undefined', () => {
+        const result = buildQueryJson({
+            keyword: 'Important meeting',
+            caseReferenceNumber: '26-711111',
+            pageNumber: 1,
+            itemsPerPage: 5,
+            options: {
+                searchType: SEARCH_TYPES.KEYWORD
+            }
+        });
+
+        assert.strictEqual(Object.hasOwn(result, '_source'), false);
+    });
+
     it('Should build query with multiple numeric dates and remaining text', () => {
         const params = {
             keyword: 'Event dates: 12/01/2024, 13-02-24 in the calendar',

--- a/api/DAL/utils/buildQueryJson/index.js
+++ b/api/DAL/utils/buildQueryJson/index.js
@@ -58,6 +58,7 @@ function normalisePagination(pageNumber, itemsPerPage) {
  * @param {'search'|'page-metadata'} [params.options.queryMode='search'] - Query builder mode.
  * @param {boolean} [params.options.includePagination=true] - Whether to include pagination fields in the query.
  * @param {boolean} [params.options.includeNamedQueries=false] - Whether to include named-query `_name` metadata in the generated DSL.
+ * @param {string[]|boolean|{includes?: string[], excludes?: string[]}} [params.options.sourceFields] - Optional OpenSearch `_source` projection.
  * @param {object} [params.options.queryDslConfig] - Optional tuning overrides for semantic thresholds, ANN k, and default boosts.
  * @param {string} [params.options.documentId] - Document UUID to scope results to a single document and page.
  * @returns {object} OpenSearch query DSL JSON object.
@@ -73,6 +74,7 @@ function buildQueryJson({
         queryMode = DEFAULT_QUERY_MODE,
         includePagination = true,
         includeNamedQueries = false,
+        sourceFields,
         documentId,
         queryDslConfig
     } = {}
@@ -142,6 +144,10 @@ function buildQueryJson({
         queryJson.size = safeItemsPerPage;
     }
 
+    if (sourceFields !== undefined) {
+        queryJson._source = sourceFields;
+    }
+
     if (queryJson?.query?.bool?.should?.length === 0) {
         delete queryJson.query.bool.should;
         delete queryJson.query.bool.minimum_should_match;
@@ -170,6 +176,7 @@ function buildQueryJson({
         safePageNumber,
         documentId,
         includeNamedQueries,
+        sourceFields,
         queryDslConfig
     };
     const prettyJsonEnabled = process.env.APP_LOG_PRETTY_JSON === 'true';

--- a/api/DAL/utils/buildQueryJson/index.js
+++ b/api/DAL/utils/buildQueryJson/index.js
@@ -1,6 +1,11 @@
 import SEARCH_TYPES, { DEFAULT_SEARCH_TYPE } from '../../../search/constants/searchTypes.js';
 import logQueryMetrics from '../logQueryMetrics/index.js';
 import {
+    DEFAULT_QUERY_MODE,
+    queryStructureBuilders as defaultQueryStructureBuilders,
+    QUERY_MODES
+} from './queryStructureBuilders.js';
+import {
     createQueryTypeBuilders,
     queryTypeBuilders as defaultQueryTypeBuilders
 } from './queryTypeBuilders.js';
@@ -50,6 +55,7 @@ function normalisePagination(pageNumber, itemsPerPage) {
  * @param {object} [params.options] - Optional behavioural overrides.
  * @param {object} [params.options.logger] - Optional structured logger instance.
  * @param {string} [params.options.searchType=DEFAULT_SEARCH_TYPE] - Search mode. One of SEARCH_TYPES.KEYWORD, SEARCH_TYPES.KEYWORD_DATES, SEARCH_TYPES.SEMANTIC, SEARCH_TYPES.HYBRID, or SEARCH_TYPES.HYBRID_DATES.
+ * @param {'search'|'page-metadata'} [params.options.queryMode='search'] - Query builder mode.
  * @param {boolean} [params.options.includePagination=true] - Whether to include pagination fields in the query.
  * @param {boolean} [params.options.includeNamedQueries=false] - Whether to include named-query `_name` metadata in the generated DSL.
  * @param {object} [params.options.queryDslConfig] - Optional tuning overrides for semantic thresholds, ANN k, and default boosts.
@@ -64,6 +70,7 @@ function buildQueryJson({
     options: {
         logger,
         searchType = DEFAULT_SEARCH_TYPE,
+        queryMode = DEFAULT_QUERY_MODE,
         includePagination = true,
         includeNamedQueries = false,
         documentId,
@@ -71,35 +78,64 @@ function buildQueryJson({
     } = {}
 }) {
     const buildStart = Date.now();
-
-    // Re-use the module-level default builder map when no config overrides are
-    // provided — avoids rebuilding the map and re-merging config on every request.
-    const queryTypeBuilders = queryDslConfig
-        ? createQueryTypeBuilders({ queryDslConfig })
-        : defaultQueryTypeBuilders;
-    // dispatch to the appropriate mode-specific builder. Each builder handles
-    // its own date preprocessing (keyword and hybrid extract dates, semantic
-    // skips preprocessing entirely for efficiency).
-    const queryTypeBuilder = queryTypeBuilders[searchType];
-    if (!queryTypeBuilder) {
-        throw new Error(
-            `Invalid searchType "${searchType}". Must be one of: ${Object.values(SEARCH_TYPES).join(', ')}`
-        );
-    }
+    const effectiveQueryMode = queryMode ?? DEFAULT_QUERY_MODE;
 
     const { safePageNumber, safeItemsPerPage } = normalisePagination(pageNumber, itemsPerPage);
 
-    const builderParams = {
-        keyword,
-        caseReferenceNumber,
-        safePageNumber,
-        documentId,
-        logger,
-        includeNamedQueries
-    };
+    let queryJson;
+    let phrases = [];
+    let phrasesVariants = [];
+    let shouldClauses = [];
+    let extractMs = 0;
+    let variantMs = 0;
 
-    const { queryJson, phrases, phrasesVariants, shouldClauses, extractMs, variantMs } =
-        queryTypeBuilder(builderParams);
+    switch (effectiveQueryMode) {
+        case QUERY_MODES.PAGE_METADATA: {
+            const queryStructureBuilder = defaultQueryStructureBuilders[effectiveQueryMode];
+            queryJson = queryStructureBuilder({
+                documentId,
+                safePageNumber,
+                caseReferenceNumber,
+                keyword,
+                logger,
+                includeNamedQueries
+            });
+            break;
+        }
+        case QUERY_MODES.SEARCH: {
+            // Re-use the module-level default builder map when no config overrides are
+            // provided — avoids rebuilding the map and re-merging config on every request.
+            const queryTypeBuilders = queryDslConfig
+                ? createQueryTypeBuilders({ queryDslConfig })
+                : defaultQueryTypeBuilders;
+            // dispatch to the appropriate mode-specific builder. Each builder handles
+            // its own date preprocessing (keyword and hybrid extract dates, semantic
+            // skips preprocessing entirely for efficiency).
+            const queryTypeBuilder = queryTypeBuilders[searchType];
+            if (!queryTypeBuilder) {
+                throw new Error(
+                    `Invalid searchType "${searchType}". Must be one of: ${Object.values(SEARCH_TYPES).join(', ')}`
+                );
+            }
+
+            const builderParams = {
+                keyword,
+                caseReferenceNumber,
+                safePageNumber,
+                documentId,
+                logger,
+                includeNamedQueries
+            };
+
+            ({ queryJson, phrases, phrasesVariants, shouldClauses, extractMs, variantMs } =
+                queryTypeBuilder(builderParams));
+            break;
+        }
+        default:
+            throw new Error(
+                `Invalid queryMode "${effectiveQueryMode}". Must be one of: ${Object.values(QUERY_MODES).join(', ')}`
+            );
+    }
 
     if (includePagination === true) {
         queryJson.from = safeItemsPerPage * (safePageNumber - 1);
@@ -130,6 +166,7 @@ function buildQueryJson({
     const queryTypeBuilderParamsLog = {
         keyword,
         caseReferenceNumber,
+        queryMode: effectiveQueryMode,
         safePageNumber,
         documentId,
         includeNamedQueries,

--- a/api/DAL/utils/buildQueryJson/index.js
+++ b/api/DAL/utils/buildQueryJson/index.js
@@ -60,7 +60,7 @@ function normalisePagination(pageNumber, itemsPerPage) {
  * @param {boolean} [params.options.includeNamedQueries=false] - Whether to include named-query `_name` metadata in the generated DSL.
  * @param {string[]|boolean|{includes?: string[], excludes?: string[]}} [params.options.sourceFields] - Optional OpenSearch `_source` projection.
  * @param {object} [params.options.queryDslConfig] - Optional tuning overrides for semantic thresholds, ANN k, and default boosts.
- * @param {string} [params.options.documentId] - Document UUID to scope results to a single document and page.
+ * @param {string} [params.options.documentId] - Document UUID to scope results to a single document and page. Required when queryMode is `page-metadata`.
  * @returns {object} OpenSearch query DSL JSON object.
  */
 function buildQueryJson({
@@ -93,14 +93,19 @@ function buildQueryJson({
 
     switch (effectiveQueryMode) {
         case QUERY_MODES.PAGE_METADATA: {
+            if (!documentId) {
+                throw new Error('documentId is required when queryMode is page-metadata');
+            }
             const queryStructureBuilder = defaultQueryStructureBuilders[effectiveQueryMode];
+            if (!queryStructureBuilder) {
+                throw new Error(
+                    `No query structure builder registered for queryMode "${effectiveQueryMode}"`
+                );
+            }
+
             queryJson = queryStructureBuilder({
                 documentId,
-                safePageNumber,
-                caseReferenceNumber,
-                keyword,
-                logger,
-                includeNamedQueries
+                safePageNumber
             });
             break;
         }

--- a/api/DAL/utils/buildQueryJson/queryStructureBuilders.js
+++ b/api/DAL/utils/buildQueryJson/queryStructureBuilders.js
@@ -1,0 +1,47 @@
+/**
+ * @file Builders for non-search OpenSearch query structures used by the DAL.
+ */
+
+export const QUERY_MODES = Object.freeze({
+    // Canonical default mode handled by search query type builders in buildQueryJson.
+    // Kept here so all query mode values are defined in one place.
+    SEARCH: 'search',
+    PAGE_METADATA: 'page-metadata'
+});
+
+export const DEFAULT_QUERY_MODE = QUERY_MODES.SEARCH;
+
+/**
+ * Builds the page metadata lookup query.
+ *
+ * @param {object} params - Query builder params.
+ * @param {string} params.documentId - Source document ID.
+ * @param {number} params.safePageNumber - Normalized page number.
+ * @returns {object} Page metadata query DSL.
+ */
+export function buildPageMetadataQuery({ documentId, safePageNumber }) {
+    return {
+        query: {
+            bool: {
+                must: [
+                    { match: { source_doc_id: documentId } },
+                    { match: { page_num: safePageNumber } }
+                ]
+            }
+        }
+    };
+}
+
+/**
+ * Creates a map of internal query-mode keys to structure builders.
+ *
+ * @returns {Record<string, Function>} Map of query modes to builders.
+ */
+export function createQueryStructureBuilders() {
+    return {
+        [QUERY_MODES.PAGE_METADATA]: ({ documentId, safePageNumber }) =>
+            buildPageMetadataQuery({ documentId, safePageNumber })
+    };
+}
+
+export const queryStructureBuilders = createQueryStructureBuilders();

--- a/api/document/services/page-chunks-service.js
+++ b/api/document/services/page-chunks-service.js
@@ -25,7 +25,7 @@ function createPageChunksService({
      * @param {string} [context.searchType='hybrid-dates'] - Search mode (one of SEARCH_TYPES).
      * @param {boolean} [context.includeNamedQueries=false] - Whether to include named query metadata in the generated DSL.
      * @param {object} [context.queryDslConfig] - Optional debug-only DSL tuning overrides.
-    * @param {string[]|boolean|{includes?: string[], excludes?: string[]}} [context.sourceFields] - Optional `_source` projection for OpenSearch queries.
+     * @param {string[]|boolean|{includes?: string[], excludes?: string[]}} [context.sourceFields] - Optional `_source` projection for OpenSearch queries.
      * @returns {Promise<Array<Object>>} Array of chunks with bounding boxes.
      */
     async function getPageChunks(

--- a/api/document/services/page-chunks-service.js
+++ b/api/document/services/page-chunks-service.js
@@ -25,6 +25,7 @@ function createPageChunksService({
      * @param {string} [context.searchType='hybrid-dates'] - Search mode (one of SEARCH_TYPES).
      * @param {boolean} [context.includeNamedQueries=false] - Whether to include named query metadata in the generated DSL.
      * @param {object} [context.queryDslConfig] - Optional debug-only DSL tuning overrides.
+     * @param {string[]|boolean} [context.sourceFields] - Optional `_source` projection for OpenSearch queries.
      * @returns {Promise<Array<Object>>} Array of chunks with bounding boxes.
      */
     async function getPageChunks(
@@ -32,7 +33,13 @@ function createPageChunksService({
         pageNumber,
         crn,
         searchTerm,
-        { logger, searchType = DEFAULT_SEARCH_TYPE, includeNamedQueries, queryDslConfig } = {}
+        {
+            logger,
+            searchType = DEFAULT_SEARCH_TYPE,
+            includeNamedQueries,
+            queryDslConfig,
+            sourceFields
+        } = {}
     ) {
         const dal = createDocumentDALFactory({
             caseReferenceNumber: crn,
@@ -47,7 +54,8 @@ function createPageChunksService({
                 documentId,
                 pageNumber,
                 searchTerm,
-                searchType
+                searchType,
+                sourceFields === undefined ? undefined : { sourceFields }
             );
         } catch (error) {
             logger?.error(

--- a/api/document/services/page-chunks-service.js
+++ b/api/document/services/page-chunks-service.js
@@ -25,7 +25,7 @@ function createPageChunksService({
      * @param {string} [context.searchType='hybrid-dates'] - Search mode (one of SEARCH_TYPES).
      * @param {boolean} [context.includeNamedQueries=false] - Whether to include named query metadata in the generated DSL.
      * @param {object} [context.queryDslConfig] - Optional debug-only DSL tuning overrides.
-     * @param {string[]|boolean} [context.sourceFields] - Optional `_source` projection for OpenSearch queries.
+    * @param {string[]|boolean|{includes?: string[], excludes?: string[]}} [context.sourceFields] - Optional `_source` projection for OpenSearch queries.
      * @returns {Promise<Array<Object>>} Array of chunks with bounding boxes.
      */
     async function getPageChunks(

--- a/api/document/services/page-chunks-service.test.js
+++ b/api/document/services/page-chunks-service.test.js
@@ -109,6 +109,23 @@ describe('page-chunks-service', () => {
             assert.strictEqual(capturedSearchType, 'semantic');
         });
 
+        it('should pass sourceFields to DAL query options when provided', async () => {
+            let capturedOptions;
+            mockDAL.getPageChunksByDocumentIdAndPageNumber = async (_, __, ___, ____, options) => {
+                capturedOptions = options;
+                return [];
+            };
+
+            await pageChunksService.getPageChunks('doc-123', 1, '12-745678', 'keyword', {
+                logger: mockLogger,
+                sourceFields: ['chunk_text', 'bounding_box']
+            });
+
+            assert.deepStrictEqual(capturedOptions, {
+                sourceFields: ['chunk_text', 'bounding_box']
+            });
+        });
+
         it('should pass includeNamedQueries to DAL factory when provided', async () => {
             let capturedDalOptions;
             const service = createPageChunksService({

--- a/api/search/search-service.js
+++ b/api/search/search-service.js
@@ -30,6 +30,7 @@ function createSearchService({ createDocumentDAL: dalFactory = createDocumentDAL
      * @param {string} [context.searchType=DEFAULT_SEARCH_TYPE] - Search mode. One of SEARCH_TYPES.KEYWORD, SEARCH_TYPES.KEYWORD_DATES, SEARCH_TYPES.SEMANTIC, SEARCH_TYPES.HYBRID, or SEARCH_TYPES.HYBRID_DATES.
      * @param {boolean} [context.includeNamedQueries] - Optional explicit override for named query metadata.
      * @param {object} [context.queryDslConfig] - Optional debug-only DSL tuning overrides.
+     * @param {string[]|boolean} [context.sourceFields] - Optional `_source` projection for OpenSearch queries.
      * @returns {Promise<Object[]>} A promise that resolves to an array of document results.
      */
     async function getSearchResultsByKeyword(
@@ -41,7 +42,8 @@ function createSearchService({ createDocumentDAL: dalFactory = createDocumentDAL
             logger,
             searchType = DEFAULT_SEARCH_TYPE,
             includeNamedQueries,
-            queryDslConfig
+            queryDslConfig,
+            sourceFields
         }
     ) {
         const db = dalFactory({
@@ -51,7 +53,8 @@ function createSearchService({ createDocumentDAL: dalFactory = createDocumentDAL
             includeNamedQueries,
             queryDslConfig
         });
-        return db.getDocumentsChunksByKeyword(keyword, pageNumber, itemsPerPage);
+        const queryOptions = sourceFields === undefined ? undefined : { sourceFields };
+        return db.getDocumentsChunksByKeyword(keyword, pageNumber, itemsPerPage, queryOptions);
     }
 
     return Object.freeze({

--- a/api/search/search-service.js
+++ b/api/search/search-service.js
@@ -53,8 +53,7 @@ function createSearchService({ createDocumentDAL: dalFactory = createDocumentDAL
             includeNamedQueries,
             queryDslConfig
         });
-        const queryOptions = sourceFields === undefined ? undefined : { sourceFields };
-        return db.getDocumentsChunksByKeyword(keyword, pageNumber, itemsPerPage, queryOptions);
+        return db.getDocumentsChunksByKeyword(keyword, pageNumber, itemsPerPage, { sourceFields });
     }
 
     return Object.freeze({

--- a/api/search/search-service.js
+++ b/api/search/search-service.js
@@ -30,7 +30,7 @@ function createSearchService({ createDocumentDAL: dalFactory = createDocumentDAL
      * @param {string} [context.searchType=DEFAULT_SEARCH_TYPE] - Search mode. One of SEARCH_TYPES.KEYWORD, SEARCH_TYPES.KEYWORD_DATES, SEARCH_TYPES.SEMANTIC, SEARCH_TYPES.HYBRID, or SEARCH_TYPES.HYBRID_DATES.
      * @param {boolean} [context.includeNamedQueries] - Optional explicit override for named query metadata.
      * @param {object} [context.queryDslConfig] - Optional debug-only DSL tuning overrides.
-    * @param {string[]|boolean|{includes?: string[], excludes?: string[]}} [context.sourceFields] - Optional `_source` projection for OpenSearch queries.
+     * @param {string[]|boolean|{includes?: string[], excludes?: string[]}} [context.sourceFields] - Optional `_source` projection for OpenSearch queries.
      * @returns {Promise<Object[]>} A promise that resolves to an array of document results.
      */
     async function getSearchResultsByKeyword(

--- a/api/search/search-service.js
+++ b/api/search/search-service.js
@@ -30,7 +30,7 @@ function createSearchService({ createDocumentDAL: dalFactory = createDocumentDAL
      * @param {string} [context.searchType=DEFAULT_SEARCH_TYPE] - Search mode. One of SEARCH_TYPES.KEYWORD, SEARCH_TYPES.KEYWORD_DATES, SEARCH_TYPES.SEMANTIC, SEARCH_TYPES.HYBRID, or SEARCH_TYPES.HYBRID_DATES.
      * @param {boolean} [context.includeNamedQueries] - Optional explicit override for named query metadata.
      * @param {object} [context.queryDslConfig] - Optional debug-only DSL tuning overrides.
-     * @param {string[]|boolean} [context.sourceFields] - Optional `_source` projection for OpenSearch queries.
+    * @param {string[]|boolean|{includes?: string[], excludes?: string[]}} [context.sourceFields] - Optional `_source` projection for OpenSearch queries.
      * @returns {Promise<Object[]>} A promise that resolves to an array of document results.
      */
     async function getSearchResultsByKeyword(

--- a/api/search/search-service.test.js
+++ b/api/search/search-service.test.js
@@ -77,7 +77,7 @@ describe('Search Service', () => {
 
         assert.equal(mockDAL.getDocumentsChunksByKeyword.mock.callCount(), 1);
         const args = mockDAL.getDocumentsChunksByKeyword.mock.calls[0].arguments;
-        assert.deepEqual(args, [keyword, pageNumber, itemsPerPage]);
+        assert.deepEqual(args, [keyword, pageNumber, itemsPerPage, undefined]);
     });
 
     it('should return search results from DAL', async () => {
@@ -164,7 +164,24 @@ describe('Search Service', () => {
         });
 
         const args = mockDAL.getDocumentsChunksByKeyword.mock.calls[0].arguments;
-        assert.deepEqual(args, ['test', 3, 50]);
+        assert.deepEqual(args, ['test', 3, 50, undefined]);
+    });
+
+    it('should pass sourceFields to DAL query options when provided', async () => {
+        const searchService = createSearchService({
+            createDocumentDAL: mockDALFactory
+        });
+
+        mockDAL.getDocumentsChunksByKeyword = mock.fn(async () => []);
+
+        await searchService.getSearchResultsByKeyword('test', 1, 10, {
+            caseReferenceNumber: '12-745678',
+            logger: { info: () => {} },
+            sourceFields: ['chunk_text', 'chunk_id']
+        });
+
+        const args = mockDAL.getDocumentsChunksByKeyword.mock.calls[0].arguments;
+        assert.deepEqual(args, ['test', 1, 10, { sourceFields: ['chunk_text', 'chunk_id'] }]);
     });
 
     it('should pass includeNamedQueries to DAL factory when provided', async () => {

--- a/api/search/search-service.test.js
+++ b/api/search/search-service.test.js
@@ -77,7 +77,7 @@ describe('Search Service', () => {
 
         assert.equal(mockDAL.getDocumentsChunksByKeyword.mock.callCount(), 1);
         const args = mockDAL.getDocumentsChunksByKeyword.mock.calls[0].arguments;
-        assert.deepEqual(args, [keyword, pageNumber, itemsPerPage, undefined]);
+        assert.deepEqual(args, [keyword, pageNumber, itemsPerPage, { sourceFields: undefined }]);
     });
 
     it('should return search results from DAL', async () => {
@@ -164,7 +164,7 @@ describe('Search Service', () => {
         });
 
         const args = mockDAL.getDocumentsChunksByKeyword.mock.calls[0].arguments;
-        assert.deepEqual(args, ['test', 3, 50, undefined]);
+        assert.deepEqual(args, ['test', 3, 50, { sourceFields: undefined }]);
     });
 
     it('should pass sourceFields to DAL query options when provided', async () => {

--- a/search/routes.js
+++ b/search/routes.js
@@ -103,7 +103,8 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
             });
 
             const token = createApiJwtToken(userName);
-            const searchOptions = { searchType };
+            const sourceFields = { excludes: ['embeddings'] };
+            const searchOptions = { searchType, sourceFields };
             if (isDebugMode) {
                 searchOptions.includeNamedQueries = true;
                 // In debug mode, pass the effective DSL tuning bag consistently.
@@ -142,10 +143,8 @@ function createSearchRouter({ createTemplateEngineService, createSearchService }
                     pageNumber,
                     itemsPerPage,
                     options: {
-                        searchType,
-                        logger: req.log,
-                        includeNamedQueries: isDebugMode,
-                        queryDslConfig: debugQueryDslOverrides
+                        ...searchOptions,
+                        logger: req.log
                     }
                 });
                 const queryHash = crypto

--- a/search/routes.test.js
+++ b/search/routes.test.js
@@ -136,7 +136,10 @@ describe('Search Routes', () => {
 
             assert.strictEqual(res.statusCode, 200);
             assert.deepStrictEqual(serviceCallArgs[4], {
-                searchType: 'semantic'
+                searchType: 'semantic',
+                sourceFields: {
+                    excludes: ['embeddings']
+                }
             });
         });
 
@@ -200,6 +203,9 @@ describe('Search Routes', () => {
             assert.strictEqual(res.statusCode, 200);
             assert.deepStrictEqual(serviceCallArgs[4], {
                 searchType: 'hybrid',
+                sourceFields: {
+                    excludes: ['embeddings']
+                },
                 includeNamedQueries: true,
                 queryDslConfig: {
                     semanticMinScore: 1.2,
@@ -209,6 +215,9 @@ describe('Search Routes', () => {
                     dateBoost: 2,
                     neuralBoost: 3
                 }
+            });
+            assert.deepStrictEqual(lastRenderParams.debugInfo.request.queryDsl._source, {
+                excludes: ['embeddings']
             });
         });
 


### PR DESCRIPTION
This branch centralizes OpenSearch `_source` handling in the shared query builder so the generated DSL includes the projection directly, including in debug output.

It also updates the DAL and search route call sites to pass `sourceFields` through `buildQueryJson`, removes post-build `_source` mutation, and keeps the debug panel aligned with the executed query DSL. The related tests and builder README were updated to cover and document the new behaviour.