### PR TITLE
chore: security npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3678,9 +3678,9 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5104,9 +5104,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
             "funding": [
                 {
                     "type": "github",
@@ -5471,9 +5471,9 @@
             "license": "MIT"
         },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
             "version": "0.0.1",
             "license": "MIT",
             "dependencies": {
-                "@apidevtools/json-schema-ref-parser": "^15.5.0",
-                "@aws-sdk/client-s3": "^3.1095.0",
+                "@apidevtools/json-schema-ref-parser": "^15.5.1",
+                "@aws-sdk/client-s3": "^3.1102.0",
                 "@ministryofjustice/frontend": "^9.0.0",
                 "@opensearch-project/opensearch": "3.6.0",
                 "ajv": "^8.20.0",
@@ -20,7 +20,7 @@
                 "dotenv": "^17.4.2",
                 "express": "^5.2.1",
                 "express-openapi-validator": "^5.6.2",
-                "express-rate-limit": "^8.6.1",
+                "express-rate-limit": "^8.6.2",
                 "express-session": "^1.19.0",
                 "got": "^15.1.0",
                 "helmet": "^8.3.0",
@@ -51,7 +51,7 @@
                 "husky": "^9.1.7",
                 "nodemon": "^3.1.14",
                 "sass": "^1.102.0",
-                "webpack-cli": "^7.2.1"
+                "webpack-cli": "^7.2.2"
             },
             "engines": {
                 "node": ">=24.15.0",
@@ -59,12 +59,13 @@
             }
         },
         "node_modules/@apidevtools/json-schema-ref-parser": {
-            "version": "15.5.0",
-            "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-15.5.0.tgz",
-            "integrity": "sha512-Ps4w0FwrDoeVK6hfYxWkVbkmxm+zN+6xoXF2ZfEhfiox0ZNbcSAiUWO6iAIvP5bc3DB270r+EaKcoT1IUyzfxw==",
+            "version": "15.5.1",
+            "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-15.5.1.tgz",
+            "integrity": "sha512-69KDKWQvk5jfDQfSTzAUHkI731X7CaJLwQxlS87AXyFHoJzsd/Pufrqsz7PqXMgrtAA99D9Y6NujkEkzli6kVA==",
             "license": "MIT",
             "dependencies": {
-                "js-yaml": "^4.2.0"
+                "js-yaml": "^5.2.2",
+                "undici": "^6.28.0"
             },
             "engines": {
                 "node": ">=20"
@@ -74,14 +75,14 @@
             }
         },
         "node_modules/@aws-sdk/checksums": {
-            "version": "3.1000.20",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.20.tgz",
-            "integrity": "sha512-uc5PMNcLcs+UBSLGsRjbMZKi3mgnPSalXpABw9Xjo0DMrv4gjIa/E4a02yJsuU4FF6Tmvis/JgGdKNIOoN4DQw==",
+            "version": "3.1000.25",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.25.tgz",
+            "integrity": "sha512-zUjEceMw6vhAxMayAlF/vkkKqP9gHbENqvz11t4FbfDlxB/WtW/Az1orJAQ00Pc/yORLQJXKE24w11Ktu/XBcg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.0",
+                "@aws-sdk/core": "^3.977.5",
                 "@aws-sdk/types": "^3.974.2",
-                "@smithy/core": "^3.29.8",
+                "@smithy/core": "^3.31.1",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
@@ -90,20 +91,20 @@
             }
         },
         "node_modules/@aws-sdk/client-s3": {
-            "version": "3.1095.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1095.0.tgz",
-            "integrity": "sha512-eeobm3TKci47CTTHIxc5s5UDjLL0gTKfjlcyzKU+NMoeIJ3flKPq51Fhi2nUDiMNbzsY5HAynM3bHAQFHxRTUw==",
+            "version": "3.1102.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1102.0.tgz",
+            "integrity": "sha512-VQL/oWlt0+Rj2QZcAnp3+hMHW/T01EmkPQXf9ise2gz6d95U82eVE1dPBpMlnv4aDiz99TrMR0DHmceCjCkCmA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/checksums": "^3.1000.20",
-                "@aws-sdk/core": "^3.977.0",
-                "@aws-sdk/credential-provider-node": "^3.972.72",
-                "@aws-sdk/middleware-sdk-s3": "^3.972.66",
-                "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+                "@aws-sdk/checksums": "^3.1000.25",
+                "@aws-sdk/core": "^3.977.5",
+                "@aws-sdk/credential-provider-node": "^3.972.77",
+                "@aws-sdk/middleware-sdk-s3": "^3.972.71",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.43",
                 "@aws-sdk/types": "^3.974.2",
-                "@smithy/core": "^3.29.8",
-                "@smithy/fetch-http-handler": "^5.6.10",
-                "@smithy/node-http-handler": "^4.9.10",
+                "@smithy/core": "^3.31.1",
+                "@smithy/fetch-http-handler": "^5.6.13",
+                "@smithy/node-http-handler": "^4.9.13",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
@@ -112,16 +113,16 @@
             }
         },
         "node_modules/@aws-sdk/core": {
-            "version": "3.977.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.1.tgz",
-            "integrity": "sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==",
+            "version": "3.977.5",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.5.tgz",
+            "integrity": "sha512-O5otOc1c6UZh5HsHAaPdYBcUUR9HL6mtnKqvc8nxN/CKDGUBUpsdh0q8K04Uz/dd1i0TaGyIQuQNqoO7+ad2TQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "^3.974.2",
                 "@aws-sdk/xml-builder": "^3.972.37",
                 "@aws/lambda-invoke-store": "^0.3.0",
-                "@smithy/core": "^3.29.8",
-                "@smithy/signature-v4": "^5.6.9",
+                "@smithy/core": "^3.31.1",
+                "@smithy/signature-v4": "^5.6.12",
                 "@smithy/types": "^4.16.1",
                 "bowser": "^2.11.0",
                 "tslib": "^2.6.2"
@@ -131,14 +132,14 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.972.61",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.61.tgz",
-            "integrity": "sha512-qihs2ekMb89Nxd2JenCgVFhjbkb3EIo7HEBCBzyZACKVJdrLUZBLOmAE3xr0Sayml8n/jZSzwO/IufIiIzO7PQ==",
+            "version": "3.972.66",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.66.tgz",
+            "integrity": "sha512-bOzP2+zdJ0XrghywB4FaJXtGZCx9yS0AGps+VJ5yEgg30wVyHNmVDBwVDXcRypzQY5iLGCS3NSn0nsuISqjFCQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.0",
+                "@aws-sdk/core": "^3.977.5",
                 "@aws-sdk/types": "^3.974.2",
-                "@smithy/core": "^3.29.8",
+                "@smithy/core": "^3.31.1",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
@@ -147,16 +148,16 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-http": {
-            "version": "3.972.63",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.63.tgz",
-            "integrity": "sha512-yfozsS8wkWZEi/n6IsrodcFKBWZ0iNAezhJbTReMNc0z1Px17qdeAeuL1/wziCAmCZyXiW7QzP75ggJkBQv8jQ==",
+            "version": "3.972.68",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.68.tgz",
+            "integrity": "sha512-lkunS8X+H6V76WE+t/uGQm/U8v0JXK5mLfNFTUAMlE1kqaCjwlmqKJrgCVtqjK/vqnlrSWsLK4Lr4NANBWlfTQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.0",
+                "@aws-sdk/core": "^3.977.5",
                 "@aws-sdk/types": "^3.974.2",
-                "@smithy/core": "^3.29.8",
-                "@smithy/fetch-http-handler": "^5.6.10",
-                "@smithy/node-http-handler": "^4.9.10",
+                "@smithy/core": "^3.31.1",
+                "@smithy/fetch-http-handler": "^5.6.13",
+                "@smithy/node-http-handler": "^4.9.13",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
@@ -165,22 +166,22 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.973.6",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.6.tgz",
-            "integrity": "sha512-jGLTW1bj148GL/6/IMlfY2fMYS9FtHOG+NahkFD4y0qkzYudNUahelxryY68/HGMslYuHClk1XaS/3b3eJzEkg==",
+            "version": "3.973.11",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.11.tgz",
+            "integrity": "sha512-KoDEolYtLHG/8C+IiZpXbJWyBOMkrHV+j66Kb9PBXmLv5euGb7aELvuCmLenoGAV6gBW2wM7TsG/1e5iulH4kA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.0",
-                "@aws-sdk/credential-provider-env": "^3.972.61",
-                "@aws-sdk/credential-provider-http": "^3.972.63",
-                "@aws-sdk/credential-provider-login": "^3.972.68",
-                "@aws-sdk/credential-provider-process": "^3.972.61",
-                "@aws-sdk/credential-provider-sso": "^3.973.5",
-                "@aws-sdk/credential-provider-web-identity": "^3.972.67",
-                "@aws-sdk/nested-clients": "^3.997.35",
+                "@aws-sdk/core": "^3.977.5",
+                "@aws-sdk/credential-provider-env": "^3.972.66",
+                "@aws-sdk/credential-provider-http": "^3.972.68",
+                "@aws-sdk/credential-provider-login": "^3.972.73",
+                "@aws-sdk/credential-provider-process": "^3.972.66",
+                "@aws-sdk/credential-provider-sso": "^3.973.10",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.72",
+                "@aws-sdk/nested-clients": "^3.997.40",
                 "@aws-sdk/types": "^3.974.2",
-                "@smithy/core": "^3.29.8",
-                "@smithy/credential-provider-imds": "^4.4.13",
+                "@smithy/core": "^3.31.1",
+                "@smithy/credential-provider-imds": "^4.4.16",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
@@ -189,15 +190,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-login": {
-            "version": "3.972.68",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.68.tgz",
-            "integrity": "sha512-w6tNci6g7RqFpLhj1f5xseBvaNojb4Pkgp5Jp5apl9hrJtaf2AA+rX9+qlhlWUK6kcyAFYPA7emO+55zj+S98Q==",
+            "version": "3.972.73",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.73.tgz",
+            "integrity": "sha512-tjsxMkTAFkmiV9ycmymapb9nLECWVOwFs0bZMQ9gB9bnbY8/HwfukHZlWbXZZp7qkPU6EXAfOcMm3DioFFEywA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.0",
-                "@aws-sdk/nested-clients": "^3.997.35",
+                "@aws-sdk/core": "^3.977.5",
+                "@aws-sdk/nested-clients": "^3.997.40",
                 "@aws-sdk/types": "^3.974.2",
-                "@smithy/core": "^3.29.8",
+                "@smithy/core": "^3.31.1",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
@@ -206,20 +207,20 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.972.72",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.72.tgz",
-            "integrity": "sha512-blQ7F5QGzylnzeh5549zQLoCAiMHkXFLjFovEMaVy4b2X8JhUu+u9NXro1hyK95YHdVFNmBHKs2hIHtZchxKlQ==",
+            "version": "3.972.77",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.77.tgz",
+            "integrity": "sha512-l4nitYCN/Ls57vtUfdextCjTjW41JD7lQiAnuR0RTbdByFc/6OmEAzwGd+lrp6CUtiXGQL1FCaYiamfHASrwBw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "^3.972.61",
-                "@aws-sdk/credential-provider-http": "^3.972.63",
-                "@aws-sdk/credential-provider-ini": "^3.973.6",
-                "@aws-sdk/credential-provider-process": "^3.972.61",
-                "@aws-sdk/credential-provider-sso": "^3.973.5",
-                "@aws-sdk/credential-provider-web-identity": "^3.972.67",
+                "@aws-sdk/credential-provider-env": "^3.972.66",
+                "@aws-sdk/credential-provider-http": "^3.972.68",
+                "@aws-sdk/credential-provider-ini": "^3.973.11",
+                "@aws-sdk/credential-provider-process": "^3.972.66",
+                "@aws-sdk/credential-provider-sso": "^3.973.10",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.72",
                 "@aws-sdk/types": "^3.974.2",
-                "@smithy/core": "^3.29.8",
-                "@smithy/credential-provider-imds": "^4.4.13",
+                "@smithy/core": "^3.31.1",
+                "@smithy/credential-provider-imds": "^4.4.16",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
@@ -228,14 +229,14 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.972.61",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.61.tgz",
-            "integrity": "sha512-xzRuj+fUVO4nkafKQJVKAF97kGpeQbfjuwmRrtGZNf42/1dkmcz6o7dswBy7alY0htQn5sCL1GWQYEykviWZkA==",
+            "version": "3.972.66",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.66.tgz",
+            "integrity": "sha512-YOnX6bIhdjx0QfaENu2PB0eFm5MEc9ft8XNGQ+NxMfeLSq9aE+XjWCwDupEnV4UWv5ZFpBLJbTREIx7KNOoqpQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.0",
+                "@aws-sdk/core": "^3.977.5",
                 "@aws-sdk/types": "^3.974.2",
-                "@smithy/core": "^3.29.8",
+                "@smithy/core": "^3.31.1",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
@@ -244,16 +245,16 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.973.5",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.5.tgz",
-            "integrity": "sha512-fZRjjWhLFelsDoOYjqShQTrIGYC3Pf9Mx9Czf+1ikfQDgktxjze33dVo1q1/ZQ+T0qbtejVoHNHrfD5aJVpv/w==",
+            "version": "3.973.10",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.10.tgz",
+            "integrity": "sha512-IsXnQ35j5VE+3ZK6aIhT5ypB+Jim3zRwVz0nYuVwyBKZyu/SYx+O2/LQpng8c2EiuwyqceabsDlYrICHDlJPsA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.0",
-                "@aws-sdk/nested-clients": "^3.997.35",
-                "@aws-sdk/token-providers": "3.1095.0",
+                "@aws-sdk/core": "^3.977.5",
+                "@aws-sdk/nested-clients": "^3.997.40",
+                "@aws-sdk/token-providers": "3.1102.0",
                 "@aws-sdk/types": "^3.974.2",
-                "@smithy/core": "^3.29.8",
+                "@smithy/core": "^3.31.1",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
@@ -262,15 +263,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.972.67",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.67.tgz",
-            "integrity": "sha512-FTNZ05gkPBA6CKbU3N4zPgybV+stdazwMOya75CmGdcJL7p8Fw/BdHP8WVxJd0mvzyPK2cg/C3gli58Ir4HgCw==",
+            "version": "3.972.72",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.72.tgz",
+            "integrity": "sha512-nj9Zlsy7ya+fy+jhWTJwgfr7YdtDM4xHyZvgKuftuny0UgROVx9lxwvsWJSLvpKk4lig0m0tHng3k1fEnt0LeA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.0",
-                "@aws-sdk/nested-clients": "^3.997.35",
+                "@aws-sdk/core": "^3.977.5",
+                "@aws-sdk/nested-clients": "^3.997.40",
                 "@aws-sdk/types": "^3.974.2",
-                "@smithy/core": "^3.29.8",
+                "@smithy/core": "^3.31.1",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
@@ -279,15 +280,15 @@
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-s3": {
-            "version": "3.972.66",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.66.tgz",
-            "integrity": "sha512-sTZKP1+SvyzWc/3alO8AM/PUiEzDCmn2P/KOcFFSk2UKzKZkB5ZxXdlHVtACE7DHaMFvx6DY0bognwHa1qTv4g==",
+            "version": "3.972.71",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.71.tgz",
+            "integrity": "sha512-5fpExT7JOIZSIWExXCgJVbZzbaOlNrS/rE5Eoesnp0ONMbnCtiyYsCkahNIdlXtKrO6XHqXI6ceqssVWMYKmWQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.0",
-                "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+                "@aws-sdk/core": "^3.977.5",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.43",
                 "@aws-sdk/types": "^3.974.2",
-                "@smithy/core": "^3.29.8",
+                "@smithy/core": "^3.31.1",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
@@ -296,17 +297,17 @@
             }
         },
         "node_modules/@aws-sdk/nested-clients": {
-            "version": "3.997.35",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.35.tgz",
-            "integrity": "sha512-2MJfseVG/aXvIyOIBlYA/Oaf6qFDdsu4D8RKsEUdOQpVuLaor0BdxIBBtJLBNQQEe6Ku3YMvLljwb1MwVUpzRw==",
+            "version": "3.997.40",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.40.tgz",
+            "integrity": "sha512-hEdHT0PBR4fkGxWhwKG5EtEYKnAM7HKkp0vD10ufk4YcXejH4r4q6G/XhPzjUc6Yxo5kBS2vHg7llj4ViR9VTQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.0",
-                "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+                "@aws-sdk/core": "^3.977.5",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.43",
                 "@aws-sdk/types": "^3.974.2",
-                "@smithy/core": "^3.29.8",
-                "@smithy/fetch-http-handler": "^5.6.10",
-                "@smithy/node-http-handler": "^4.9.10",
+                "@smithy/core": "^3.31.1",
+                "@smithy/fetch-http-handler": "^5.6.13",
+                "@smithy/node-http-handler": "^4.9.13",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
@@ -315,13 +316,13 @@
             }
         },
         "node_modules/@aws-sdk/signature-v4-multi-region": {
-            "version": "3.996.42",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.42.tgz",
-            "integrity": "sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q==",
+            "version": "3.996.43",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
+            "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-sdk/types": "^3.974.2",
-                "@smithy/signature-v4": "^5.6.9",
+                "@smithy/signature-v4": "^5.6.12",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
@@ -330,15 +331,15 @@
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.1095.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1095.0.tgz",
-            "integrity": "sha512-65SudS6y4nzaYHybtqcpm3sHe5jLhdMn68HRKS1nUx690BtQeaAQOoujQ+dpOjBATIVGVgKKjEP8tR+U06QJQA==",
+            "version": "3.1102.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1102.0.tgz",
+            "integrity": "sha512-Ua700vVvM1q105yABSUQWkCK6FeTrNfU6ORGetJe5BzkZWY7QhkF7SVTOlmDGWRDNd6jbyY0Dv5e+E4bMBEmLg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.977.0",
-                "@aws-sdk/nested-clients": "^3.997.35",
+                "@aws-sdk/core": "^3.977.5",
+                "@aws-sdk/nested-clients": "^3.997.40",
                 "@aws-sdk/types": "^3.974.2",
-                "@smithy/core": "^3.29.8",
+                "@smithy/core": "^3.31.1",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
@@ -468,14 +469,14 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-            "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+            "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.29.7",
-                "@babel/types": "^7.29.7",
+                "@babel/parser": "^7.29.8",
+                "@babel/types": "^7.29.8",
                 "@jridgewell/gen-mapping": "^0.3.12",
                 "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
@@ -760,13 +761,13 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-            "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+            "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.29.7"
+                "@babel/types": "^7.29.8"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -1360,16 +1361,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-systemjs": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.7.tgz",
-            "integrity": "sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==",
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.8.tgz",
+            "integrity": "sha512-6iSnEK0zlkLKU4heofK/AdmRD4e2SHVpJMtrwnTCzhnaM98ria4rTrOXBBi45BTTYnJtO8txnPsX4fChYXkmeA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-module-transforms": "^7.29.7",
                 "@babel/helper-plugin-utils": "^7.29.7",
                 "@babel/helper-validator-identifier": "^7.29.7",
-                "@babel/traverse": "^7.29.7"
+                "@babel/traverse": "^7.29.8"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1598,9 +1599,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-regenerator": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.7.tgz",
-            "integrity": "sha512-rNNFV0DBAJp988xW2DOntfDoYn1eR8GGF5AT5vYc+rjyfaQkM242c9tZUHHPe7KYaiJizXPWhQTzzdbXySyhBw==",
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.8.tgz",
+            "integrity": "sha512-0UpIXPtdDtMXfnV2OJAVMLpj3H/92vmkA6lpSRakmycJvj3VUy6Xs1dM8tXRugupykr5WB+LpiVl0J8LMVg2mg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1684,9 +1685,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-spread": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.29.7.tgz",
-            "integrity": "sha512-/u5K1QWada7tbYNqTjMh96718g9NTwh9tfPJMsSmVsQwGT447FskV+KcfeXkXq2GWki4EM/MuTdmBec+hOuVTQ==",
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.29.8.tgz",
+            "integrity": "sha512-4S9ksMGVWUshvgK0mKfvZky7leuG5/uoFVwMpAomJ8bMoDJiNHRVmc1EglwW/CmGVSqqWpEbXm9FmbRit22qoA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1946,18 +1947,18 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
-            "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+            "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.29.7",
-                "@babel/generator": "^7.29.7",
+                "@babel/generator": "^7.29.8",
                 "@babel/helper-globals": "^7.29.7",
-                "@babel/parser": "^7.29.7",
+                "@babel/parser": "^7.29.8",
                 "@babel/template": "^7.29.7",
-                "@babel/types": "^7.29.7",
+                "@babel/types": "^7.29.8",
                 "debug": "^4.3.1"
             },
             "engines": {
@@ -1965,9 +1966,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-            "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+            "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2902,9 +2903,9 @@
             }
         },
         "node_modules/@smithy/core": {
-            "version": "3.30.0",
-            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.30.0.tgz",
-            "integrity": "sha512-dl2yRglDxfzH9uJ4fSo4zTaAHa0zH7+V7BZMRWy8hEYIKT1BiqMUK/CN6T3ADQ3kbA5N1tmUulroJ2UtONS7Kw==",
+            "version": "3.31.1",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
+            "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^4.16.1",
@@ -2915,12 +2916,12 @@
             }
         },
         "node_modules/@smithy/credential-provider-imds": {
-            "version": "4.4.14",
-            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.14.tgz",
-            "integrity": "sha512-QgbuahIb2qxQeZQvNK0sw3aF3JH5zwH8j2lLp5DUasVXexGGMWULAR+7z0omPXFolCP/m5wN9M5lm9EGdSviTQ==",
+            "version": "4.4.16",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
+            "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.30.0",
+                "@smithy/core": "^3.31.1",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
@@ -2929,12 +2930,12 @@
             }
         },
         "node_modules/@smithy/fetch-http-handler": {
-            "version": "5.6.11",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.11.tgz",
-            "integrity": "sha512-o0Zkj1nKqJAoq+a+BrkhU39tRftMNjLwpc/z06Frfl43wpbHrJMaSAVZE4vTqlxtVkNaGaT0bIDxOp7tkFTuQQ==",
+            "version": "5.6.13",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
+            "integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.30.0",
+                "@smithy/core": "^3.31.1",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
@@ -2943,12 +2944,12 @@
             }
         },
         "node_modules/@smithy/node-http-handler": {
-            "version": "4.9.11",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.11.tgz",
-            "integrity": "sha512-slbzbz8taEOzoXv/9y34YNBoE+ZHmddLykCgjDAjvMAsu2nM5s2Gzwa5OGF721tD8s+CKeFUBds5lSj9lcbuDg==",
+            "version": "4.9.13",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
+            "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.30.0",
+                "@smithy/core": "^3.31.1",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
@@ -2957,12 +2958,12 @@
             }
         },
         "node_modules/@smithy/signature-v4": {
-            "version": "5.6.10",
-            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.10.tgz",
-            "integrity": "sha512-EXhWePm3SXJAX38npIy4TXL2Aex/OVgCClTjelN2QHw/U+8CQUH8C7AaxsVzQcYieYPseywn48s89DmvuGjiAg==",
+            "version": "5.6.12",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
+            "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.30.0",
+                "@smithy/core": "^3.31.1",
                 "@smithy/types": "^4.16.1",
                 "tslib": "^2.6.2"
             },
