### PR TITLE
feat: Make search result headings linked with page reference

### DIFF
--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -10,8 +10,9 @@ on:
 permissions: {}
 
 jobs:
-  sca:
-    name: Software Composition Analysis
+  sca-pr:
+    if: ${{ github.event_name == 'pull_request' }}
+    name: Software Composition Analysis (PR)
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -27,3 +28,24 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           renovate-version: "43.55.5"
+          disable-node-audit: "true"
+
+  sca-full:
+    if: ${{ github.event_name != 'pull_request' }}
+    name: Software Composition Analysis (Scheduled/Manual)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      security-events: write
+      actions: read
+
+    steps:
+      - uses: ministryofjustice/devsecops-actions/sca@7dc13c20e2bf541b8a77fa1320a04983b18846f6 # v1.6.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          renovate-version: "43.55.5"
+          disable-node-audit: "false"

--- a/search/macro/search-result-item/template.njk
+++ b/search/macro/search-result-item/template.njk
@@ -1,8 +1,8 @@
-<h2 class="govuk-heading-m">{{ params._source.correspondence_type }} - {{ params._source.source_file_name }}</h2>
+<h2 class="govuk-heading-m">
+  <a href="/document/{{ params.docUuid }}/view/page/{{ params._source.page_number or '0' }}?crn={{ params.caseReferenceNumber | urlencode }}&searchTerm={{ params.searchTerm | urlencode }}&type={{ params.searchType | urlencode }}" class="govuk-link">Page {{ params._source.page_number }} · {{ params._source.correspondence_type }} {{ params._source.source_file_name }}</a>
+</h2>
 <p class="govuk-hint govuk-visually-hidden">Received on {{ params._source.received_date | formatDate}}</p>
 <p class="govuk-body">{{ params._source.chunk_text | safe }}</p>
-
-<p class="govuk-body"><strong>Found on:</strong> <a href="/document/{{ params.docUuid }}/view/page/{{ params._source.page_number or '0' }}?crn={{ params.caseReferenceNumber | urlencode }}&searchTerm={{ params.searchTerm | urlencode }}&type={{ params.searchType | urlencode }}" class="govuk-link">Page {{ params._source.page_number }}</a></p>
 
 {% if params.isDebugMode %}
   <div class="search-result-debug">

--- a/search/macro/search-result-item/template.njk
+++ b/search/macro/search-result-item/template.njk
@@ -1,5 +1,5 @@
 <h2 class="govuk-heading-m">
-  <a href="/document/{{ params.docUuid }}/view/page/{{ params._source.page_number or '0' }}?crn={{ params.caseReferenceNumber | urlencode }}&searchTerm={{ params.searchTerm | urlencode }}&type={{ params.searchType | urlencode }}" class="govuk-link">Page {{ params._source.page_number }} · {{ params._source.correspondence_type }} {{ params._source.source_file_name }}</a>
+  <a href="/document/{{ params.docUuid }}/view/page/{{ params._source.page_number or '0' }}?crn={{ params.caseReferenceNumber | urlencode }}&searchTerm={{ params.searchTerm | urlencode }}&type={{ params.searchType | urlencode }}" class="govuk-link">Page {{ params._source.page_number or '0' }} · {{ params._source.correspondence_type }} {{ params._source.source_file_name }}</a>
 </h2>
 <p class="govuk-hint govuk-visually-hidden">Received on {{ params._source.received_date | formatDate}}</p>
 <p class="govuk-body">{{ params._source.chunk_text | safe }}</p>

--- a/search/macro/search-result-item/template.njk
+++ b/search/macro/search-result-item/template.njk
@@ -1,5 +1,8 @@
+{% set pageNumber = params._source.page_number or '0' %}
+{% set pageHref = '/document/' + params.docUuid + '/view/page/' + pageNumber + '?crn=' + (params.caseReferenceNumber | urlencode) + '&searchTerm=' + (params.searchTerm | urlencode) + '&type=' + (params.searchType | urlencode) %}
+
 <h2 class="govuk-heading-m">
-  <a href="/document/{{ params.docUuid }}/view/page/{{ params._source.page_number or '0' }}?crn={{ params.caseReferenceNumber | urlencode }}&searchTerm={{ params.searchTerm | urlencode }}&type={{ params.searchType | urlencode }}" class="govuk-link">Page {{ params._source.page_number or '0' }} · {{ params._source.correspondence_type }} {{ params._source.source_file_name }}</a>
+  <a href="{{ pageHref }}" class="govuk-link">Page {{ pageNumber }} - {{ params._source.correspondence_type }}</a>
 </h2>
 <p class="govuk-hint govuk-visually-hidden">Received on {{ params._source.received_date | formatDate}}</p>
 <p class="govuk-body">{{ params._source.chunk_text | safe }}</p>

