### PR TITLE
tests: add experimental search page subset validation tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ stuff/
 scan.js
 .env
 coverage/
+expeerimental/integration-tests/page-subset-query-matching/results

--- a/experimental/integration-tests/page-subset-query-matching/query_dsls/hybrid_base_search_date_query_dsl.json
+++ b/experimental/integration-tests/page-subset-query-matching/query_dsls/hybrid_base_search_date_query_dsl.json
@@ -1,0 +1,108 @@
+{
+    "_source": {
+        "includes": ["chunk_id", "chunk_text", "page_number", "case_ref", "chunk_type"]
+    },
+    "query": {
+        "index": "page_chunks",
+        "preference": "session-346fa2d18bbdd560e3c27a367916f4b547a3a927dfe58b505fe29d0381ed259e",
+        "body": {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "term": {
+                                "case_ref": "26-700001"
+                            }
+                        }
+                    ],
+                    "should": [
+                        {
+                            "bool": {
+                                "should": [
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "28 1 18"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "28 1 2018"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "28 01 18"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "28 01 2018"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "28 Jan 18"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "28 Jan 2018"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "28 January 18"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "28 January 2018"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "2018 1 28"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "2018 01 28"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "2018 Jan 28"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "2018 January 28"
+                                        }
+                                    }
+                                ],
+                                "minimum_should_match": 1,
+                                "boost": 4
+                            }
+                        },
+                        {
+                            "neural": {
+                                "embedding": {
+                                    "query_text": "28 Jan 2018",
+                                    "k": 250,
+                                    "filter": {
+                                        "term": {
+                                            "case_ref": "26-700001"
+                                        }
+                                    },
+                                    "boost": 4
+                                }
+                            }
+                        }
+                    ],
+                    "minimum_should_match": 1
+                }
+            },
+            "min_score": 2.25
+        }
+    }
+}

--- a/experimental/integration-tests/page-subset-query-matching/query_dsls/hybrid_base_search_query_dsl.json
+++ b/experimental/integration-tests/page-subset-query-matching/query_dsls/hybrid_base_search_query_dsl.json
@@ -1,0 +1,48 @@
+{
+    "_source": {
+        "includes": ["chunk_id", "chunk_text", "page_number", "case_ref", "chunk_type"]
+    },
+    "query": {
+        "index": "page_chunks",
+        "preference": "session-edb18f1a1d5884f245c40fe76a64e864b337bfadcea2391d648f4b8643a976a9",
+        "body": {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "term": {
+                                "case_ref": "26-700001"
+                            }
+                        }
+                    ],
+                    "should": [
+                        {
+                            "match": {
+                                "chunk_text": {
+                                    "query": "Did the applicant suffer brain damage?",
+                                    "boost": 20
+                                }
+                            }
+                        },
+                        {
+                            "neural": {
+                                "embedding": {
+                                    "query_text": "Did the applicant suffer brain damage?",
+                                    "k": 250,
+                                    "filter": {
+                                        "term": {
+                                            "case_ref": "26-700001"
+                                        }
+                                    },
+                                    "boost": 4
+                                }
+                            }
+                        }
+                    ],
+                    "minimum_should_match": 1
+                }
+            },
+            "min_score": 2.25
+        }
+    }
+}

--- a/experimental/integration-tests/page-subset-query-matching/query_dsls/hybrid_base_search_three_part_date_query_dsl.json
+++ b/experimental/integration-tests/page-subset-query-matching/query_dsls/hybrid_base_search_three_part_date_query_dsl.json
@@ -1,0 +1,101 @@
+{
+    "_source": {
+        "includes": ["chunk_id", "chunk_text", "page_number", "case_ref", "chunk_type"]
+    },
+    "query": {
+        "index": "page_chunks",
+        "preference": "session-edb18f1a1d5884f245c40fe76a64e864b337bfadcea2391d648f4b8643a976a9",
+        "body": {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "term": {
+                                "case_ref": "26-700001"
+                            }
+                        }
+                    ],
+                    "should": [
+                        {
+                            "match": {
+                                "chunk_text": {
+                                    "query": "Repeat Past",
+                                    "boost": 20
+                                }
+                            }
+                        },
+                        {
+                            "bool": {
+                                "should": [
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "28 11 22"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "28 11 2022"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "28 Nov 22"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "28 Nov 2022"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "28 November 22"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "28 November 2022"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "2022 11 28"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "2022 Nov 28"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "2022 November 28"
+                                        }
+                                    }
+                                ],
+                                "minimum_should_match": 1,
+                                "boost": 1
+                            }
+                        },
+                        {
+                            "neural": {
+                                "embedding": {
+                                    "query_text": "Repeat Past 28-Nov-2022",
+                                    "k": 250,
+                                    "filter": {
+                                        "term": {
+                                            "case_ref": "26-700001"
+                                        }
+                                    },
+                                    "boost": 4
+                                }
+                            }
+                        }
+                    ],
+                    "minimum_should_match": 1
+                }
+            },
+            "min_score": 2.25
+        }
+    }
+}

--- a/experimental/integration-tests/page-subset-query-matching/query_dsls/hybrid_base_search_two_part_date_query_dsl.json
+++ b/experimental/integration-tests/page-subset-query-matching/query_dsls/hybrid_base_search_two_part_date_query_dsl.json
@@ -1,0 +1,76 @@
+{
+    "_source": {
+        "includes": ["chunk_id", "chunk_text", "page_number", "case_ref", "chunk_type"]
+    },
+    "query": {
+        "index": "page_chunks",
+        "preference": "session-edb18f1a1d5884f245c40fe76a64e864b337bfadcea2391d648f4b8643a976a9",
+        "body": {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "term": {
+                                "case_ref": "26-700001"
+                            }
+                        }
+                    ],
+                    "should": [
+                        {
+                            "match": {
+                                "chunk_text": {
+                                    "query": "symptoms after",
+                                    "boost": 20
+                                }
+                            }
+                        },
+                        {
+                            "bool": {
+                                "should": [
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "Feb 18"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "Feb 2018"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "February 18"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "February 2018"
+                                        }
+                                    }
+                                ],
+                                "minimum_should_match": 1,
+                                "boost": 4
+                            }
+                        },
+                        {
+                            "neural": {
+                                "embedding": {
+                                    "query_text": "symptoms after February 2018",
+                                    "k": 250,
+                                    "filter": {
+                                        "term": {
+                                            "case_ref": "26-700001"
+                                        }
+                                    },
+                                    "boost": 4
+                                }
+                            }
+                        }
+                    ],
+                    "minimum_should_match": 1
+                }
+            },
+            "min_score": 2.25
+        }
+    }
+}