@@ -3028,9 +3029,9 @@
             }
         },
         "node_modules/@types/express-serve-static-core": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.2.tgz",
-            "integrity": "sha512-d3KvEXBSo/lOAMc2u6fkyDHBvetBHeqD7wm/AcXfLpSOQwlmG9D/aQ0SFswVjv05p7ullQS7Mjohj6/VdbZuTg==",
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.3.tgz",
+            "integrity": "sha512-dPfW8NFiOF4wOHc7+N/QSxlY9cfSsenewGbAz8C8U/MULPd/YZ27LvJUIlzaXie7e6Ove9YunJGgC9tbHD2cKw==",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
@@ -3075,9 +3076,9 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "26.1.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-            "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+            "version": "26.1.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+            "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~8.3.0"
@@ -3115,9 +3116,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.65.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
-            "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+            "version": "8.66.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
+            "integrity": "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3340,9 +3341,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-            "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+            "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -3609,9 +3610,9 @@
             }
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.11.4",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.4.tgz",
-            "integrity": "sha512-s4+sLr9mZ/CyqeRritFeYV/Zx73OAtmaHn6kkBS1XRoJn1hrg3xIDUcpicAEX68tkcIN0iBCgti31C8zxtkhsQ==",
+            "version": "2.11.12",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+            "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -4501,9 +4502,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.396",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz",
-            "integrity": "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==",
+            "version": "1.5.400",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.400.tgz",
+            "integrity": "sha512-96EWDNjM59SYflgeV5Ylsf4EMiq1a25YjCnJH7cxn/AF2H3pILRweaUnoLax0yKHWdpOzY6JKEu45e8irqZIHA==",
             "dev": true,
             "license": "ISC"
         },