--- a/search/page/templates.test.js
+++ b/search/page/templates.test.js
@@ -81,6 +81,8 @@ describe('search page templates', () => {
             html,
             /\/document\/doc-123\/view\/page\/3\?crn=12-745678&searchTerm=jaw%20fracture&type=semantic/
         );
+        assert.match(html, /Page 3 · Medical report report\.pdf/);
+        assert.doesNotMatch(html, /Found on:/);
     });
 
     it('renders result-level debug tags and relevance score when debug feature flag is enabled', () => {

--- a/search/page/templates.test.js
+++ b/search/page/templates.test.js
@@ -79,9 +79,9 @@ describe('search page templates', () => {
         );
         assert.match(
             html,
-            /\/document\/doc-123\/view\/page\/3\?crn=12-745678&searchTerm=jaw%20fracture&type=semantic/
+            /\/document\/doc-123\/view\/page\/3\?crn=12-745678&amp;searchTerm=jaw%20fracture&amp;type=semantic/
         );
-        assert.match(html, /Page 3 · Medical report report\.pdf/);
+        assert.match(html, /Page 3 - Medical report/);
         assert.doesNotMatch(html, /Found on:/);
     });
 
@@ -170,8 +170,8 @@ describe('search page templates', () => {
 
         assert.match(
             html,
-            /\/document\/doc-123\/view\/page\/0\?crn=12-745678&searchTerm=jaw%20fracture&type=semantic/
+            /\/document\/doc-123\/view\/page\/0\?crn=12-745678&amp;searchTerm=jaw%20fracture&amp;type=semantic/
         );
-        assert.match(html, /Page 0 · Medical report report\.pdf/);
+        assert.match(html, /Page 0 - Medical report/);
     });
 });

--- a/search/page/templates.test.js
+++ b/search/page/templates.test.js
@@ -79,7 +79,7 @@ describe('search page templates', () => {
         );
         assert.match(
             html,
-            /\/document\/doc-123\/view\/page\/3\?crn=12-745678&amp;searchTerm=jaw%20fracture&amp;type=semantic/
+            /\/document\/doc-123\/view\/page\/3\?crn=12-745678(?:&|&amp;)searchTerm=jaw%20fracture(?:&|&amp;)type=semantic/
         );
         assert.match(html, /Page 3 - Medical report/);
         assert.doesNotMatch(html, /Found on:/);
@@ -170,7 +170,7 @@ describe('search page templates', () => {
 
         assert.match(
             html,
-            /\/document\/doc-123\/view\/page\/0\?crn=12-745678&amp;searchTerm=jaw%20fracture&amp;type=semantic/
+            /\/document\/doc-123\/view\/page\/0\?crn=12-745678(?:&|&amp;)searchTerm=jaw%20fracture(?:&|&amp;)type=semantic/
         );
         assert.match(html, /Page 0 - Medical report/);
     });

--- a/search/page/templates.test.js
+++ b/search/page/templates.test.js
@@ -148,4 +148,30 @@ describe('search page templates', () => {
         assert.doesNotMatch(html, /search-result-debug/);
         assert.doesNotMatch(html, /Relevance score:/);
     });
+
+    it('renders page number fallback in both result link href and visible text when page_number is missing', () => {
+        const html = createRenderer().render('search/page/results.njk', {
+            ...baseResultsContext,
+            searchResults: [
+                {
+                    docUuid: 'doc-123',
+                    searchTerm: 'jaw fracture',
+                    searchType: 'semantic',
+                    caseReferenceNumber: '12-745678',
+                    _source: {
+                        correspondence_type: 'Medical report',
+                        source_file_name: 'report.pdf',
+                        chunk_text: 'Result snippet',
+                        received_date: '2026-01-12T00:00:00Z'
+                    }
+                }
+            ]
+        });
+
+        assert.match(
+            html,
+            /\/document\/doc-123\/view\/page\/0\?crn=12-745678&searchTerm=jaw%20fracture&type=semantic/
+        );
+        assert.match(html, /Page 0 · Medical report report\.pdf/);
+    });
 });


### PR DESCRIPTION
Display each search result page reference and document name as a linked h2 heading (e.g., "Page 1 · TC19 Additional Information") with extracted text snippet beneath. This improves heading hierarchy for accessibility while maintaining the existing document navigation functionality.