--- a/experimental/integration-tests/page-subset-query-matching/query_dsls/hybrid_page_search_date_query_dsl.json
+++ b/experimental/integration-tests/page-subset-query-matching/query_dsls/hybrid_page_search_date_query_dsl.json
@@ -1,0 +1,142 @@
+{
+    "_source": {
+        "includes": ["chunk_id", "chunk_text", "page_number", "case_ref", "chunk_type"]
+    },
+    "query": {
+        "index": "page_chunks",
+        "preference": "session-346fa2d18bbdd560e3c27a367916f4b547a3a927dfe58b505fe29d0381ed259e",
+        "body": {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "term": {
+                                "case_ref": "26-700001"
+                            }
+                        },
+                        {
+                            "term": {
+                                "source_doc_id": "4bcba3af-d9ab-53f2-9fd7-bf4263f8118e"
+                            }
+                        },
+                        {
+                            "term": {
+                                "page_number": 6
+                            }
+                        }
+                    ],
+                    "should": [
+                        {
+                            "bool": {
+                                "should": [
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "28 1 18"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "28 1 2018"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "28 01 18"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "28 01 2018"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "28 Jan 18"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "28 Jan 2018"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "28 January 18"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "28 January 2018"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "2018 1 28"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "2018 01 28"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "2018 Jan 28"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "2018 January 28"
+                                        }
+                                    }
+                                ],
+                                "minimum_should_match": 1,
+                                "boost": 4
+                            }
+                        },
+                        {
+                            "neural": {
+                                "embedding": {
+                                    "query_text": "28 Jan 2018",
+                                    "k": 250,
+                                    "filter": {
+                                        "bool": {
+                                            "filter": [
+                                                {
+                                                    "term": {
+                                                        "case_ref": "26-700001"
+                                                    }
+                                                },
+                                                {
+                                                    "term": {
+                                                        "source_doc_id": "4bcba3af-d9ab-53f2-9fd7-bf4263f8118e"
+                                                    }
+                                                },
+                                                {
+                                                    "term": {
+                                                        "page_number": 6
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "boost": 4
+                                }
+                            }
+                        }
+                    ],
+                    "minimum_should_match": 1
+                }
+            },
+            "min_score": 2.25,
+            "track_scores": true,
+            "sort": [
+                {
+                    "chunk_index": {
+                        "order": "asc"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/experimental/integration-tests/page-subset-query-matching/query_dsls/hybrid_page_search_query_dsl.json
+++ b/experimental/integration-tests/page-subset-query-matching/query_dsls/hybrid_page_search_query_dsl.json
@@ -1,0 +1,81 @@
+{
+    "_source": {
+        "includes": ["chunk_id", "chunk_text", "page_number", "case_ref", "chunk_type"]
+    },
+    "query": {
+        "index": "page_chunks",
+        "preference": "session-edb18f1a1d5884f245c40fe76a64e864b337bfadcea2391d648f4b8643a976a9",
+        "body": {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "term": {
+                                "case_ref": "26-700001"
+                            }
+                        },
+                        {
+                            "term": {
+                                "source_doc_id": "4bcba3af-d9ab-53f2-9fd7-bf4263f8118e"
+                            }
+                        },
+                        {
+                            "term": {
+                                "page_number": 6
+                            }
+                        }
+                    ],
+                    "should": [
+                        {
+                            "match": {
+                                "chunk_text": {
+                                    "query": "Did the applicant suffer brain damage?",
+                                    "boost": 20
+                                }
+                            }
+                        },
+                        {
+                            "neural": {
+                                "embedding": {
+                                    "query_text": "Did the applicant suffer brain damage?",
+                                    "k": 250,
+                                    "filter": {
+                                        "bool": {
+                                            "filter": [
+                                                {
+                                                    "term": {
+                                                        "case_ref": "26-700001"
+                                                    }
+                                                },
+                                                {
+                                                    "term": {
+                                                        "source_doc_id": "4bcba3af-d9ab-53f2-9fd7-bf4263f8118e"
+                                                    }
+                                                },
+                                                {
+                                                    "term": {
+                                                        "page_number": 6
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "boost": 4
+                                }
+                            }
+                        }
+                    ],
+                    "minimum_should_match": 1
+                }
+            },
+            "min_score": 2.25,
+            "sort": [
+                {
+                    "chunk_index": {
+                        "order": "asc"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/experimental/integration-tests/page-subset-query-matching/query_dsls/hybrid_page_search_three_part_date_query_dsl.json
+++ b/experimental/integration-tests/page-subset-query-matching/query_dsls/hybrid_page_search_three_part_date_query_dsl.json
@@ -1,0 +1,135 @@
+{
+    "_source": {
+        "includes": ["chunk_id", "chunk_text", "page_number", "case_ref", "chunk_type"]
+    },
+    "query": {
+        "index": "page_chunks",
+        "preference": "session-edb18f1a1d5884f245c40fe76a64e864b337bfadcea2391d648f4b8643a976a9",
+        "body": {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "term": {
+                                "case_ref": "26-700001"
+                            }
+                        },
+                        {
+                            "term": {
+                                "source_doc_id": "4bcba3af-d9ab-53f2-9fd7-bf4263f8118e"
+                            }
+                        },
+                        {
+                            "term": {
+                                "page_number": 6
+                            }
+                        }
+                    ],
+                    "should": [
+                        {
+                            "match": {
+                                "chunk_text": {
+                                    "query": "Repeat Past",
+                                    "boost": 20
+                                }
+                            }
+                        },
+                        {
+                            "bool": {
+                                "should": [
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "28 11 22"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "28 11 2022"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "28 Nov 22"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "28 Nov 2022"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "28 November 22"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "28 November 2022"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "2022 11 28"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "2022 Nov 28"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "2022 November 28"
+                                        }
+                                    }
+                                ],
+                                "minimum_should_match": 1,
+                                "boost": 4
+                            }
+                        },
+                        {
+                            "neural": {
+                                "embedding": {
+                                    "query_text": "Repeat Past 28-Nov-2022",
+                                    "k": 250,
+                                    "filter": {
+                                        "bool": {
+                                            "filter": [
+                                                {
+                                                    "term": {
+                                                        "case_ref": "26-700001"
+                                                    }
+                                                },
+                                                {
+                                                    "term": {
+                                                        "source_doc_id": "4bcba3af-d9ab-53f2-9fd7-bf4263f8118e"
+                                                    }
+                                                },
+                                                {
+                                                    "term": {
+                                                        "page_number": 6
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "boost": 4
+                                }
+                            }
+                        }
+                    ],
+                    "minimum_should_match": 1
+                }
+            },
+            "min_score": 2.25,
+            "track_scores": true,
+            "sort": [
+                {
+                    "chunk_index": {
+                        "order": "asc"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/experimental/integration-tests/page-subset-query-matching/query_dsls/hybrid_page_search_two_part_date_query_dsl.json
+++ b/experimental/integration-tests/page-subset-query-matching/query_dsls/hybrid_page_search_two_part_date_query_dsl.json
@@ -1,0 +1,110 @@
+{
+    "_source": {
+        "includes": ["chunk_id", "chunk_text", "page_number", "case_ref", "chunk_type"]
+    },
+    "query": {
+        "index": "page_chunks",
+        "preference": "session-edb18f1a1d5884f245c40fe76a64e864b337bfadcea2391d648f4b8643a976a9",
+        "body": {
+            "query": {
+                "bool": {
+                    "filter": [
+                        {
+                            "term": {
+                                "case_ref": "26-700001"
+                            }
+                        },
+                        {
+                            "term": {
+                                "source_doc_id": "4bcba3af-d9ab-53f2-9fd7-bf4263f8118e"
+                            }
+                        },
+                        {
+                            "term": {
+                                "page_number": 18
+                            }
+                        }
+                    ],
+                    "should": [
+                        {
+                            "match": {
+                                "chunk_text": {
+                                    "query": "symptoms after",
+                                    "boost": 20
+                                }
+                            }
+                        },
+                        {
+                            "bool": {
+                                "should": [
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "Feb 18"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "Feb 2018"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "February 18"
+                                        }
+                                    },
+                                    {
+                                        "match_phrase": {
+                                            "chunk_text": "February 2018"
+                                        }
+                                    }
+                                ],
+                                "minimum_should_match": 1,
+                                "boost": 4
+                            }
+                        },
+                        {
+                            "neural": {
+                                "embedding": {
+                                    "query_text": "symptoms after February 2018",
+                                    "k": 250,
+                                    "filter": {
+                                        "bool": {
+                                            "filter": [
+                                                {
+                                                    "term": {
+                                                        "case_ref": "26-700001"
+                                                    }
+                                                },
+                                                {
+                                                    "term": {
+                                                        "source_doc_id": "4bcba3af-d9ab-53f2-9fd7-bf4263f8118e"
+                                                    }
+                                                },
+                                                {
+                                                    "term": {
+                                                        "page_number": 18
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "boost": 4
+                                }
+                            }
+                        }
+                    ],
+                    "minimum_should_match": 1
+                }
+            },
+            "min_score": 2.25,
+            "track_scores": true,
+            "sort": [
+                {
+                    "chunk_index": {
+                        "order": "asc"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/experimental/integration-tests/page-subset-query-matching/results/Did_the_applicant_suffer_brain_damage?-20260710-092030.json
+++ b/experimental/integration-tests/page-subset-query-matching/results/Did_the_applicant_suffer_brain_damage?-20260710-092030.json
@@ -1,0 +1,560 @@
+{
+    "meta": {
+        "generatedAt": "2026-07-10T08:20:41.368Z",
+        "generatedAtEuropeLondon": "Friday, 10 July 2026 at 09:20:41 BST",
+        "outputPath": "/home/enigma/cica-review-case-documents/expeerimental/integration-tests/page-subset-query-matching/results/Did_the_applicant_suffer_brain_damage?-20260710-092030.json",
+        "baseDslPath": "/home/enigma/cica-review-case-documents/expeerimental/integration-tests/page-subset-query-matching/query_dsls/hybrid_base_search_query_dsl.json",
+        "pageDslPath": "/home/enigma/cica-review-case-documents/expeerimental/integration-tests/page-subset-query-matching/query_dsls/hybrid_page_search_query_dsl.json",
+        "opensearchUrl": "http://localhost:9200",
+        "fallbackIndex": "page_chunks",
+        "queryInputs": {
+            "base": {
+                "keywordQuery": "Did the applicant suffer brain damage?",
+                "neuralQueryText": "Did the applicant suffer brain damage?"
+            },
+            "page": {
+                "keywordQuery": "Did the applicant suffer brain damage?",
+                "neuralQueryText": "Did the applicant suffer brain damage?"
+            }
+        },
+        "queryConfig": {
+            "base": {
+                "index": "page_chunks",
+                "preference": "session-edb18f1a1d5884f245c40fe76a64e864b337bfadcea2391d648f4b8643a976a9",
+                "rows": null,
+                "min_score": 2.25,
+                "track_scores": null,
+                "minimum_should_match": 1,
+                "sort": null,
+                "boosts": {
+                    "keyword": 20,
+                    "phraseGroup": null,
+                    "neural": 4
+                },
+                "neural": {
+                    "k": 250
+                }
+            },
+            "page": {
+                "index": "page_chunks",
+                "preference": "session-edb18f1a1d5884f245c40fe76a64e864b337bfadcea2391d648f4b8643a976a9",
+                "rows": null,
+                "min_score": 2.25,
+                "track_scores": null,
+                "minimum_should_match": 1,
+                "sort": [
+                    {
+                        "chunk_index": {
+                            "order": "asc"
+                        }
+                    }
+                ],
+                "boosts": {
+                    "keyword": 20,
+                    "phraseGroup": null,
+                    "neural": 4
+                },
+                "neural": {
+                    "k": 250
+                }
+            }
+        }
+    },
+    "base": {
+        "index": "page_chunks",
+        "totalHits": {
+            "value": 100,
+            "relation": "eq"
+        },
+        "totalHitsValue": 100,
+        "returnedHits": 100,
+        "returnedHitsMeaning": "Number of hits returned for the executed query window (affected by size/from/min_score).",
+        "fetchedAllHits": true,
+        "byPage": {
+            "1": 2,
+            "2": 2,
+            "3": 2,
+            "5": 4,
+            "6": 2,
+            "8": 3,
+            "10": 1,
+            "11": 1,
+            "12": 1,
+            "13": 4,
+            "14": 2,
+            "15": 6,
+            "17": 3,
+            "18": 4,
+            "19": 1,
+            "20": 1,
+            "21": 1,
+            "22": 4,
+            "23": 2,
+            "24": 4,
+            "25": 2,
+            "26": 4,
+            "27": 4,
+            "28": 1,
+            "29": 1,
+            "30": 1,
+            "31": 4,
+            "32": 2,
+            "33": 3,
+            "34": 4,
+            "35": 2,
+            "36": 4,
+            "37": 2,
+            "38": 1,
+            "39": 2,
+            "40": 1,
+            "41": 2,
+            "43": 1,
+            "44": 1,
+            "45": 1,
+            "47": 1,
+            "48": 2,
+            "49": 2,
+            "50": 2
+        }
+    },
+    "pageValidation": {
+        "index": "page_chunks",
+        "scopesTested": 44,
+        "aggregateReturnedHits": 100,
+        "failingScopeCount": 0,
+        "sampleScopes": [
+            {
+                "source_doc_id": "535aaa3d-41df-58d4-8eb1-897a5d39830a",
+                "page_number": 1,
+                "baseHits": 2,
+                "returnedHits": 2,
+                "base_chunk_ids": [
+                    "110957da-cac1-54e5-9ae8-c9df10c8f374",
+                    "c355be77-1c79-50f3-9d21-4e2a98a2b9f3"
+                ],
+                "returned_chunk_ids": [
+                    "110957da-cac1-54e5-9ae8-c9df10c8f374",
+                    "c355be77-1c79-50f3-9d21-4e2a98a2b9f3"
+                ],
+                "subsetPass": true,
+                "scopeFilterPass": true,
+                "missingCount": 0,
+                "outsideScopeCount": 0,
+                "missingFromPageCount": 0,
+                "additionalHitsCount": 0,
+                "exactMatchPass": true
+            },
+            {
+                "source_doc_id": "535aaa3d-41df-58d4-8eb1-897a5d39830a",
+                "page_number": 2,
+                "baseHits": 2,
+                "returnedHits": 2,
+                "base_chunk_ids": [
+                    "1d910b33-8ee7-5f63-949a-1c3291bf6a22",
+                    "ba966626-3f39-5b73-9fe3-f4230087d273"
+                ],
+                "returned_chunk_ids": [
+                    "1d910b33-8ee7-5f63-949a-1c3291bf6a22",
+                    "ba966626-3f39-5b73-9fe3-f4230087d273"
+                ],
+                "subsetPass": true,
+                "scopeFilterPass": true,
+                "missingCount": 0,
+                "outsideScopeCount": 0,
+                "missingFromPageCount": 0,
+                "additionalHitsCount": 0,
+                "exactMatchPass": true
+            },
+            {
+                "source_doc_id": "535aaa3d-41df-58d4-8eb1-897a5d39830a",
+                "page_number": 3,
+                "baseHits": 2,
+                "returnedHits": 2,
+                "base_chunk_ids": [
+                    "a42105ad-2ded-576f-9418-a5a8ff285b09",
+                    "d85863c0-ef6a-52b7-9a17-6005cf4f937f"
+                ],
+                "returned_chunk_ids": [
+                    "a42105ad-2ded-576f-9418-a5a8ff285b09",
+                    "d85863c0-ef6a-52b7-9a17-6005cf4f937f"
+                ],
+                "subsetPass": true,
+                "scopeFilterPass": true,
+                "missingCount": 0,
+                "outsideScopeCount": 0,
+                "missingFromPageCount": 0,
+                "additionalHitsCount": 0,
+                "exactMatchPass": true
+            },
+            {
+                "source_doc_id": "535aaa3d-41df-58d4-8eb1-897a5d39830a",
+                "page_number": 5,
+                "baseHits": 4,
+                "returnedHits": 4,
+                "base_chunk_ids": [
+                    "144e72dc-3475-56c4-92dc-266f3f37e071",
+                    "4bc975c7-70cd-5444-bad4-55ecaaa4f5ea",
+                    "c7fc799d-83ee-5bbf-a7bc-6f5bbac91fe7",
+                    "f3b3baf4-c7da-56cc-8cf4-ea0e1612a934"
+                ],
+                "returned_chunk_ids": [
+                    "144e72dc-3475-56c4-92dc-266f3f37e071",
+                    "4bc975c7-70cd-5444-bad4-55ecaaa4f5ea",
+                    "c7fc799d-83ee-5bbf-a7bc-6f5bbac91fe7",
+                    "f3b3baf4-c7da-56cc-8cf4-ea0e1612a934"
+                ],
+                "subsetPass": true,
+                "scopeFilterPass": true,
+                "missingCount": 0,
+                "outsideScopeCount": 0,
+                "missingFromPageCount": 0,
+                "additionalHitsCount": 0,
+                "exactMatchPass": true
+            },
+            {
+                "source_doc_id": "535aaa3d-41df-58d4-8eb1-897a5d39830a",
+                "page_number": 6,
+                "baseHits": 2,
+                "returnedHits": 2,
+                "base_chunk_ids": [
+                    "71f4c421-6b98-5ecc-b618-97eabeadad7d",
+                    "d083b19d-4289-5488-aa25-e813122a5dc7"
+                ],
+                "returned_chunk_ids": [
+                    "71f4c421-6b98-5ecc-b618-97eabeadad7d",
+                    "d083b19d-4289-5488-aa25-e813122a5dc7"
+                ],
+                "subsetPass": true,
+                "scopeFilterPass": true,
+                "missingCount": 0,
+                "outsideScopeCount": 0,
+                "missingFromPageCount": 0,
+                "additionalHitsCount": 0,
+                "exactMatchPass": true
+            },
+            {
+                "source_doc_id": "535aaa3d-41df-58d4-8eb1-897a5d39830a",
+                "page_number": 8,
+                "baseHits": 3,
+                "returnedHits": 3,
+                "base_chunk_ids": [
+                    "532501d0-55e5-5d6c-b6ae-ece86eb7c89e",
+                    "da57787c-628d-5802-82d1-8481d2e99721",
+                    "e3ef482c-087f-5435-8271-4628ce84889f"
+                ],
+                "returned_chunk_ids": [
+                    "532501d0-55e5-5d6c-b6ae-ece86eb7c89e",
+                    "da57787c-628d-5802-82d1-8481d2e99721",
+                    "e3ef482c-087f-5435-8271-4628ce84889f"
+                ],
+                "subsetPass": true,
+                "scopeFilterPass": true,
+                "missingCount": 0,
+                "outsideScopeCount": 0,
+                "missingFromPageCount": 0,
+                "additionalHitsCount": 0,
+                "exactMatchPass": true
+            },
+            {
+                "source_doc_id": "535aaa3d-41df-58d4-8eb1-897a5d39830a",
+                "page_number": 10,
+                "baseHits": 1,
+                "returnedHits": 1,
+                "base_chunk_ids": ["8fd17628-8c55-5bca-bef6-8d470a1fe9c3"],
+                "returned_chunk_ids": ["8fd17628-8c55-5bca-bef6-8d470a1fe9c3"],
+                "subsetPass": true,
+                "scopeFilterPass": true,
+                "missingCount": 0,
+                "outsideScopeCount": 0,
+                "missingFromPageCount": 0,
+                "additionalHitsCount": 0,
+                "exactMatchPass": true
+            },
+            {
+                "source_doc_id": "535aaa3d-41df-58d4-8eb1-897a5d39830a",
+                "page_number": 11,
+                "baseHits": 1,
+                "returnedHits": 1,
+                "base_chunk_ids": ["3a94bac3-326b-5bf9-a7d8-6454113ae3d3"],
+                "returned_chunk_ids": ["3a94bac3-326b-5bf9-a7d8-6454113ae3d3"],
+                "subsetPass": true,
+                "scopeFilterPass": true,
+                "missingCount": 0,
+                "outsideScopeCount": 0,
+                "missingFromPageCount": 0,
+                "additionalHitsCount": 0,
+                "exactMatchPass": true
+            },
+            {
+                "source_doc_id": "535aaa3d-41df-58d4-8eb1-897a5d39830a",
+                "page_number": 12,
+                "baseHits": 1,
+                "returnedHits": 1,
+                "base_chunk_ids": ["65dd7445-51ee-58ad-bcd5-9ab4531c7c24"],
+                "returned_chunk_ids": ["65dd7445-51ee-58ad-bcd5-9ab4531c7c24"],
+                "subsetPass": true,
+                "scopeFilterPass": true,
+                "missingCount": 0,
+                "outsideScopeCount": 0,
+                "missingFromPageCount": 0,
+                "additionalHitsCount": 0,
+                "exactMatchPass": true
+            },
+            {
+                "source_doc_id": "535aaa3d-41df-58d4-8eb1-897a5d39830a",
+                "page_number": 13,
+                "baseHits": 4,
+                "returnedHits": 4,
+                "base_chunk_ids": [
+                    "1b062561-5226-572e-a20a-baf1c32a30ef",
+                    "2f403ef1-a942-52c6-ad9e-ada0052492ec",
+                    "3a18301e-568a-59b2-829f-add79ab5cbba",
+                    "9f811df2-8ee7-5aae-9d8f-4e0012d14703"
+                ],
+                "returned_chunk_ids": [
+                    "1b062561-5226-572e-a20a-baf1c32a30ef",
+                    "2f403ef1-a942-52c6-ad9e-ada0052492ec",
+                    "3a18301e-568a-59b2-829f-add79ab5cbba",
+                    "9f811df2-8ee7-5aae-9d8f-4e0012d14703"
+                ],
+                "subsetPass": true,
+                "scopeFilterPass": true,
+                "missingCount": 0,
+                "outsideScopeCount": 0,
+                "missingFromPageCount": 0,
+                "additionalHitsCount": 0,
+                "exactMatchPass": true
+            },
+            {
+                "source_doc_id": "535aaa3d-41df-58d4-8eb1-897a5d39830a",
+                "page_number": 14,
+                "baseHits": 2,
+                "returnedHits": 2,
+                "base_chunk_ids": [
+                    "6e20855c-29ff-5952-b6e8-5bca76b9674f",
+                    "894c6500-bff9-55e7-9bda-d66f9841bf6c"
+                ],
+                "returned_chunk_ids": [
+                    "6e20855c-29ff-5952-b6e8-5bca76b9674f",
+                    "894c6500-bff9-55e7-9bda-d66f9841bf6c"
+                ],
+                "subsetPass": true,
+                "scopeFilterPass": true,
+                "missingCount": 0,
+                "outsideScopeCount": 0,
+                "missingFromPageCount": 0,
+                "additionalHitsCount": 0,
+                "exactMatchPass": true
+            },
+            {
+                "source_doc_id": "535aaa3d-41df-58d4-8eb1-897a5d39830a",
+                "page_number": 15,
+                "baseHits": 6,
+                "returnedHits": 6,
+                "base_chunk_ids": [
+                    "20bf802d-ccc8-56a5-931c-049986d5912f",
+                    "22863540-fee4-5811-811c-7710498d354c",
+                    "4cc294aa-7596-5ac3-89b2-f19b5446e133",
+                    "cb980903-bb55-525d-a831-90900481a4ce",
+                    "d2f89525-cfaa-52ba-8571-e752b981e1d8",
+                    "f4cd449f-acb6-53e6-923d-dcc39f582645"
+                ],
+                "returned_chunk_ids": [
+                    "20bf802d-ccc8-56a5-931c-049986d5912f",
+                    "22863540-fee4-5811-811c-7710498d354c",
+                    "4cc294aa-7596-5ac3-89b2-f19b5446e133",
+                    "cb980903-bb55-525d-a831-90900481a4ce",
+                    "d2f89525-cfaa-52ba-8571-e752b981e1d8",
+                    "f4cd449f-acb6-53e6-923d-dcc39f582645"
+                ],
+                "subsetPass": true,
+                "scopeFilterPass": true,
+                "missingCount": 0,
+                "outsideScopeCount": 0,
+                "missingFromPageCount": 0,
+                "additionalHitsCount": 0,
+                "exactMatchPass": true
+            },
+            {
+                "source_doc_id": "535aaa3d-41df-58d4-8eb1-897a5d39830a",
+                "page_number": 17,
+                "baseHits": 3,
+                "returnedHits": 3,
+                "base_chunk_ids": [
+                    "265d1c77-bdb3-59c0-bef4-3073e6c38de1",
+                    "68789fbc-7fc3-56f1-a1d2-4786ce1d3dd9",
+                    "74acf3e1-42e1-54ae-b66f-816fe78af57a"
+                ],
+                "returned_chunk_ids": [
+                    "265d1c77-bdb3-59c0-bef4-3073e6c38de1",
+                    "68789fbc-7fc3-56f1-a1d2-4786ce1d3dd9",
+                    "74acf3e1-42e1-54ae-b66f-816fe78af57a"
+                ],
+                "subsetPass": true,
+                "scopeFilterPass": true,
+                "missingCount": 0,
+                "outsideScopeCount": 0,
+                "missingFromPageCount": 0,
+                "additionalHitsCount": 0,
+                "exactMatchPass": true
+            },
+            {
+                "source_doc_id": "535aaa3d-41df-58d4-8eb1-897a5d39830a",
+                "page_number": 18,
+                "baseHits": 4,
+                "returnedHits": 4,
+                "base_chunk_ids": [
+                    "1bca0caf-6f8f-549c-94e8-1f6301ae2eed",
+                    "a5edd5af-4e79-5962-adef-f72caaff1b61",
+                    "b4bd542c-8ea0-5005-bb79-29f7def0341a",
+                    "d27d71e9-1ada-58c6-b692-d15c31bddd4b"
+                ],
+                "returned_chunk_ids": [
+                    "1bca0caf-6f8f-549c-94e8-1f6301ae2eed",
+                    "a5edd5af-4e79-5962-adef-f72caaff1b61",
+                    "b4bd542c-8ea0-5005-bb79-29f7def0341a",
+                    "d27d71e9-1ada-58c6-b692-d15c31bddd4b"
+                ],
+                "subsetPass": true,
+                "scopeFilterPass": true,
+                "missingCount": 0,
+                "outsideScopeCount": 0,
+                "missingFromPageCount": 0,
+                "additionalHitsCount": 0,
+                "exactMatchPass": true
+            },
+            {
+                "source_doc_id": "535aaa3d-41df-58d4-8eb1-897a5d39830a",
+                "page_number": 19,
+                "baseHits": 1,
+                "returnedHits": 1,
+                "base_chunk_ids": ["25afde94-b258-5343-9976-0cbdceb13f83"],
+                "returned_chunk_ids": ["25afde94-b258-5343-9976-0cbdceb13f83"],
+                "subsetPass": true,
+                "scopeFilterPass": true,
+                "missingCount": 0,
+                "outsideScopeCount": 0,
+                "missingFromPageCount": 0,
+                "additionalHitsCount": 0,
+                "exactMatchPass": true
+            },
+            {
+                "source_doc_id": "535aaa3d-41df-58d4-8eb1-897a5d39830a",
+                "page_number": 20,
+                "baseHits": 1,
+                "returnedHits": 1,
+                "base_chunk_ids": ["73a9864c-ed42-54d9-a8b6-595b3050f5f7"],
+                "returned_chunk_ids": ["73a9864c-ed42-54d9-a8b6-595b3050f5f7"],
+                "subsetPass": true,
+                "scopeFilterPass": true,
+                "missingCount": 0,
+                "outsideScopeCount": 0,
+                "missingFromPageCount": 0,
+                "additionalHitsCount": 0,
+                "exactMatchPass": true
+            },
+            {
+                "source_doc_id": "535aaa3d-41df-58d4-8eb1-897a5d39830a",
+                "page_number": 21,
+                "baseHits": 1,
+                "returnedHits": 1,
+                "base_chunk_ids": ["8e1e7b1a-3e39-5d02-97de-3e236f476937"],
+                "returned_chunk_ids": ["8e1e7b1a-3e39-5d02-97de-3e236f476937"],
+                "subsetPass": true,
+                "scopeFilterPass": true,
+                "missingCount": 0,
+                "outsideScopeCount": 0,
+                "missingFromPageCount": 0,
+                "additionalHitsCount": 0,
+                "exactMatchPass": true
+            },
+            {
+                "source_doc_id": "535aaa3d-41df-58d4-8eb1-897a5d39830a",
+                "page_number": 22,
+                "baseHits": 4,
+                "returnedHits": 4,
+                "base_chunk_ids": [
+                    "4e6a8dbc-5e0f-5911-a07c-6a2f0231899a",
+                    "78d13c8a-8c03-56fb-b102-ee0457abe4f3",
+                    "8b2e4a00-dd4f-598a-ad37-a6537f9c5780",
+                    "d143e161-e2d4-5b22-a89a-f2e06a119ae5"
+                ],
+                "returned_chunk_ids": [
+                    "4e6a8dbc-5e0f-5911-a07c-6a2f0231899a",
+                    "78d13c8a-8c03-56fb-b102-ee0457abe4f3",
+                    "8b2e4a00-dd4f-598a-ad37-a6537f9c5780",
+                    "d143e161-e2d4-5b22-a89a-f2e06a119ae5"
+                ],
+                "subsetPass": true,
+                "scopeFilterPass": true,
+                "missingCount": 0,
+                "outsideScopeCount": 0,
+                "missingFromPageCount": 0,
+                "additionalHitsCount": 0,
+                "exactMatchPass": true
+            },
+            {
+                "source_doc_id": "535aaa3d-41df-58d4-8eb1-897a5d39830a",
+                "page_number": 23,
+                "baseHits": 2,
+                "returnedHits": 2,
+                "base_chunk_ids": [
+                    "7ffa13ce-1438-51dd-8fac-92f7c37bc318",
+                    "9c23d535-d808-5151-9ea4-c4a4b8668d04"
+                ],
+                "returned_chunk_ids": [
+                    "7ffa13ce-1438-51dd-8fac-92f7c37bc318",
+                    "9c23d535-d808-5151-9ea4-c4a4b8668d04"
+                ],
+                "subsetPass": true,
+                "scopeFilterPass": true,
+                "missingCount": 0,
+                "outsideScopeCount": 0,
+                "missingFromPageCount": 0,
+                "additionalHitsCount": 0,
+                "exactMatchPass": true
+            },
+            {
+                "source_doc_id": "535aaa3d-41df-58d4-8eb1-897a5d39830a",
+                "page_number": 24,
+                "baseHits": 4,
+                "returnedHits": 4,
+                "base_chunk_ids": [
+                    "5bbc25a1-76d6-58f0-b7ba-a5f7aea87d03",
+                    "7cbc06cd-babf-5058-9807-f1ac5788be68",
+                    "89791abf-b21d-5944-aa99-12e2d220f741",
+                    "d0ca079a-9907-5d05-8510-ed276e183ee6"
+                ],
+                "returned_chunk_ids": [
+                    "5bbc25a1-76d6-58f0-b7ba-a5f7aea87d03",
+                    "7cbc06cd-babf-5058-9807-f1ac5788be68",
+                    "89791abf-b21d-5944-aa99-12e2d220f741",
+                    "d0ca079a-9907-5d05-8510-ed276e183ee6"
+                ],
+                "subsetPass": true,
+                "scopeFilterPass": true,
+                "missingCount": 0,
+                "outsideScopeCount": 0,
+                "missingFromPageCount": 0,
+                "additionalHitsCount": 0,
+                "exactMatchPass": true
+            }
+        ]
+    },
+    "checks": {
+        "subsetPass": true,
+        "scopeFilterPass": true,
+        "missingCount": 0,
+        "outsideScopeCount": 0,
+        "exactSetPass": true,
+        "missingFromPageCount": 0,
+        "additionalHitsCount": 0,
+        "pageDslContainsNeural": true,
+        "baseDslContainsNeural": true
+    },
+    "examples": {
+        "missingFromBase": [],
+        "missingFromPage": [],
+        "outsideRequestedScope": []
+    }
+}

--- a/experimental/integration-tests/page-subset-query-matching/validate-page-filter-subset.js
+++ b/experimental/integration-tests/page-subset-query-matching/validate-page-filter-subset.js
@@ -1,0 +1,767 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { Client } from '@opensearch-project/opensearch';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const resolvePath = (relativePath) => path.resolve(__dirname, relativePath);
+
+const DEFAULT_OPENSEARCH_URL = 'http://localhost:9200';
+const DEFAULT_OPENSEARCH_INDEX = 'page_chunks';
+
+const HYBRID_SEARCH_QUERIES = [
+    'assault',
+    'brain injury',
+    'Mental Injury',
+    'nerve damage',
+    'skull fracture',
+    'coma',
+    'CBT',
+    'neuropsychologist',
+    'CMHT report',
+    'Physiotheraphy treatment',
+    'brain injury after assault',
+    'nerve damage symptoms',
+    'skull fracture diagnosis',
+    'mental health treatment CBT',
+    'neuropsychologist report',
+    'injuries reported after assault',
+    'treatment after brain injury',
+    'repeat symptoms after incident',
+    'Did the applicant suffer brain damage?',
+    'Was the applicant in a coma?',
+    'What injuries did the applicant have?',
+    'What treatment was provided after the assault?',
+    'Is there evidence of mental health issues?',
+    'Was a neuropsychologist involved?',
+    'Did the applicant have depressive episodes?',
+    'Did the applicant have suicidal thoughts?',
+    'Did the applicant self harm?'
+];
+
+const HYBRID_SEARCH_DATE_QUERIES = ['28 Jan 2018'];
+const HYBRID_SEARCH_TWO_PART_DATE_QUERIES = ['coma January 2018', 'symptoms after February 2018'];
+
+const HYBRID_SEARCH_THREE_PART_DATE_QUERIES = ['What happened on 28 Jan 2018?'];
+
+const HYBRID_SEARCH_CONFIG = {
+    baseDslPath: resolvePath('./query_dsls/hybrid_base_search_query_dsl.json'),
+    pageDslPath: resolvePath('./query_dsls/hybrid_page_search_query_dsl.json'),
+    queries: HYBRID_SEARCH_QUERIES
+};
+
+const HYBRID_SEARCH_DATE_CONFIG = {
+    baseDslPath: resolvePath('./query_dsls/hybrid_base_search_date_query_dsl.json'),
+    pageDslPath: resolvePath('./query_dsls/hybrid_page_search_date_query_dsl.json'),
+    queries: HYBRID_SEARCH_DATE_QUERIES
+};
+
+const HYBRID_SEARCH_TWO_PART_DATE_CONFIG = {
+    baseDslPath: resolvePath('./query_dsls/hybrid_base_search_two_part_date_query_dsl.json'),
+    pageDslPath: resolvePath('./query_dsls/hybrid_page_search_two_part_date_query_dsl.json'),
+    queries: HYBRID_SEARCH_TWO_PART_DATE_QUERIES
+};
+
+const HYBRID_SEARCH_THREE_PART_DATE_CONFIG = {
+    baseDslPath: resolvePath('./query_dsls/hybrid_base_search_three_part_date_query_dsl.json'),
+    pageDslPath: resolvePath('./query_dsls/hybrid_page_search_three_part_date_query_dsl.json'),
+    queries: HYBRID_SEARCH_THREE_PART_DATE_QUERIES
+};
+
+// This works for
+// search_query k:60
+// page_query k:10
+
+function parseArgs(argv) {
+    const args = {
+        baseDslPath: resolvePath('./query_dsls/hybrid_base_search_query_dsl.json'),
+        pageDslPath: resolvePath('./query_dsls/hybrid_page_search_query_dsl.json'),
+        index: process.env.OPENSEARCH_INDEX_CHUNKS_NAME || DEFAULT_OPENSEARCH_INDEX,
+        failOnSubsetBreach: true,
+        showExamples: 10,
+        outputPath: undefined
+    };
+
+    for (let i = 2; i < argv.length; i += 1) {
+        const token = argv[i];
+        const next = argv[i + 1];
+
+        if (token === '--base' && next) {
+            args.baseDslPath = resolvePath(next);
+            i += 1;
+            continue;
+        }
+        if (token === '--page' && next) {
+            args.pageDslPath = resolvePath(next);
+            i += 1;
+            continue;
+        }
+        if (token === '--index' && next) {
+            args.index = next;
+            i += 1;
+            continue;
+        }
+        if (token === '--out' && next) {
+            args.outputPath = resolvePath(next);
+            i += 1;
+            continue;
+        }
+        if (token === '--no-fail') {
+            args.failOnSubsetBreach = false;
+            continue;
+        }
+        if (token === '--examples' && next) {
+            const parsed = Number.parseInt(next, 10);
+            if (Number.isFinite(parsed) && parsed > 0) {
+                args.showExamples = parsed;
+            }
+            i += 1;
+            continue;
+        }
+        if (token === '--help' || token === '-h') {
+            printUsage();
+            process.exit(0);
+        }
+    }
+
+    return args;
+}
+
+function printUsage() {
+    console.log(`Usage:
+  node stuff/validate-page-filter-subset.js [options]
+
+Options:
+  --base <path>       Base search DSL file (default: query_dsls/hybrid_base_search_query_dsl.json)
+  --page <path>       Page-filtered DSL file (default: query_dsls/hybrid_page_search_query_dsl.json)
+  --index <name>      OpenSearch index (fallback if not in DSL)
+        --out <path>        JSON report file path (default: results/{query}-{stamp}.json)
+  --examples <count>  Number of mismatch examples to print (default: 10)
+  --no-fail           Exit 0 even when subset check fails
+  --help, -h          Show this help
+
+Environment:
+    APP_DATABASE_URL                Optional. Default: ${DEFAULT_OPENSEARCH_URL}
+    OPENSEARCH_INDEX_CHUNKS_NAME    Optional. Default: ${DEFAULT_OPENSEARCH_INDEX}
+`);
+}
+
+function queryToFileSlug(query) {
+    const compact = String(query || '')
+        .trim()
+        .replace(/\s+/g, '_');
+
+    if (compact.length > 0) {
+        return compact;
+    }
+
+    return 'query';
+}
+
+function buildTimestampedOutputPath(query) {
+    const parts = new Intl.DateTimeFormat('en-GB', {
+        timeZone: 'Europe/London',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hourCycle: 'h23'
+    })
+        .formatToParts(new Date())
+        .reduce((acc, part) => {
+            if (part.type !== 'literal') {
+                acc[part.type] = part.value;
+            }
+            return acc;
+        }, {});
+
+    const stamp = `${parts.year}${parts.month}${parts.day}-${parts.hour}${parts.minute}${parts.second}`;
+    const querySlug = queryToFileSlug(query);
+    return resolvePath(`./results/${querySlug}-${stamp}.json`);
+}
+
+async function readJsonFile(filePath) {
+    const raw = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(raw);
+}
+
+function buildSearchParams(dsl, fallbackIndex) {
+    // Supports both styles used in this repo:
+    // 1) { query: { ... } } + external index
+    // 2) { query: { index, preference, body: { query, ... } }, rows }
+    if (dsl?.query?.body) {
+        const index = dsl.query.index || fallbackIndex;
+        if (!index) {
+            throw new Error('No index found in page DSL and no fallback index supplied');
+        }
+        return {
+            index,
+            preference: dsl.query.preference,
+            body: dsl.query.body
+        };
+    }
+
+    if (dsl?.query) {
+        if (!fallbackIndex) {
+            throw new Error('No index supplied for base DSL style { query: ... }');
+        }
+        return {
+            index: fallbackIndex,
+            body: dsl
+        };
+    }
+
+    throw new Error(
+        'Unrecognized DSL format. Expected either { query: ... } or { query: { body: ... } }'
+    );
+}
+
+function extractHits(searchResponse) {
+    return searchResponse?.body?.hits?.hits || searchResponse?.hits?.hits || [];
+}
+
+function extractTotalValue(searchResponse, fallback = 0) {
+    const total = searchResponse?.body?.hits?.total ?? searchResponse?.hits?.total;
+    if (typeof total === 'number') {
+        return total;
+    }
+    if (total && typeof total.value === 'number') {
+        return total.value;
+    }
+    return fallback;
+}
+
+function inferPageSizeFromBody(body) {
+    const size = Number.parseInt(body?.size, 10);
+    if (Number.isFinite(size) && size > 0) {
+        return size;
+    }
+    return 10;
+}
+
+async function fetchAllBaseHits(client, baseSearchParams) {
+    const firstResponse = await client.search(baseSearchParams);
+    const firstHits = extractHits(firstResponse);
+    const totalValue = extractTotalValue(firstResponse, firstHits.length);
+
+    const allHits = [...firstHits];
+    const pageSize = inferPageSizeFromBody(baseSearchParams.body);
+    let from = Number.parseInt(baseSearchParams?.body?.from, 10);
+    if (!Number.isFinite(from) || from < 0) {
+        from = 0;
+    }
+
+    while (allHits.length < totalValue) {
+        from += pageSize;
+        const pagedParams = {
+            ...baseSearchParams,
+            body: {
+                ...baseSearchParams.body,
+                from,
+                size: pageSize
+            }
+        };
+
+        const pagedResponse = await client.search(pagedParams);
+        const pagedHits = extractHits(pagedResponse);
+        if (pagedHits.length === 0) {
+            break;
+        }
+        allHits.push(...pagedHits);
+    }
+
+    return {
+        firstResponse,
+        allHits,
+        totalValue,
+        fetchedAllHits: allHits.length >= totalValue
+    };
+}
+
+function keyFromHit(hit) {
+    const source = hit?._source || {};
+
+    if (source.chunk_id) {
+        return `chunk_id:${source.chunk_id}`;
+    }
+
+    if (hit?._id) {
+        return `_id:${hit._id}`;
+    }
+
+    // Last-resort stable key if IDs are absent.
+    return `fallback:${source.source_doc_id || 'na'}:${source.page_number || 'na'}:${source.chunk_index || 'na'}`;
+}
+
+function summarizeByPage(hits) {
+    const counts = new Map();
+    for (const hit of hits) {
+        const page = hit?._source?.page_number;
+        const key = page === undefined ? 'unknown' : String(page);
+        counts.set(key, (counts.get(key) || 0) + 1);
+    }
+    return Object.fromEntries([...counts.entries()].sort((a, b) => Number(a[0]) - Number(b[0])));
+}
+
+function uniqueChunkIdsFromHits(hits) {
+    const chunkIds = new Set();
+    for (const hit of hits) {
+        const chunkId = hit?._source?.chunk_id;
+        if (chunkId) {
+            chunkIds.add(chunkId);
+        }
+    }
+    return [...chunkIds].sort();
+}
+
+function chunkScoresFromHits(hits) {
+    const scoreByChunkId = new Map();
+
+    for (const hit of hits) {
+        const chunkId = hit?._source?.chunk_id;
+        if (!chunkId) {
+            continue;
+        }
+
+        scoreByChunkId.set(chunkId, hit?._score ?? null);
+    }
+
+    return [...scoreByChunkId.entries()]
+        .sort((a, b) => String(a[0]).localeCompare(String(b[0])))
+        .map(([chunk_id, score]) => ({ chunk_id, score }));
+}
+
+function hasNeuralClause(dsl) {
+    const shouldClauses = dsl?.query?.body?.query?.bool?.should || dsl?.query?.bool?.should || [];
+    return shouldClauses.some((clause) => clause?.neural?.embedding);
+}
+
+function extractQueryInputsFromDsl(dsl) {
+    const shouldClauses = dsl?.query?.body?.query?.bool?.should || dsl?.query?.bool?.should || [];
+
+    const matchClause = shouldClauses.find((clause) => clause?.match?.chunk_text?.query);
+    const neuralClause = shouldClauses.find((clause) => clause?.neural?.embedding?.query_text);
+
+    return {
+        keywordQuery: matchClause?.match?.chunk_text?.query || null,
+        neuralQueryText: neuralClause?.neural?.embedding?.query_text || null
+    };
+}
+
+function extractQueryConfigFromDsl(dsl, searchParams) {
+    const body = dsl?.query?.body || dsl;
+    const boolQuery = body?.query?.bool || {};
+    const shouldClauses = boolQuery?.should || [];
+
+    const keywordClause = shouldClauses.find((clause) => clause?.match?.chunk_text);
+    const phraseGroupClause = shouldClauses.find((clause) => clause?.bool?.should);
+    const neuralClause = shouldClauses.find((clause) => clause?.neural?.embedding);
+
+    return {
+        index: searchParams?.index || null,
+        preference: searchParams?.preference || null,
+        rows: dsl?.rows ?? null,
+        min_score: body?.min_score ?? null,
+        track_scores: body?.track_scores ?? null,
+        minimum_should_match: boolQuery?.minimum_should_match ?? null,
+        sort: body?.sort || null,
+        boosts: {
+            keyword: keywordClause?.match?.chunk_text?.boost ?? null,
+            phraseGroup: phraseGroupClause?.bool?.boost ?? null,
+            neural: neuralClause?.neural?.embedding?.boost ?? null
+        },
+        neural: {
+            k: neuralClause?.neural?.embedding?.k ?? null
+        }
+    };
+}
+
+function deepClone(value) {
+    return JSON.parse(JSON.stringify(value));
+}
+
+function shellSingleQuote(value) {
+    return `'${String(value).replace(/'/g, `'"'"'`)}'`;
+}
+
+function buildSearchCurlCommand({ nodeUrl, index, preference, body }) {
+    const trimmedNodeUrl = String(nodeUrl || '').replace(/\/+$/, '');
+    const encodedIndex = encodeURIComponent(index);
+    const queryParts = ['pretty=true'];
+
+    if (preference) {
+        queryParts.push(`preference=${encodeURIComponent(preference)}`);
+    }
+
+    const endpoint = `${trimmedNodeUrl}/${encodedIndex}/_search?${queryParts.join('&')}`;
+    const bodyJson = JSON.stringify(body);
+
+    return [
+        `curl -sS -X POST ${shellSingleQuote(endpoint)} \\`,
+        "  -H 'Content-Type: application/json' \\",
+        `  --data-raw ${shellSingleQuote(bodyJson)}`
+    ].join('\n');
+}
+
+function upsertTermFilter(filterArray, field, value) {
+    if (!Array.isArray(filterArray)) {
+        return;
+    }
+
+    const existing = filterArray.find((item) => item?.term && Object.hasOwn(item.term, field));
+    if (existing) {
+        existing.term[field] = value;
+        return;
+    }
+
+    filterArray.push({ term: { [field]: value } });
+}
+
+function applyPageScopeToBody(body, { sourceDocId, pageNumber }) {
+    const scopedBody = deepClone(body);
+    const topFilters = scopedBody?.query?.bool?.filter;
+    upsertTermFilter(topFilters, 'source_doc_id', sourceDocId);
+    upsertTermFilter(topFilters, 'page_number', pageNumber);
+
+    const shouldClauses = scopedBody?.query?.bool?.should;
+    if (Array.isArray(shouldClauses)) {
+        for (const clause of shouldClauses) {
+            const neuralFilter = clause?.neural?.embedding?.filter;
+            if (!neuralFilter) {
+                continue;
+            }
+
+            if (Array.isArray(neuralFilter?.bool?.filter)) {
+                upsertTermFilter(neuralFilter.bool.filter, 'source_doc_id', sourceDocId);
+                upsertTermFilter(neuralFilter.bool.filter, 'page_number', pageNumber);
+                continue;
+            }
+
+            if (neuralFilter.term && Object.hasOwn(neuralFilter.term, 'source_doc_id')) {
+                neuralFilter.term.source_doc_id = sourceDocId;
+            }
+            if (neuralFilter.term && Object.hasOwn(neuralFilter.term, 'page_number')) {
+                neuralFilter.term.page_number = pageNumber;
+            }
+        }
+    }
+
+    return scopedBody;
+}
+
+function collectPageScopes(hits) {
+    const scopes = new Map();
+
+    for (const hit of hits) {
+        const sourceDocId = hit?._source?.source_doc_id;
+        const pageNumber = hit?._source?.page_number;
+        if (!sourceDocId || pageNumber === undefined || pageNumber === null) {
+            continue;
+        }
+
+        const key = `${sourceDocId}::${pageNumber}`;
+        const existing = scopes.get(key) || {
+            sourceDocId,
+            pageNumber,
+            baseCount: 0
+        };
+        existing.baseCount += 1;
+        scopes.set(key, existing);
+    }
+
+    return [...scopes.values()].sort((a, b) => {
+        if (a.sourceDocId === b.sourceDocId) {
+            return Number(a.pageNumber) - Number(b.pageNumber);
+        }
+        return a.sourceDocId.localeCompare(b.sourceDocId);
+    });
+}
+
+function scopeKey(sourceDocId, pageNumber) {
+    return `${sourceDocId}::${pageNumber}`;
+}
+
+function buildScopedBaseKeySets(hits) {
+    const scopedSets = new Map();
+
+    for (const hit of hits) {
+        const sourceDocId = hit?._source?.source_doc_id;
+        const pageNumber = hit?._source?.page_number;
+        if (!sourceDocId || pageNumber === undefined || pageNumber === null) {
+            continue;
+        }
+
+        const key = scopeKey(sourceDocId, pageNumber);
+        if (!scopedSets.has(key)) {
+            scopedSets.set(key, new Set());
+        }
+        scopedSets.get(key).add(keyFromHit(hit));
+    }
+
+    return scopedSets;
+}
+
+async function run() {
+    const args = parseArgs(process.argv);
+    const appDatabaseUrl = process.env.APP_DATABASE_URL || DEFAULT_OPENSEARCH_URL;
+
+    const baseDslPath = path.resolve(args.baseDslPath);
+    const pageDslPath = path.resolve(args.pageDslPath);
+
+    const [baseDsl, pageDsl] = await Promise.all([
+        readJsonFile(baseDslPath),
+        readJsonFile(pageDslPath)
+    ]);
+
+    const baseSearchParams = buildSearchParams(baseDsl, args.index);
+    const pageSearchParams = buildSearchParams(pageDsl, args.index || baseSearchParams.index);
+    const baseQueryInputs = extractQueryInputsFromDsl(baseDsl);
+    const pageQueryInputs = extractQueryInputsFromDsl(pageDsl);
+    const baseQueryConfig = extractQueryConfigFromDsl(baseDsl, baseSearchParams);
+    const pageQueryConfig = extractQueryConfigFromDsl(pageDsl, pageSearchParams);
+    const outputPath =
+        args.outputPath || buildTimestampedOutputPath(baseQueryInputs.neuralQueryText);
+
+    const client = new Client({ node: appDatabaseUrl });
+
+    console.log(`OpenSearch URL: ${appDatabaseUrl}`);
+    console.log(`Fallback index: ${args.index}`);
+    console.log('Base query inputs:', baseQueryInputs);
+    console.log('Page query inputs:', pageQueryInputs);
+
+    const baseDslCurlCommand = buildSearchCurlCommand({
+        nodeUrl: appDatabaseUrl,
+        index: baseSearchParams.index,
+        preference: baseSearchParams.preference,
+        body: baseSearchParams.body
+    });
+    console.log('\nBase DSL curl command:');
+    console.log(baseDslCurlCommand);
+
+    console.log('Running base search (fetching all pages)...');
+    const {
+        firstResponse: baseResponse,
+        allHits: baseHits,
+        totalValue: baseTotalValue,
+        fetchedAllHits
+    } = await fetchAllBaseHits(client, baseSearchParams);
+    const pageScopes = collectPageScopes(baseHits);
+
+    console.log(`Running page-filtered searches across ${pageScopes.length} scope(s)...`);
+
+    const baseKeys = new Set(baseHits.map(keyFromHit));
+    const scopedBaseKeySets = buildScopedBaseKeySets(baseHits);
+    const baseHitByKey = new Map(baseHits.map((hit) => [keyFromHit(hit), hit]));
+
+    const scopeResults = [];
+    const allMissingFromBase = [];
+    const allOutsideScope = [];
+    const allMissingFromPage = [];
+    let aggregateReturnedHits = 0;
+
+    for (const scope of pageScopes) {
+        const scopedBody = applyPageScopeToBody(pageSearchParams.body, scope);
+        const scopedParams = {
+            ...pageSearchParams,
+            body: scopedBody
+        };
+
+        const pageResponse = await client.search(scopedParams);
+        const pageHits = extractHits(pageResponse);
+        aggregateReturnedHits += pageHits.length;
+        const pageKeys = new Set(pageHits.map(keyFromHit));
+
+        const currentScopeKey = scopeKey(scope.sourceDocId, scope.pageNumber);
+        const scopedBaseKeys = scopedBaseKeySets.get(currentScopeKey) || new Set();
+
+        const missingFromBase = pageHits
+            .map((hit) => ({ hit, key: keyFromHit(hit), scope }))
+            .filter(({ key }) => !baseKeys.has(key));
+
+        const outsideScope = pageHits
+            .map((hit) => ({ hit, key: keyFromHit(hit), scope }))
+            .filter(({ key }) => !scopedBaseKeys.has(key));
+
+        const missingFromPage = [...scopedBaseKeys]
+            .filter((key) => !pageKeys.has(key))
+            .map((key) => ({
+                key,
+                hit: baseHitByKey.get(key),
+                scope
+            }));
+
+        allMissingFromBase.push(...missingFromBase);
+        allOutsideScope.push(...outsideScope);
+        allMissingFromPage.push(...missingFromPage);
+
+        const exactMatchPass = missingFromPage.length === 0 && outsideScope.length === 0;
+        const returnedChunkIds = uniqueChunkIdsFromHits(pageHits);
+        const baseChunkIds = uniqueChunkIdsFromHits(
+            [...scopedBaseKeys].map((key) => baseHitByKey.get(key)).filter(Boolean)
+        );
+
+        scopeResults.push({
+            source_doc_id: scope.sourceDocId,
+            page_number: scope.pageNumber,
+            baseHits: scope.baseCount,
+            returnedHits: pageHits.length,
+            base_chunk_ids: baseChunkIds,
+            returned_chunk_ids: returnedChunkIds,
+            subsetPass: missingFromBase.length === 0,
+            scopeFilterPass: outsideScope.length === 0,
+            missingCount: missingFromBase.length,
+            outsideScopeCount: outsideScope.length,
+            missingFromPageCount: missingFromPage.length,
+            additionalHitsCount: outsideScope.length,
+            exactMatchPass
+        });
+    }
+
+    const failingScopeCount = scopeResults.filter((scope) => scope.exactMatchPass === false).length;
+
+    const missingExamples = allMissingFromBase
+        .slice(0, args.showExamples)
+        .map(({ hit, key, scope }) => ({
+            key,
+            scoped_doc_id: scope.sourceDocId,
+            scoped_page_number: scope.pageNumber,
+            score: hit?._score,
+            source_doc_id: hit?._source?.source_doc_id,
+            page_number: hit?._source?.page_number,
+            chunk_index: hit?._source?.chunk_index,
+            chunk_id: hit?._source?.chunk_id,
+            chunk_text_preview: String(hit?._source?.chunk_text || '').slice(0, 140)
+        }));
+
+    const outsideScopeExamples = allOutsideScope
+        .slice(0, args.showExamples)
+        .map(({ hit, key, scope }) => ({
+            key,
+            scoped_doc_id: scope.sourceDocId,
+            scoped_page_number: scope.pageNumber,
+            source_doc_id: hit?._source?.source_doc_id,
+            page_number: hit?._source?.page_number,
+            chunk_index: hit?._source?.chunk_index,
+            chunk_id: hit?._source?.chunk_id,
+            chunk_text_preview: String(hit?._source?.chunk_text || '').slice(0, 140)
+        }));
+
+    const missingFromPageExamples = allMissingFromPage
+        .slice(0, args.showExamples)
+        .map(({ hit, key, scope }) => ({
+            key,
+            scoped_doc_id: scope.sourceDocId,
+            scoped_page_number: scope.pageNumber,
+            source_doc_id: hit?._source?.source_doc_id,
+            page_number: hit?._source?.page_number,
+            chunk_index: hit?._source?.chunk_index,
+            chunk_id: hit?._source?.chunk_id,
+            chunk_text_preview: String(hit?._source?.chunk_text || '').slice(0, 140)
+        }));
+
+    const result = {
+        meta: {
+            generatedAt: new Date().toISOString(),
+            generatedAtEuropeLondon: new Intl.DateTimeFormat('en-GB', {
+                timeZone: 'Europe/London',
+                dateStyle: 'full',
+                timeStyle: 'long'
+            }).format(new Date()),
+            outputPath,
+            baseDslPath,
+            pageDslPath,
+            opensearchUrl: appDatabaseUrl,
+            fallbackIndex: args.index,
+            queryInputs: {
+                base: baseQueryInputs,
+                page: pageQueryInputs
+            },
+            queryConfig: {
+                base: baseQueryConfig,
+                page: pageQueryConfig
+            }
+        },
+        base: {
+            index: baseSearchParams.index,
+            totalHits: baseResponse?.body?.hits?.total,
+            totalHitsValue: baseTotalValue,
+            returnedHits: baseHits.length,
+            returnedHitsMeaning:
+                'Number of hits returned for the executed query window (affected by size/from/min_score).',
+            fetchedAllHits,
+            byPage: summarizeByPage(baseHits)
+        },
+        pageValidation: {
+            index: pageSearchParams.index,
+            scopesTested: pageScopes.length,
+            aggregateReturnedHits,
+            failingScopeCount,
+            sampleScopes: scopeResults.slice(0, 20)
+        },
+        checks: {
+            subsetPass: allMissingFromBase.length === 0,
+            scopeFilterPass: allOutsideScope.length === 0,
+            missingCount: allMissingFromBase.length,
+            outsideScopeCount: allOutsideScope.length,
+            exactSetPass: allMissingFromPage.length === 0 && allOutsideScope.length === 0,
+            missingFromPageCount: allMissingFromPage.length,
+            additionalHitsCount: allOutsideScope.length,
+            pageDslContainsNeural: hasNeuralClause(pageDsl),
+            baseDslContainsNeural: hasNeuralClause(baseDsl)
+        },
+        examples: {
+            missingFromBase: missingExamples,
+            missingFromPage: missingFromPageExamples,
+            outsideRequestedScope: outsideScopeExamples
+        }
+    };
+
+    console.log('\n=== Validation Summary ===');
+    console.log(JSON.stringify(result, null, 2));
+
+    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+    await fs.writeFile(outputPath, `${JSON.stringify(result, null, 2)}\n`, 'utf8');
+    console.log(`\nReport written to: ${outputPath}`);
+
+    if (allMissingFromBase.length > 0) {
+        console.log('\n=== Examples missing from base set ===');
+        console.log(JSON.stringify(missingExamples, null, 2));
+    }
+
+    if (allOutsideScope.length > 0) {
+        console.log('\n=== Examples outside requested page scope ===');
+        console.log(JSON.stringify(outsideScopeExamples, null, 2));
+    }
+
+    if (allMissingFromPage.length > 0) {
+        console.log('\n=== Examples missing from page results (present in base scope) ===');
+        console.log(JSON.stringify(missingFromPageExamples, null, 2));
+    }
+
+    if (
+        (allMissingFromBase.length > 0 || allOutsideScope.length > 0) &&
+        result.checks.pageDslContainsNeural
+    ) {
+        console.log(
+            '\nNote: Page DSL contains a neural clause; check neural filter semantics if subset/scope violations appear.'
+        );
+    }
+
+    if ((allMissingFromPage.length > 0 || allOutsideScope.length > 0) && args.failOnSubsetBreach) {
+        process.exit(2);
+    }
+
+    console.log('\nSubset validation passed.');
+}
+
+run().catch((err) => {
+    console.error('Validation script failed:', err.message);
+    process.exit(1);
+});


### PR DESCRIPTION
Experimental integration page subset valdiation tests.
Ensures that page searches contain a subset of the original total search results, for different DSL query shapes. 
Quickly pulled together.

Run: validate-page-filter-subset.js

change base values to other DSL query shapes.

Run: validate-page-filter-subset.js