@@ -4533,9 +4534,9 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.24.3",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
-            "integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
+            "version": "5.24.5",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+            "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -4988,10 +4989,32 @@
                 "@types/json-schema": "^7.0.15"
             }
         },
+        "node_modules/express-openapi-validator/node_modules/js-yaml": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
         "node_modules/express-rate-limit": {
-            "version": "8.6.1",
-            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
-            "integrity": "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==",
+            "version": "8.6.2",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+            "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
             "license": "MIT",
             "dependencies": {
                 "debug": "^4.4.3",
@@ -5210,9 +5233,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
-            "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+            "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
             "dev": true,
             "license": "ISC",
             "peer": true
@@ -5815,9 +5838,9 @@
             }
         },
         "node_modules/ip-address": {
-            "version": "10.3.1",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
-            "integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+            "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
             "license": "MIT",
             "engines": {
                 "node": ">= 12"
@@ -6083,9 +6106,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.3.tgz",
+            "integrity": "sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==",
             "funding": [
                 {
                     "type": "github",
@@ -6101,7 +6124,7 @@
                 "argparse": "^2.0.1"
             },
             "bin": {
-                "js-yaml": "bin/js-yaml.js"
+                "js-yaml": "bin/js-yaml.mjs"
             }
         },
         "node_modules/jsdoc-type-pratt-parser": {
@@ -6502,13 +6525,13 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "version": "10.2.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+            "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.5"
+                "brace-expansion": "^5.0.8"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -6728,9 +6751,9 @@
             "optional": true
         },
         "node_modules/node-releases": {
-            "version": "2.0.51",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
-            "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+            "version": "2.0.52",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.52.tgz",
+            "integrity": "sha512-MRlTqhAfoMx/4mhEbPo3Hi02g9LJZaJkka69V6h67Cb1gjrAG0jsTE4CZX1eptNx+VCAwJmfpnDIF4P0Nh1A7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7286,9 +7309,9 @@
             }
         },
         "node_modules/process-warning": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
-            "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.1.0.tgz",
+            "integrity": "sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==",
             "funding": [
                 {
                     "type": "github",
@@ -8231,9 +8254,9 @@
             }
         },
         "node_modules/swagger-ui-dist": {
-            "version": "5.32.11",
-            "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.11.tgz",
-            "integrity": "sha512-NEZzRuxHHQkbG3GCjNbzz+XRDoM7AztnXyzc2VCW5RXUvZBDW7bb3W29/SPfvav3yOzqnDTOLP2Xzbjxo0bldQ==",
+            "version": "5.32.12",
+            "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.12.tgz",
+            "integrity": "sha512-ceXE+KNc5LXafhh36trB6nxK+U2EIKUWzHT7sBiMosf2eJLAefalYnTwMouQBmSyED6m7Yz+GYZEcL+Glt3sww==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@scarf/scarf": "=1.4.0"
@@ -8282,9 +8305,9 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.49.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
-            "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
+            "version": "5.49.1",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.1.tgz",
+            "integrity": "sha512-7A2xlQ5EnGT8KPA92dUh6RbRYTVw8hEaEN9L1K68l4UOXFuV511NnAqObGoRqGOQofQcMypisu1s3xawCEHrvA==",
             "dev": true,
             "license": "BSD-2-Clause",
             "peer": true,
@@ -8522,6 +8545,15 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/undici": {
+            "version": "6.28.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+            "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.17"
+            }
+        },
         "node_modules/undici-types": {
             "version": "8.3.0",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
@@ -8695,9 +8727,9 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.109.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.109.0.tgz",
-            "integrity": "sha512-vomrngskVVXEZF9sMZfYAd4pXZUnfaWdJGlF+BTNF+gJBCKYCQBnOeVPlrh39Ewl7nlCsirDplMy6o5g9xJHBg==",
+            "version": "5.109.2",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.109.2.tgz",
+            "integrity": "sha512-U9/cvLzxObKNEZ9+TtdqrHM5/9z3lgl2c+c4BzbqGxFQvQvBAq87yql5A8pQ+rrMbS496MZJeF5enVBndIy2hw==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -8710,7 +8742,7 @@
                 "acorn": "^8.16.0",
                 "browserslist": "^4.28.1",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.24.2",
+                "enhanced-resolve": "^5.24.4",
                 "es-module-lexer": "^2.1.0",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
@@ -8740,9 +8772,9 @@
             }
         },
         "node_modules/webpack-cli": {
-            "version": "7.2.1",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-7.2.1.tgz",
-            "integrity": "sha512-YwSGbcZdfz12DM8JIseVPr3oBb09IgVCVc4vY3oDvZnI/mALTGPAP1QiqOi4/bBLSJrRHaqDIXeHcNA0+G38aw==",
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-7.2.2.tgz",
+            "integrity": "sha512-lD0pALneslq8FfV+rwvm1BMW0AFAJrHHhNupAGN4asYjMvqrtRsenU4iKpiBo09gS4ntMxKGUxl9jhTEzVt0oA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
         "prepare": "husky"
     },
     "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^15.5.0",
-        "@aws-sdk/client-s3": "^3.1095.0",
+        "@apidevtools/json-schema-ref-parser": "^15.5.1",
+        "@aws-sdk/client-s3": "^3.1102.0",
         "@ministryofjustice/frontend": "^9.0.0",
         "@opensearch-project/opensearch": "3.6.0",
         "ajv": "^8.20.0",
@@ -49,7 +49,7 @@
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
         "express-openapi-validator": "^5.6.2",
-        "express-rate-limit": "^8.6.1",
+        "express-rate-limit": "^8.6.2",
         "express-session": "^1.19.0",
         "got": "^15.1.0",
         "helmet": "^8.3.0",
@@ -80,6 +80,6 @@
         "husky": "^9.1.7",
         "nodemon": "^3.1.14",
         "sass": "^1.102.0",
-        "webpack-cli": "^7.2.1"
+        "webpack-cli": "^7.2.2"
     }
 }


### PR DESCRIPTION
This PR updates a small set of npm dependencies (and the corresponding lockfile) to address npm audit security findings, without changing application/runtime code.

Changes:

- Bump direct dependencies: @apidevtools/json-schema-ref-parser, @aws-sdk/client-s3, and express-rate-limit.
- Bump dev dependency: webpack-cli.
- Refresh package-lock.json to reflect updated resolved versions and transitive dependency changes (notably including new transitive undici via json-schema-ref-parser).